### PR TITLE
Consume libecl as targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ install:
     # We do this conditionally because it saves us some downloading if the version is the same.
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
         if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-          wget https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -O miniconda.sh;
+          wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh;
         else
-          wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+          wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
         fi
       else
         if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,19 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - george-edison55-precise-backports
     packages:
       - liblapack-dev
       - valgrind
       - gcc-4.8
       - g++-4.8
       - clang
+      - cmake
+      - cmake-data
 
 install:
     - if [[ "$CC" == "gcc" ]]; then export CXX="g++-4.8"; fi
-
+    - cmake --version
     - export TRAVIS_PYTHON_VERSION="2.7"
     # We do this conditionally because it saves us some downloading if the version is the same.
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -68,7 +71,12 @@ before_script:
   - popd
   - mkdir build
   - pushd build
-  - cmake  -DCMAKE_INSTALL_PREFIX=$LIBRES_INSTALL_ROOT  -DCMAKE_PREFIX_PATH=$LIBECL_INSTALL_ROOT -DBUILD_TESTS=ON -DBUILD_PYTHON=ON -DERT_DOC=OFF -DINSTALL_ERT_LEGACY=ON ..
+  - export PYTHONPATH=$LIBECL_INSTALL_ROOT/lib/python2.7/dist-packages:$(pwd)/lib/python2.7/dist-packages
+  - cmake   -DCMAKE_INSTALL_PREFIX=$LIBRES_INSTALL_ROOT
+            -DCMAKE_PREFIX_PATH=$LIBECL_INSTALL_ROOT
+            -DCMAKE_MODULE_PATH=$LIBECL_INSTALL_ROOT/share/cmake/Modules
+            -DBUILD_TESTS=ON -DBUILD_PYTHON=ON -DERT_DOC=OFF -DINSTALL_ERT_LEGACY=ON
+            ..
 
 script:
   - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ set( ERT_VERSION_MICRO git ) # with "new in Ert Version X.X.X"!
 
 option( BUILD_TESTS         "Should the tests be built"                               OFF)
 option( BUILD_PYTHON        "Run py_compile on the python wrappers"                   ON )
-option( ERT_USE_OPENMP      "Use OpenMP"                                              OFF )
 option( ERT_DOC             "Build ERT documantation"                                 OFF)
 option( ERT_BUILD_CXX       "Build some CXX wrappers"                                 ON)
 option( USE_RUNPATH         "Should we embed path to libraries"                       ON)
@@ -26,7 +25,7 @@ option( INSTALL_ERT_LEGACY  "Install legacy ert code"                           
 
 set( BUILD_SHARED_LIBS ON )
 
-find_package( libecl REQUIRED )
+find_package( ecl REQUIRED )
 include_directories( ${libecl_INCLUDE_DIRS} )
 
 
@@ -81,18 +80,6 @@ endif()
 
 if (MSVC)
     add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /wd4996" )
-endif()
-
-
-if (ERT_USE_OPENMP)
-  find_package(OpenMP)
-  if (OPENMP_FOUND) 
-     message(STATUS "Enabling OpenMP support")
-     # The actual use of OpenMP is only in the libecl library - the compile flags is only applied there.
-  else()
-     set( ERT_USE_OPENMP OFF )
-     message(STATUS "OpenMP package not found - OpenMP disabled")
-  endif()
 endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)

--- a/libanalysis/src/CMakeLists.txt
+++ b/libanalysis/src/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library( analysis  SHARED ${source_files} )
 set_target_properties( analysis PROPERTIES COMPILE_DEFINITIONS INTERNAL_LINK)
 set_target_properties( analysis PROPERTIES VERSION ${ERT_VERSION_MAJOR}.${ERT_VERSION_MINOR} SOVERSION ${ERT_VERSION_MAJOR} )
 
-target_link_libraries( analysis ${libecl_LIBRARIES} dl)
+target_link_libraries( analysis ert_util )
 
 if (USE_RUNPATH)
    add_runpath( analysis )

--- a/libconfig/src/CMakeLists.txt
+++ b/libconfig/src/CMakeLists.txt
@@ -4,7 +4,7 @@ set( header_files config_parser.h config_content.h config_error.h config_schema_
 add_library( config ${LIBRARY_TYPE} ${source_files} )
 set_target_properties( config PROPERTIES VERSION ${ERT_VERSION_MAJOR}.${ERT_VERSION_MINOR} SOVERSION ${ERT_VERSION_MAJOR} )
 
-target_link_libraries( config ${libecl_LIBRARIES})
+target_link_libraries( config ert_util )
 
 if (USE_RUNPATH)
    add_runpath( config )

--- a/libenkf/src/CMakeLists.txt
+++ b/libenkf/src/CMakeLists.txt
@@ -210,7 +210,7 @@ endif()
 
 set_source_files_properties( site_config.c PROPERTIES COMPILE_DEFINITIONS "SITE_CONFIG_FILE=\"${SITE_CONFIG_FILE}\"")
 
-target_link_libraries( enkf sched analysis rms config job_queue ${libecl_LIBRARIES} )
+target_link_libraries( enkf sched analysis rms config job_queue ecl )
 if (USE_RUNPATH)
    add_runpath( enkf )
 endif()

--- a/libjob_queue/src/CMakeLists.txt
+++ b/libjob_queue/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if (USE_RUNPATH)
    add_runpath( job_queue )
 endif()
 
-target_link_libraries( job_queue config ${libecl_LIBRARIES} dl )
+target_link_libraries( job_queue config ert_util )
 
 install(TARGETS job_queue DESTINATION ${CMAKE_INSTALL_LIBDIR})
 foreach(header ${header_files})

--- a/libjob_queue/tests/CMakeLists.txt
+++ b/libjob_queue/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries( job_loadFail job_queue   )
 target_link_libraries( job_lsf_parse_bsub_stdout job_queue )
 target_link_libraries( job_node_test job_queue )
 target_link_libraries( job_list_test job_queue )
-target_link_libraries( job_lsf_exclude_hosts_test job_queue ${libecl_LIBRARIES} )
+target_link_libraries( job_lsf_exclude_hosts_test job_queue ert_util )
 
 add_test( job_status_test ${EXECUTABLE_OUTPUT_PATH}/job_status_test)
 add_test( job_lsf_parse_bsub_stdout ${EXECUTABLE_OUTPUT_PATH}/job_lsf_parse_bsub_stdout )
@@ -36,14 +36,14 @@ add_test( job_list_test valgrind --leak-check=full --error-exitcode=1 ${EXECUTAB
 add_test( job_lsf_exclude_hosts_test ${EXECUTABLE_OUTPUT_PATH}/job_lsf_exclude_hosts_test ${EXECUTABLE_OUTPUT_PATH}/job_program NULL LOCAL)
 
 add_executable( job_program_output job_program_output.c )
-target_link_libraries( job_program_output ${libecl_LIBRARIES} )
+target_link_libraries( job_program_output ert_util )
 
 add_executable( job_queue_test job_job_queue_test.c )
 target_link_libraries( job_queue_test job_queue  )
 add_test( job_queue_test ${EXECUTABLE_OUTPUT_PATH}/job_queue_test ${EXECUTABLE_OUTPUT_PATH}/job_program_output )
 
 add_executable( job_queue_stress_task job_queue_stress_task.c )
-target_link_libraries( job_queue_stress_task  ${libecl_LIBRARIES} )
+target_link_libraries( job_queue_stress_task ert_util )
 
 add_executable( job_queue_stress_test job_queue_stress_test.c )
 target_link_libraries( job_queue_stress_test job_queue  )
@@ -60,16 +60,16 @@ add_test( job_queue_driver_test ${EXECUTABLE_OUTPUT_PATH}/job_queue_driver_test 
 
 
 if (ERT_LSF_SUBMIT_TEST)
-   include( lsf_tests.cmake ) 
+   include( lsf_tests.cmake )
 endif()
 
 
 add_executable( job_torque_test job_torque_test.c )
-target_link_libraries( job_torque_test job_queue ${libecl_LIBRARIES} )
+target_link_libraries( job_torque_test job_queue ert_util )
 add_test( job_torque_test ${EXECUTABLE_OUTPUT_PATH}/job_torque_test )
 
 add_executable( job_queue_manager job_queue_manager.c )
-target_link_libraries( job_queue_manager job_queue ${libecl_LIBRARIES}  )
+target_link_libraries( job_queue_manager job_queue ert_util  )
 add_test( job_queue_manager ${EXECUTABLE_OUTPUT_PATH}/job_queue_manager )
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data/qsub_emulators/ DESTINATION ${EXECUTABLE_OUTPUT_PATH})

--- a/librms/src/CMakeLists.txt
+++ b/librms/src/CMakeLists.txt
@@ -3,7 +3,7 @@ set( header_files rms_file.h rms_util.h rms_tag.h rms_type.h rms_tagkey.h rms_st
 
 add_library( rms ${LIBRARY_TYPE} ${source_files} )
 set_target_properties( rms PROPERTIES VERSION ${ERT_VERSION_MAJOR}.${ERT_VERSION_MINOR} SOVERSION ${ERT_VERSION_MAJOR} )
-target_link_libraries( rms ${libecl_LIBRARIES})
+target_link_libraries( rms ecl )
 if (USE_RUNPATH)
    add_runpath( rms )
 endif()   

--- a/libsched/src/CMakeLists.txt
+++ b/libsched/src/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories( ${libutil_src_path} )
 add_library( sched ${LIBRARY_TYPE} ${source_files} )
 set_target_properties( sched PROPERTIES VERSION ${ERT_VERSION_MAJOR}.${ERT_VERSION_MINOR} SOVERSION ${ERT_VERSION_MAJOR} )
 
-target_link_libraries( sched ${libecl_LIBRARIES})
+target_link_libraries( sched ecl )
 if (USE_RUNPATH)
    add_runpath( sched )
 endif()


### PR DESCRIPTION
This is a showcase of what downstream can look like with https://github.com/Statoil/libecl/pull/54 applied. Currently it's just the absolute minimal set of changes to demo what's going on.

Compiled and tested with `cmake -DCMAKE_MODULE_PATH=libecl/cmake/Modules -DCMAKE_MODULE_PATH=libecl/python/cmake/Modules`