### PR TITLE
Extract loading site_config from enkf_main

### DIFF
--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -130,7 +130,6 @@ foreach (test   enkf_active_list
                 enkf_iter_config
                 enkf_local_obsdata
                 enkf_local_obsdata_node
-                enkf_main
                 enkf_meas_data
                 enkf_model_config
                 enkf_obs_tests
@@ -151,6 +150,12 @@ foreach (test   enkf_active_list
     target_link_libraries(${test} enkf)
     add_test(NAME ${test} COMMAND ${test})
 endforeach ()
+
+add_executable(enkf_main tests/enkf_main.c)
+target_link_libraries(enkf_main enkf)
+add_test(NAME enkf_main
+         COMMAND enkf_main
+                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config rng)
 
 add_executable(enkf_runpath_list tests/enkf_runpath_list.c)
 target_link_libraries(enkf_runpath_list enkf)

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -119,7 +119,7 @@ extern "C" {
   void                          enkf_main_set_state_run_path(const enkf_main_type * , int );
   void                          enkf_main_set_state_eclbase(const enkf_main_type * , int );
   void                          enkf_main_interactive_set_runpath__(void * );
-  enkf_main_type              * enkf_main_bootstrap(const char * model_config, bool strict, bool verbose);
+  enkf_main_type              * enkf_main_alloc(const char *, const site_config_type *, bool, bool);
   void                          enkf_main_create_new_config( const char * config_file , const char * storage_path , const char * dbase_type , int num_realizations);
 
 
@@ -157,7 +157,7 @@ extern "C" {
 
   subst_list_type        * enkf_main_get_data_kw( const enkf_main_type * enkf_main );
   void                     enkf_main_clear_data_kw( enkf_main_type * enkf_main );
-  site_config_type       * enkf_main_get_site_config( const enkf_main_type * enkf_main );
+  const site_config_type * enkf_main_get_site_config( const enkf_main_type * enkf_main );
   void                     enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size );
   void                     enkf_main_get_observations( const enkf_main_type * enkf_main, const char * user_key , int obs_count , time_t * obs_time , double * y , double * std);
   int                      enkf_main_get_observation_count( const enkf_main_type * enkf_main, const char * user_key );

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -195,8 +195,6 @@ extern "C" {
   void                     enkf_main_run_workflows( enkf_main_type * enkf_main , const stringlist_type * workflows);
   bool                     enkf_main_run_workflow( enkf_main_type * enkf_main , const char * workflow);
 
-  enkf_main_type      * enkf_main_alloc_empty( );
-
   rng_config_type     * enkf_main_get_rng_config( const enkf_main_type * enkf_main );
   void                  enkf_main_rng_init( enkf_main_type * enkf_main);
 

--- a/libenkf/include/ert/enkf/model_config.h
+++ b/libenkf/include/ert/enkf/model_config.h
@@ -90,7 +90,7 @@ extern "C" {
   void                   model_config_set_gen_kw_export_file( model_config_type * model_config, const char * file_name);
   const char           * model_config_get_gen_kw_export_file( const model_config_type * model_config);
 
-  config_content_type * model_config_alloc_content(const char*, config_parser_type*);
+  config_content_type  * model_config_alloc_content(const char*, config_parser_type*);
 
   UTIL_IS_INSTANCE_HEADER( model_config);
 

--- a/libenkf/include/ert/enkf/model_config.h
+++ b/libenkf/include/ert/enkf/model_config.h
@@ -90,6 +90,8 @@ extern "C" {
   void                   model_config_set_gen_kw_export_file( model_config_type * model_config, const char * file_name);
   const char           * model_config_get_gen_kw_export_file( const model_config_type * model_config);
 
+  config_content_type * model_config_alloc_content(const char*, config_parser_type*);
+
   UTIL_IS_INSTANCE_HEADER( model_config);
 
 #ifdef __cplusplus

--- a/libenkf/include/ert/enkf/site_config.h
+++ b/libenkf/include/ert/enkf/site_config.h
@@ -42,6 +42,7 @@ typedef struct site_config_struct site_config_type;
   const char *             site_config_get_location();
 
   const char *             site_config_get_config_file(const site_config_type*);
+  // TODO: remove?
   void                     site_config_set_config_file(site_config_type*, const char*);
   
   const char *             site_config_get_manual_url( const site_config_type * site_config );
@@ -103,6 +104,8 @@ typedef struct site_config_struct site_config_type;
   mode_t                   site_config_get_umask( const site_config_type * site_config );
 
   site_config_type       * site_config_alloc_empty();
+  site_config_type       * site_config_alloc_default();
+
   void                     site_config_add_config_items( config_parser_type * config , bool site_mode);
 #ifdef __cplusplus
 }

--- a/libenkf/include/ert/enkf/site_config.h
+++ b/libenkf/include/ert/enkf/site_config.h
@@ -42,7 +42,6 @@ typedef struct site_config_struct site_config_type;
   const char *             site_config_get_location();
 
   const char *             site_config_get_config_file(const site_config_type*);
-  // TODO: remove?
   void                     site_config_set_config_file(site_config_type*, const char*);
   
   const char *             site_config_get_manual_url( const site_config_type * site_config );
@@ -60,7 +59,6 @@ typedef struct site_config_struct site_config_type;
   bool                     site_config_load_user_config(site_config_type *, const char *);
   void                     site_config_free(site_config_type *);
   ext_joblist_type       * site_config_get_installed_jobs( const site_config_type * );
-  void                     site_config_set_ens_size( site_config_type * site_config , int ens_size );
 
   void                     site_config_set_max_running_lsf( site_config_type * site_config , int max_running_lsf);
   int                      site_config_get_max_running_lsf( const site_config_type * site_config );
@@ -106,6 +104,7 @@ typedef struct site_config_struct site_config_type;
 
   site_config_type       * site_config_alloc_empty();
   site_config_type       * site_config_alloc_default();
+  site_config_type       * site_config_alloc_model_config(const char *);
 
   config_content_type    * site_config_alloc_content(const site_config_type*, config_parser_type*);
 

--- a/libenkf/include/ert/enkf/site_config.h
+++ b/libenkf/include/ert/enkf/site_config.h
@@ -106,6 +106,8 @@ typedef struct site_config_struct site_config_type;
   site_config_type       * site_config_alloc_empty();
   site_config_type       * site_config_alloc_default();
 
+  config_content_type    * site_config_alloc_content(const site_config_type*, config_parser_type*);
+
   void                     site_config_add_config_items( config_parser_type * config , bool site_mode);
 #ifdef __cplusplus
 }

--- a/libenkf/include/ert/enkf/site_config.h
+++ b/libenkf/include/ert/enkf/site_config.h
@@ -42,7 +42,6 @@ typedef struct site_config_struct site_config_type;
   const char *             site_config_get_location();
 
   const char *             site_config_get_config_file(const site_config_type*);
-  void                     site_config_set_config_file(site_config_type*, const char*);
   
   const char *             site_config_get_manual_url( const site_config_type * site_config );
   void                     site_config_set_manual_url( site_config_type * site_config , const char * manual_url );
@@ -102,9 +101,8 @@ typedef struct site_config_struct site_config_type;
   void                     site_config_set_umask( site_config_type * site_config , mode_t umask);
   mode_t                   site_config_get_umask( const site_config_type * site_config );
 
-  site_config_type       * site_config_alloc_empty();
-  site_config_type       * site_config_alloc_default();
-  site_config_type       * site_config_alloc_model_config(const char *);
+  site_config_type       * site_config_alloc();
+  site_config_type       * site_config_alloc_load_user_config(const char *);
 
   config_content_type    * site_config_alloc_content(const site_config_type*, config_parser_type*);
 

--- a/libenkf/include/ert/enkf/site_config.h
+++ b/libenkf/include/ert/enkf/site_config.h
@@ -57,6 +57,7 @@ typedef struct site_config_struct site_config_type;
   void                     site_config_set_num_cpu( site_config_type * site_config , int num_cpu );
   void                     site_config_update_lsf_request(site_config_type *  , const forward_model_type *);
   bool                     site_config_init(site_config_type * site_config , const config_content_type * config);
+  bool                     site_config_load_user_config(site_config_type *, const char *);
   void                     site_config_free(site_config_type *);
   ext_joblist_type       * site_config_get_installed_jobs( const site_config_type * );
   void                     site_config_set_ens_size( site_config_type * site_config , int ens_size );

--- a/libenkf/include/ert/enkf/site_config.h
+++ b/libenkf/include/ert/enkf/site_config.h
@@ -41,6 +41,8 @@ typedef struct site_config_struct site_config_type;
   queue_config_type *      site_config_get_queue_config(const site_config_type * site_config);
   const char *             site_config_get_location();
 
+  const char *             site_config_get_config_file(const site_config_type*);
+  void                     site_config_set_config_file(site_config_type*, const char*);
   
   const char *             site_config_get_manual_url( const site_config_type * site_config );
   void                     site_config_set_manual_url( site_config_type * site_config , const char * manual_url );

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -168,7 +168,6 @@ struct enkf_main_struct {
   int_vector_type      * keep_runpath;       /* HACK: This is only used in the initialization period - afterwards the data is held by the enkf_state object. */
   bool                   pre_clear_runpath;  /* HACK: This is only used in the initialization period - afterwards the data is held by the enkf_state object. */
 
-  char                 * site_config_file;
   char                 * user_config_file;
   char                 * rft_config_file;       /* File giving the configuration to the RFTwells*/
   enkf_obs_type        * obs;
@@ -235,7 +234,7 @@ void enkf_main_set_rft_config_file( enkf_main_type * enkf_main , const char * rf
 }
 
 void enkf_main_set_site_config_file( enkf_main_type * enkf_main , const char * site_config_file ) {
-  enkf_main->site_config_file = util_realloc_string_copy( enkf_main->site_config_file , site_config_file );
+  site_config_set_config_file(enkf_main->site_config, site_config_file);
 }
 
 const char * enkf_main_get_user_config_file( const enkf_main_type * enkf_main ) {
@@ -243,7 +242,7 @@ const char * enkf_main_get_user_config_file( const enkf_main_type * enkf_main ) 
 }
 
 const char * enkf_main_get_site_config_file( const enkf_main_type * enkf_main ) {
-  return enkf_main->site_config_file;
+  return site_config_get_config_file(enkf_main->site_config);
 }
 
 const char * enkf_main_get_rft_config_file( const enkf_main_type * enkf_main ) {
@@ -397,7 +396,6 @@ void enkf_main_free(enkf_main_type * enkf_main){
   subst_func_pool_free( enkf_main->subst_func_pool );
   subst_list_free( enkf_main->subst_list );
   util_safe_free( enkf_main->user_config_file );
-  util_safe_free( enkf_main->site_config_file );
   util_safe_free( enkf_main->rft_config_file );
   free(enkf_main);
 }
@@ -2189,7 +2187,6 @@ enkf_main_type * enkf_main_alloc_empty( ) {
   res_log_open_empty();
   enkf_main->ensemble           = NULL;
   enkf_main->user_config_file   = NULL;
-  enkf_main->site_config_file   = NULL;
   enkf_main->rft_config_file    = NULL;
   enkf_main->local_config       = NULL;
   enkf_main->rng                = NULL;

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -2301,7 +2301,10 @@ static void enkf_main_bootstrap_site(enkf_main_type * enkf_main) {
   config_content_free(content);
 }
 
-char * enkf_main_alloc_model_config_filename(const char * model_config) {
+/**
+ * Note: This function will chdir into the directory of the model_config file.
+ */
+static char * enkf_main_alloc_model_config_filename(const char * model_config) {
   if(model_config == NULL)
     return NULL;
 
@@ -2354,12 +2357,8 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
   if (!enkf_main->user_config_file)
     return;
 
-  site_config_init_user_mode(enkf_main->site_config);
-
   config_parser_type * config = config_alloc();
   config_content_type * content = model_config_alloc_content(enkf_main->user_config_file, config);
-
-  site_config_init( enkf_main->site_config , content );                                   /*  <---- model_config : second pass. */
 
   {
     char * log_file;
@@ -2544,9 +2543,13 @@ itializing the various 'large' sub config objects.
 // TODO: Rename as alloc
 enkf_main_type * enkf_main_bootstrap(const char * _model_config, bool strict , bool verbose) {
   // TODO: site_config should be given as a const parameter
+  site_config_type * site_config = site_config_alloc_default();
+
+  if(_model_config)
+    site_config_load_user_config(site_config, _model_config);
 
   enkf_main_type * enkf_main = enkf_main_alloc_empty();
-  enkf_main->site_config = site_config_alloc_default();
+  enkf_main->site_config = site_config;
   enkf_main_set_verbose(enkf_main, verbose);
   enkf_main_bootstrap_site(enkf_main);
 

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1948,117 +1948,6 @@ void enkf_main_create_all_active_config( const enkf_main_type * enkf_main) {
 }
 
 
-static void enkf_main_user_config_deprecate( config_parser_type * config )
-{
-  config_parser_deprecate( config , "MAX_RUNNING_LSF" , "MAX_RUNNING_LSF is deprecated. Use the general QUEUE_OPTION LSF MAX_RUNNING instead.");
-  config_parser_deprecate( config , "MAX_RUNNING_LOCAL" , "MAX_RUNNING_LOCAL is deprecated. Use the general QUEUE_OPTION LOCAL MAX_RUNNING instead.");
-  config_parser_deprecate( config , "MAX_RUNNING_RSH" , "MAX_RUNNING_RSH is deprecated. Use the general QUEUE_OPTION RSH MAX_RUNNING instead.");
-}
-
-
-static void enkf_main_init_user_config(config_parser_type * config ) {
-  config_schema_item_type * item;
-
-  /*****************************************************************/
-  /* config_add_schema_item():                                     */
-  /*                                                               */
-  /*  1. boolean - required?                                       */
-  /*****************************************************************/
-
-  ert_workflow_list_add_config_items( config );
-  plot_settings_add_config_items( config );
-  analysis_config_add_config_items( config );
-  ensemble_config_add_config_items( config );
-  ecl_config_add_config_items( config );
-  rng_config_add_config_items( config );
-
-  /*****************************************************************/
-  /* Required keywords from the ordinary model_config file */
-
-  item = config_add_schema_item(config , CASE_TABLE_KEY , false  );
-  config_schema_item_set_argc_minmax(item , 1 , 1);
-  config_schema_item_iset_type( item , 0 , CONFIG_EXISTING_PATH );
-
-  config_add_key_value( config , LOG_LEVEL_KEY , false , CONFIG_INT);
-  config_add_key_value( config , LOG_FILE_KEY  , false , CONFIG_STRING);
-
-  config_add_key_value(config , MAX_RESAMPLE_KEY , false , CONFIG_INT);
-
-
-  item = config_add_schema_item(config , NUM_REALIZATIONS_KEY , true  );
-  config_schema_item_set_argc_minmax(item , 1 , 1);
-  config_schema_item_iset_type( item , 0 , CONFIG_INT );
-  config_add_alias(config , NUM_REALIZATIONS_KEY , "SIZE");
-  config_add_alias(config , NUM_REALIZATIONS_KEY , "NUM_REALISATIONS");
-  config_install_message(config , "SIZE" , "** Warning: \'SIZE\' is depreceated - use \'NUM_REALIZATIONS\' instead.");
-
-
-  /*****************************************************************/
-  /* Optional keywords from the model config file */
-
-  item = config_add_schema_item( config , RUN_TEMPLATE_KEY , false  );
-  config_schema_item_set_argc_minmax(item , 2 , CONFIG_DEFAULT_ARG_MAX );
-  config_schema_item_iset_type( item , 0 , CONFIG_EXISTING_PATH );
-
-  config_add_key_value(config , RUNPATH_KEY , false , CONFIG_STRING);
-
-  item = config_add_schema_item(config , ENSPATH_KEY , false  );
-  config_schema_item_set_argc_minmax(item , 1 , 1 );
-
-  item = config_add_schema_item( config , JOBNAME_KEY , false  );
-  config_schema_item_set_argc_minmax(item , 1 , 1 );
-
-  item = config_add_schema_item(config , DBASE_TYPE_KEY , false  );
-  config_schema_item_set_argc_minmax(item , 1, 1 );
-  config_schema_item_set_common_selection_set(item , 2 , (const char *[2]) {"PLAIN" , "BLOCK_FS"});
-
-  item = config_add_schema_item(config , FORWARD_MODEL_KEY , false  );
-  config_schema_item_set_argc_minmax(item , 1 , CONFIG_DEFAULT_ARG_MAX);
-
-  item = config_add_schema_item(config , DATA_KW_KEY , false  );
-  config_schema_item_set_argc_minmax(item , 2 , 2);
-
-  config_add_key_value(config , PRE_CLEAR_RUNPATH_KEY , false , CONFIG_BOOL);
-
-  item = config_add_schema_item(config , DELETE_RUNPATH_KEY , false  );
-  config_schema_item_set_argc_minmax(item , 1 , CONFIG_DEFAULT_ARG_MAX);
-
-  item = config_add_schema_item(config , OBS_CONFIG_KEY  , false  );
-  config_schema_item_set_argc_minmax(item , 1 , 1 );
-  config_schema_item_iset_type( item , 0 , CONFIG_EXISTING_PATH );
-
-  config_add_key_value(config , TIME_MAP_KEY , false , CONFIG_EXISTING_PATH);
-
-  item = config_add_schema_item(config , RFT_CONFIG_KEY , false  );
-  config_schema_item_set_argc_minmax(item , 1 , 1 );
-  config_schema_item_iset_type( item , 0 , CONFIG_EXISTING_PATH );
-
-  item = config_add_schema_item(config , RFTPATH_KEY , false  );
-  config_schema_item_set_argc_minmax(item , 1 , 1 );
-
-  item = config_add_schema_item(config, GEN_KW_EXPORT_FILE_KEY, false );
-  config_schema_item_set_argc_minmax(item , 1 , 1 );
-
-  item = config_add_schema_item(config , LOCAL_CONFIG_KEY  , false  );
-  config_schema_item_set_argc_minmax(item , 1 , 1 );
-  config_schema_item_iset_type( item , 0 , CONFIG_EXISTING_PATH );
-
-  {
-    stringlist_type * refcase_dep = stringlist_alloc_argv_ref( (const char *[1]) { REFCASE_KEY } , 1);
-
-    item = config_add_schema_item(config , HISTORY_SOURCE_KEY , false  );
-    config_schema_item_set_argc_minmax(item , 1 , 1);
-    config_schema_item_set_common_selection_set(item , 3 , (const char *[3]) {"SCHEDULE" , "REFCASE_SIMULATED" , "REFCASE_HISTORY"});
-    config_schema_item_set_required_children_on_value(item , "REFCASE_SIMULATED" , refcase_dep);
-    config_schema_item_set_required_children_on_value(item , "REFCASE_HISTORY"  , refcase_dep);
-
-    stringlist_free(refcase_dep);
-  }
-
-  hook_manager_add_config_items( config );
-}
-
-
 keep_runpath_type  enkf_main_iget_keep_runpath( const enkf_main_type * enkf_main , int iens ) {
   return enkf_state_get_keep_runpath( enkf_main->ensemble[iens] );
 }
@@ -2392,36 +2281,6 @@ void enkf_main_update_local_updates( enkf_main_type * enkf_main) {
   }
 }
 
-static char * __enkf_main_alloc_user_config_file(const enkf_main_type * enkf_main, bool base_only) {
-    char * base_name;
-    char * extension;
-    util_alloc_file_components(enkf_main_get_user_config_file(enkf_main), NULL, &base_name, &extension);
-
-    char * config_file;
-    if (base_only) {
-        config_file = util_alloc_filename(NULL, base_name, NULL);;
-    } else {
-        config_file = util_alloc_filename(NULL, base_name, extension);
-    }
-
-    free(base_name);
-    free(extension);
-    return config_file;
-}
-
-static hash_type *__enkf_main_alloc_predefined_kw_map(const enkf_main_type *enkf_main) {
-    char * config_file_base       = __enkf_main_alloc_user_config_file(enkf_main, true);
-    char * config_file            = __enkf_main_alloc_user_config_file(enkf_main, false);
-    hash_type * pre_defined_kw_map = hash_alloc();
-
-    hash_insert_string(pre_defined_kw_map, "<CONFIG_FILE>", config_file);
-    hash_insert_string(pre_defined_kw_map, "<CONFIG_FILE_BASE>", config_file_base);
-
-    free( config_file ) ;
-    free( config_file_base );
-    return pre_defined_kw_map;
-}
-
 
 /**
    Observe that the site-config initializations starts with chdir() to
@@ -2495,43 +2354,12 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
   if (!enkf_main->user_config_file)
     return;
 
-  config_parser_type * config = config_alloc();
-  enkf_main_init_user_config(config);
-  site_config_add_config_items(config, false);
   site_config_init_user_mode(enkf_main->site_config);
-  enkf_main_user_config_deprecate(config);
 
-  hash_type *pre_defined_kw_map = __enkf_main_alloc_predefined_kw_map(enkf_main);
-  config_content_type * content = config_parse(
-          config , enkf_main->user_config_file,
-          "--", INCLUDE_KEY, DEFINE_KEY,
-          pre_defined_kw_map, CONFIG_UNRECOGNIZED_WARN, true
-          );
-  hash_free(pre_defined_kw_map);
-
-  const stringlist_type * warnings = config_content_get_warnings(content);
-  if (stringlist_get_size( warnings ) > 0) {
-    fprintf(stderr," ** There were warnings when parsing the configuration file: %s" , enkf_main->user_config_file );
-    for (int i=0; i < stringlist_get_size( warnings ); i++)
-      fprintf(stderr, " %02d : %s \n",i , stringlist_iget( warnings , i ));
-  }
-
-  if (!config_content_is_valid( content )) {
-    config_error_type * errors = config_content_get_errors( content );
-    config_error_fprintf( errors , true , stderr );
-    exit(1);
-  }
+  config_parser_type * config = config_alloc();
+  config_content_type * content = model_config_alloc_content(enkf_main->user_config_file, config);
 
   site_config_init( enkf_main->site_config , content );                                   /*  <---- model_config : second pass. */
-
-  /*****************************************************************/
-  /*
- - now we have parsed everything - and we are ready to start
-pulating the enkf_main object.
-  */
-
-
-
 
   {
     char * log_file;

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1956,7 +1956,7 @@ static void enkf_main_user_config_deprecate( config_parser_type * config )
 }
 
 
-static void enkf_main_init_user_config( const enkf_main_type * enkf_main , config_parser_type * config ) {
+static void enkf_main_init_user_config(config_parser_type * config ) {
   config_schema_item_type * item;
 
   /*****************************************************************/
@@ -2442,6 +2442,233 @@ static void enkf_main_bootstrap_site(enkf_main_type * enkf_main) {
   config_content_free(content);
 }
 
+char * enkf_main_alloc_model_config_filename(const char * model_config) {
+  if(model_config == NULL)
+    return NULL;
+
+  char * path             = NULL;
+  char * base             = NULL;
+  char * ext              = NULL;
+
+  // The command line argument given is a symlink - we start by changing to
+  // the real location of the configuration file.
+  if (util_is_link(model_config)) {
+    char * realpath = util_alloc_link_target(model_config);
+    util_alloc_file_components(realpath, &path, &base, &ext);
+    free(realpath);
+  }
+  else {
+    util_alloc_file_components(model_config, &path, &base, &ext);
+  }
+
+  char * abs_model_config = NULL;
+  if (path == NULL) {
+    abs_model_config = util_alloc_string_copy(model_config);
+  }
+  else {
+    if(util_chdir(path) != 0)
+      util_abort(
+              "%s: failed to change directory to: %s : %s \n",
+              __func__, path, strerror(errno)
+              );
+
+    if (ext != NULL)
+      abs_model_config = util_alloc_filename(NULL, base, ext);
+    else
+      abs_model_config = util_alloc_string_copy(base);
+  }
+
+  util_safe_free(path);
+  util_safe_free(base);
+  util_safe_free(ext);
+
+  if (!util_file_exists(abs_model_config))
+    util_exit(
+            "%s: can not locate user configuration file:%s \n",
+            __func__ , abs_model_config
+            );
+
+  return abs_model_config;
+}
+
+static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, bool verbose) {
+  if (!enkf_main->user_config_file)
+    return;
+
+  config_parser_type * config = config_alloc();
+  enkf_main_init_user_config(config);
+  site_config_add_config_items(config, false);
+  site_config_init_user_mode(enkf_main->site_config);
+  enkf_main_user_config_deprecate(config);
+
+  hash_type *pre_defined_kw_map = __enkf_main_alloc_predefined_kw_map(enkf_main);
+  config_content_type * content = config_parse(
+          config , enkf_main->user_config_file,
+          "--", INCLUDE_KEY, DEFINE_KEY,
+          pre_defined_kw_map, CONFIG_UNRECOGNIZED_WARN, true
+          );
+  hash_free(pre_defined_kw_map);
+
+  const stringlist_type * warnings = config_content_get_warnings(content);
+  if (stringlist_get_size( warnings ) > 0) {
+    fprintf(stderr," ** There were warnings when parsing the configuration file: %s" , enkf_main->user_config_file );
+    for (int i=0; i < stringlist_get_size( warnings ); i++)
+      fprintf(stderr, " %02d : %s \n",i , stringlist_iget( warnings , i ));
+  }
+
+  if (!config_content_is_valid( content )) {
+    config_error_type * errors = config_content_get_errors( content );
+    config_error_fprintf( errors , true , stderr );
+    exit(1);
+  }
+
+  site_config_init( enkf_main->site_config , content );                                   /*  <---- model_config : second pass. */
+
+  /*****************************************************************/
+  /*
+ - now we have parsed everything - and we are ready to start
+pulating the enkf_main object.
+  */
+
+
+
+
+  {
+    char * log_file;
+    int log_level = DEFAULT_LOG_LEVEL;
+    if(config_content_has_item( content , LOG_LEVEL_KEY))
+      log_level = config_content_get_value_as_int(content , LOG_LEVEL_KEY);
+
+    if (config_content_has_item( content , LOG_FILE_KEY))
+      log_file = util_alloc_string_copy( config_content_get_value(content , LOG_FILE_KEY));
+    else
+      log_file = util_alloc_filename( NULL , enkf_main->user_config_file , "log");
+
+    ert_log_init_log(log_level, log_file ,  enkf_main->verbose);
+
+    free( log_file );
+  }
+
+  /*
+itializing the various 'large' sub config objects.
+  */
+  rng_config_init( enkf_main->rng_config , content );
+  enkf_main_rng_init( enkf_main );  /* Must be called before the ensmeble is created. */
+
+  enkf_main_init_subst_list( enkf_main );
+  ert_workflow_list_init( enkf_main->workflow_list , content );
+
+  analysis_config_load_internal_modules( enkf_main->analysis_config );
+  analysis_config_init( enkf_main->analysis_config , content );
+  ecl_config_init( enkf_main->ecl_config , content );
+  config_settings_apply( enkf_main->plot_config , content );
+
+  ensemble_config_init( enkf_main->ensemble_config , content ,
+                        ecl_config_get_grid( enkf_main->ecl_config ) ,
+                        ecl_config_get_refcase( enkf_main->ecl_config) );
+
+  model_config_init( enkf_main->model_config ,
+                     content ,
+                     enkf_main_get_ensemble_size( enkf_main ),
+                     site_config_get_installed_jobs(enkf_main->site_config) ,
+                     ecl_config_get_last_history_restart( enkf_main->ecl_config ),
+                     ecl_config_get_sched_file(enkf_main->ecl_config) ,
+                     ecl_config_get_refcase( enkf_main->ecl_config ));
+
+  enkf_main_init_hook_manager( enkf_main , content );
+  enkf_main_init_data_kw( enkf_main , content );
+  enkf_main_update_num_cpu( enkf_main );
+  {
+    if (config_content_has_item( content , SCHEDULE_PREDICTION_FILE_KEY )) {
+      const config_content_item_type * pred_item = config_content_get_item( content , SCHEDULE_PREDICTION_FILE_KEY );
+      config_content_node_type * pred_node = config_content_item_get_last_node( pred_item );
+      const char * template_file = config_content_node_iget_as_path( pred_node , 0 );
+      {
+        hash_type * opt_hash = hash_alloc();
+        config_content_node_init_opt_hash( pred_node , opt_hash , 1 );
+
+        const char * parameters = hash_safe_get( opt_hash , "PARAMETERS" );
+        const char * min_std    = hash_safe_get( opt_hash , "MIN_STD"    );
+        const char * init_files = hash_safe_get( opt_hash , "INIT_FILES" );
+
+        enkf_main_set_schedule_prediction_file__( enkf_main , template_file , parameters , min_std , init_files );
+        hash_free( opt_hash );
+      }
+    }
+  }
+
+
+  /*****************************************************************/
+  /**
+     By default the simulation directories are left intact when
+     the simulations re complete, but using the keyword
+     DELETE_RUNPATH you can request (some of) the directories to
+     be wiped after the simulations are complete.
+  */
+  {
+    {
+      char * delete_runpath_string = NULL;
+      int    ens_size              = config_content_get_value_as_int(content , NUM_REALIZATIONS_KEY);
+
+      {
+        char * log_file=NULL;
+        if (config_content_has_item( content , LOG_FILE_KEY))
+          log_file = util_alloc_string_copy( config_content_get_value(content , LOG_FILE_KEY));
+        if(config_content_has_item( content , LOG_LEVEL_KEY))
+          res_log_init_log(config_content_get_value_as_int(content , LOG_LEVEL_KEY), log_file ,  enkf_main->verbose);
+        else
+          res_log_init_log_default_log_level(log_file ,  enkf_main->verbose);
+        free( log_file );
+      }
+
+      if (config_content_has_item(content , DELETE_RUNPATH_KEY))
+        delete_runpath_string = config_content_alloc_joined_string(content , DELETE_RUNPATH_KEY , "");
+
+      enkf_main_parse_keep_runpath( enkf_main , delete_runpath_string , ens_size );
+
+      util_safe_free( delete_runpath_string );
+    }
+
+    /* This is really in the wrong place ... */
+    {
+      enkf_main->pre_clear_runpath = DEFAULT_PRE_CLEAR_RUNPATH;
+      if (config_content_has_item(content , PRE_CLEAR_RUNPATH_KEY))
+        enkf_main->pre_clear_runpath = config_content_get_value_as_bool( content , PRE_CLEAR_RUNPATH_KEY);
+    }
+
+    ecl_config_static_kw_init( enkf_main->ecl_config , content );
+
+    /* Installing templates */
+    ert_templates_init( enkf_main->templates , content );
+
+    {
+      const char * rft_config_file = NULL;
+      if (config_content_has_item(content , RFT_CONFIG_KEY))
+        rft_config_file = config_content_iget(content , RFT_CONFIG_KEY , 0,0);
+
+      enkf_main_set_rft_config_file( enkf_main , rft_config_file );
+    }
+
+
+    /*****************************************************************/
+    enkf_main_user_select_initial_fs( enkf_main );
+
+    /* Adding ensemble members */
+    enkf_main_resize_ensemble( enkf_main, config_content_iget_as_int(content, NUM_REALIZATIONS_KEY , 0 , 0) );
+
+    /*****************************************************************/
+
+    /* Loading observations */
+    enkf_main_alloc_obs(enkf_main);
+    if (config_content_has_item(content , OBS_CONFIG_KEY)) {
+      const char * obs_config_file = config_content_iget(content  , OBS_CONFIG_KEY , 0,0);
+      enkf_main_load_obs( enkf_main , obs_config_file , true );
+    }
+
+  }
+  config_content_free( content );
+  config_free(config);
+}
 
 /**
    This function boots everything needed for running a EnKF
@@ -2486,216 +2713,25 @@ static void enkf_main_bootstrap_site(enkf_main_type * enkf_main) {
 */
 
 
+// TODO: Rename as alloc
 enkf_main_type * enkf_main_bootstrap(const char * _model_config, bool strict , bool verbose) {
-  char           * model_config = NULL;
-  enkf_main_type * enkf_main;    /* The enkf_main object is allocated when the config parsing is completed. */
+  // TODO: site_config should be given as a const parameter
 
-  if (_model_config) {
-    {
-      char * path;
-      char * base;
-      char * ext;
-      if (util_is_link( _model_config )) {   /* The command line argument given is a symlink - we start by changing to */
-                                       /* the real location of the configuration file. */
-        char  * realpath = util_alloc_link_target( _model_config );
-        util_alloc_file_components(realpath , &path , &base , &ext);
-        free( realpath );
-      } else
-        util_alloc_file_components(_model_config , &path , &base , &ext);
+  enkf_main_type * enkf_main = enkf_main_alloc_empty();
+  enkf_main->site_config = site_config_alloc_default();
+  enkf_main_set_verbose(enkf_main, verbose);
+  enkf_main_bootstrap_site(enkf_main);
 
-      if (path != NULL) {
-        if (util_chdir(path) != 0)
-          util_abort("%s: failed to change directory to: %s : %s \n",__func__ , path , strerror(errno));
+  char * model_config = enkf_main_alloc_model_config_filename(_model_config);
+  if(model_config) {
+      enkf_main_set_user_config_file(enkf_main, model_config);
+      free(model_config);
 
-      if (verbose)
-        printf("Changing to directory ...................: %s \n",path);
-
-      if (ext != NULL)
-        model_config = util_alloc_filename( NULL , base , ext );
-      else
-        model_config = util_alloc_string_copy( base );
-      } else
-        model_config = util_alloc_string_copy(_model_config);
-
-      util_safe_free( path );
-      util_safe_free( base );
-      util_safe_free( ext );
-    }
-
-    if (!util_file_exists(model_config))
-      util_exit("%s: can not locate user configuration file:%s \n",__func__ , model_config);
+      enkf_main_bootstrap_model(enkf_main, strict, verbose);
   }
 
+  enkf_main_init_jobname(enkf_main);
 
-  {
-    config_parser_type * config;
-    config_content_type * content;
-    enkf_main            = enkf_main_alloc_empty( );
-    enkf_main->site_config = site_config_alloc_default();
-    enkf_main_set_verbose( enkf_main , verbose );
-    enkf_main_bootstrap_site(enkf_main);
-
-    if (model_config) {
-      enkf_main_set_user_config_file( enkf_main , model_config );
-
-      config = config_alloc();
-      enkf_main_init_user_config( enkf_main , config );
-      site_config_add_config_items( config , false );
-      site_config_init_user_mode( enkf_main->site_config );
-      enkf_main_user_config_deprecate( config );
-
-      {
-        hash_type *pre_defined_kw_map = __enkf_main_alloc_predefined_kw_map(enkf_main);
-        content = config_parse(config , model_config , "--" , INCLUDE_KEY , DEFINE_KEY , pre_defined_kw_map, CONFIG_UNRECOGNIZED_WARN , true);
-        hash_free(pre_defined_kw_map);
-      }
-
-      {
-        const stringlist_type * warnings = config_content_get_warnings( content );
-        if (stringlist_get_size( warnings ) > 0) {
-          fprintf(stderr," ** There were warnings when parsing the configuration file: %s" , model_config );
-          for (int i=0; i < stringlist_get_size( warnings ); i++)
-            fprintf(stderr, " %02d : %s \n",i , stringlist_iget( warnings , i ));
-        }
-      }
-
-      if (!config_content_is_valid( content )) {
-        config_error_type * errors = config_content_get_errors( content );
-        config_error_fprintf( errors , true , stderr );
-        exit(1);
-      }
-
-      site_config_init( enkf_main->site_config , content );                                   /*  <---- model_config : second pass. */
-
-      /*****************************************************************/
-      /*
-  OK - now we have parsed everything - and we are ready to start
-  populating the enkf_main object.
-      */
-
-      {
-        char * log_file=NULL;
-        if (config_content_has_item( content , LOG_FILE_KEY))
-          log_file = util_alloc_string_copy( config_content_get_value(content , LOG_FILE_KEY));
-        if(config_content_has_item( content , LOG_LEVEL_KEY))
-          res_log_init_log(config_content_get_value_as_int(content , LOG_LEVEL_KEY), log_file ,  enkf_main->verbose);
-        else
-          res_log_init_log_default_log_level(log_file ,  enkf_main->verbose);
-        free( log_file );
-      }
-
-      /*
-  Initializing the various 'large' sub config objects.
-      */
-      rng_config_init( enkf_main->rng_config , content );
-      enkf_main_rng_init( enkf_main );  /* Must be called before the ensmeble is created. */
-
-      enkf_main_init_subst_list( enkf_main );
-      ert_workflow_list_init( enkf_main->workflow_list , content );
-
-      analysis_config_load_internal_modules( enkf_main->analysis_config );
-      analysis_config_init( enkf_main->analysis_config , content );
-      ecl_config_init( enkf_main->ecl_config , content );
-      config_settings_apply( enkf_main->plot_config , content );
-
-      ensemble_config_init( enkf_main->ensemble_config , content ,
-                            ecl_config_get_grid( enkf_main->ecl_config ) ,
-                            ecl_config_get_refcase( enkf_main->ecl_config) );
-
-      model_config_init( enkf_main->model_config ,
-                         content ,
-                         enkf_main_get_ensemble_size( enkf_main ),
-                         site_config_get_installed_jobs(enkf_main->site_config) ,
-                         ecl_config_get_last_history_restart( enkf_main->ecl_config ),
-                         ecl_config_get_sched_file(enkf_main->ecl_config) ,
-                         ecl_config_get_refcase( enkf_main->ecl_config ));
-
-      enkf_main_init_hook_manager( enkf_main , content );
-      enkf_main_init_data_kw( enkf_main , content );
-      enkf_main_update_num_cpu( enkf_main );
-      {
-        if (config_content_has_item( content , SCHEDULE_PREDICTION_FILE_KEY )) {
-          const config_content_item_type * pred_item = config_content_get_item( content , SCHEDULE_PREDICTION_FILE_KEY );
-          config_content_node_type * pred_node = config_content_item_get_last_node( pred_item );
-          const char * template_file = config_content_node_iget_as_path( pred_node , 0 );
-          {
-            hash_type * opt_hash = hash_alloc();
-            config_content_node_init_opt_hash( pred_node , opt_hash , 1 );
-
-            const char * parameters = hash_safe_get( opt_hash , "PARAMETERS" );
-            const char * min_std    = hash_safe_get( opt_hash , "MIN_STD"    );
-            const char * init_files = hash_safe_get( opt_hash , "INIT_FILES" );
-
-            enkf_main_set_schedule_prediction_file__( enkf_main , template_file , parameters , min_std , init_files );
-            hash_free( opt_hash );
-          }
-        }
-      }
-
-
-      /*****************************************************************/
-      /**
-         By default the simulation directories are left intact when
-         the simulations re complete, but using the keyword
-         DELETE_RUNPATH you can request (some of) the directories to
-         be wiped after the simulations are complete.
-      */
-      {
-        {
-          char * delete_runpath_string = NULL;
-          int    ens_size              = config_content_get_value_as_int(content , NUM_REALIZATIONS_KEY);
-
-          if (config_content_has_item(content , DELETE_RUNPATH_KEY))
-            delete_runpath_string = config_content_alloc_joined_string(content , DELETE_RUNPATH_KEY , "");
-
-          enkf_main_parse_keep_runpath( enkf_main , delete_runpath_string , ens_size );
-
-          util_safe_free( delete_runpath_string );
-        }
-
-        /* This is really in the wrong place ... */
-        {
-          enkf_main->pre_clear_runpath = DEFAULT_PRE_CLEAR_RUNPATH;
-          if (config_content_has_item(content , PRE_CLEAR_RUNPATH_KEY))
-            enkf_main->pre_clear_runpath = config_content_get_value_as_bool( content , PRE_CLEAR_RUNPATH_KEY);
-        }
-
-        ecl_config_static_kw_init( enkf_main->ecl_config , content );
-
-        /* Installing templates */
-        ert_templates_init( enkf_main->templates , content );
-
-        {
-          const char * rft_config_file = NULL;
-          if (config_content_has_item(content , RFT_CONFIG_KEY))
-            rft_config_file = config_content_iget(content , RFT_CONFIG_KEY , 0,0);
-
-          enkf_main_set_rft_config_file( enkf_main , rft_config_file );
-        }
-
-
-        /*****************************************************************/
-        enkf_main_user_select_initial_fs( enkf_main );
-
-        /* Adding ensemble members */
-        enkf_main_resize_ensemble( enkf_main, config_content_iget_as_int(content, NUM_REALIZATIONS_KEY , 0 , 0) );
-
-        /*****************************************************************/
-
-        /* Loading observations */
-        enkf_main_alloc_obs(enkf_main);
-        if (config_content_has_item(content , OBS_CONFIG_KEY)) {
-          const char * obs_config_file = config_content_iget(content  , OBS_CONFIG_KEY , 0,0);
-          enkf_main_load_obs( enkf_main , obs_config_file , true );
-        }
-
-      }
-      config_content_free( content );
-      config_free(config);
-    }
-    enkf_main_init_jobname( enkf_main );
-    free( model_config );
-  }
   return enkf_main;
 }
 

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -2433,28 +2433,14 @@ static hash_type *__enkf_main_alloc_predefined_kw_map(const enkf_main_type *enkf
 
 
 static void enkf_main_bootstrap_site(enkf_main_type * enkf_main) {
-  const char * site_config_file = site_config_get_config_file(enkf_main->site_config);
+  config_parser_type * config = config_alloc();
+  config_content_type * content = site_config_alloc_content(enkf_main->site_config, config);
 
-  if (site_config_file != NULL) {
-    if (!util_file_exists(site_config_file))  util_exit("%s: can not locate site configuration file:%s \n",__func__ , site_config_file);
-    config_parser_type * config = config_alloc();
-    site_config_add_config_items( config , true );
-    {
-      config_content_type * content = config_parse(config , site_config_file  , "--" , INCLUDE_KEY , DEFINE_KEY , NULL, CONFIG_UNRECOGNIZED_WARN , false);
-      if (config_content_is_valid( content )) {
-        site_config_init( enkf_main->site_config , content );
-        analysis_config_load_all_external_modules_from_config(enkf_main->analysis_config, content);
-        ert_workflow_list_init( enkf_main->workflow_list , content );
-      } else {
-        config_error_type * errors = config_content_get_errors( content );
-        fprintf(stderr , "** ERROR: Parsing site configuration file:%s failed \n\n" , site_config_file);
-        config_error_fprintf( errors , true , stderr );
-        exit(1);
-      }
-      config_content_free( content );
-    }
-    config_free( config );
-  }
+  analysis_config_load_all_external_modules_from_config(enkf_main->analysis_config, content);
+  ert_workflow_list_init(enkf_main->workflow_list, content);
+
+  config_free(config);
+  config_content_free(content);
 }
 
 
@@ -2501,7 +2487,6 @@ static void enkf_main_bootstrap_site(enkf_main_type * enkf_main) {
 */
 
 
-// TODO: Rename with alloc
 enkf_main_type * enkf_main_bootstrap(const char * _model_config, bool strict , bool verbose) {
   char           * model_config = NULL;
   enkf_main_type * enkf_main;    /* The enkf_main object is allocated when the config parsing is completed. */

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -2193,7 +2193,7 @@ enkf_main_type * enkf_main_alloc_empty( ) {
   enkf_main->ens_size           = 0;
   enkf_main->keep_runpath       = int_vector_alloc( 0 , DEFAULT_KEEP );
   enkf_main->rng_config         = rng_config_alloc( );
-  enkf_main->site_config        = site_config_alloc_empty();
+  enkf_main->site_config        = site_config_alloc_default();
   enkf_main->ensemble_config    = ensemble_config_alloc();
   enkf_main->ecl_config         = ecl_config_alloc();
   enkf_main->ranking_table      = ranking_table_alloc( 0 );
@@ -2432,7 +2432,9 @@ static hash_type *__enkf_main_alloc_predefined_kw_map(const enkf_main_type *enkf
 */
 
 
-static void enkf_main_bootstrap_site(enkf_main_type * enkf_main , const char * site_config_file) {
+static void enkf_main_bootstrap_site(enkf_main_type * enkf_main) {
+  const char * site_config_file = site_config_get_config_file(enkf_main->site_config);
+
   if (site_config_file != NULL) {
     if (!util_file_exists(site_config_file))  util_exit("%s: can not locate site configuration file:%s \n",__func__ , site_config_file);
     config_parser_type * config = config_alloc();
@@ -2499,8 +2501,8 @@ static void enkf_main_bootstrap_site(enkf_main_type * enkf_main , const char * s
 */
 
 
+// TODO: Rename with alloc
 enkf_main_type * enkf_main_bootstrap(const char * _model_config, bool strict , bool verbose) {
-  const char     * site_config  = site_config_get_location();
   char           * model_config = NULL;
   enkf_main_type * enkf_main;    /* The enkf_main object is allocated when the config parsing is completed. */
 
@@ -2546,10 +2548,9 @@ enkf_main_type * enkf_main_bootstrap(const char * _model_config, bool strict , b
     config_content_type * content;
     enkf_main            = enkf_main_alloc_empty( );
     enkf_main_set_verbose( enkf_main , verbose );
-    enkf_main_bootstrap_site( enkf_main , site_config);
+    enkf_main_bootstrap_site(enkf_main);
 
     if (model_config) {
-      enkf_main_set_site_config_file( enkf_main , site_config );
       enkf_main_set_user_config_file( enkf_main , model_config );
 
       config = config_alloc();

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -2498,9 +2498,6 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
 
   enkf_main_init_hook_manager(enkf_main, content);
 
-  if (config_content_has_item(content , DELETE_RUNPATH_KEY))
-    delete_runpath_string = config_content_alloc_joined_string(content , DELETE_RUNPATH_KEY , "");
-
   enkf_main_init_data_kw(enkf_main, content);
 
   enkf_main_update_num_cpu(enkf_main);

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -381,7 +381,6 @@ void enkf_main_free(enkf_main_type * enkf_main){
 
 
   hook_manager_free( enkf_main->hook_manager );
-  site_config_free( enkf_main->site_config);
   ensemble_config_free( enkf_main->ensemble_config );
 
   local_config_free( enkf_main->local_config );
@@ -2181,7 +2180,7 @@ static void enkf_main_init_subst_list( enkf_main_type * enkf_main ) {
 
 
 
-enkf_main_type * enkf_main_alloc_empty( ) {
+static enkf_main_type * enkf_main_alloc_empty( ) {
   enkf_main_type * enkf_main = util_malloc(sizeof * enkf_main);
   UTIL_TYPE_ID_INIT(enkf_main , ENKF_MAIN_ID);
   res_log_open_empty();
@@ -2193,7 +2192,7 @@ enkf_main_type * enkf_main_alloc_empty( ) {
   enkf_main->ens_size           = 0;
   enkf_main->keep_runpath       = int_vector_alloc( 0 , DEFAULT_KEEP );
   enkf_main->rng_config         = rng_config_alloc( );
-  enkf_main->site_config        = site_config_alloc_default();
+  enkf_main->site_config        = NULL;
   enkf_main->ensemble_config    = ensemble_config_alloc();
   enkf_main->ecl_config         = ecl_config_alloc();
   enkf_main->ranking_table      = ranking_table_alloc( 0 );
@@ -2532,6 +2531,7 @@ enkf_main_type * enkf_main_bootstrap(const char * _model_config, bool strict , b
     config_parser_type * config;
     config_content_type * content;
     enkf_main            = enkf_main_alloc_empty( );
+    enkf_main->site_config = site_config_alloc_default();
     enkf_main_set_verbose( enkf_main , verbose );
     enkf_main_bootstrap_site(enkf_main);
 

--- a/libenkf/src/enkf_main_ensemble.c
+++ b/libenkf/src/enkf_main_ensemble.c
@@ -38,9 +38,6 @@ void enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size ) 
     return ;
 
   ranking_table_set_ens_size( enkf_main->ranking_table , new_ens_size );
-  /* Tell the site_config object (i.e. the queue drivers) about the new ensemble size: */
-  site_config_set_ens_size( enkf_main->site_config , new_ens_size );
-
 
   /* The ensemble is shrinking. */
   if (new_ens_size < enkf_main->ens_size) {

--- a/libenkf/src/ert_test_context.c
+++ b/libenkf/src/ert_test_context.c
@@ -35,12 +35,12 @@ struct ert_test_context_struct {
   UTIL_TYPE_ID_DECLARATION;
   enkf_main_type * enkf_main;
   test_work_area_type * work_area;
+  site_config_type * site_config;
   rng_type * rng;
 };
 
 
 UTIL_IS_INSTANCE_FUNCTION( ert_test_context , ERT_TEST_CONTEXT_TYPE_ID )
-
 
 static ert_test_context_type * ert_test_context_alloc__( const char * test_name , const char * model_config , bool python_mode) {
   ert_test_context_type * test_context = util_malloc( sizeof * test_context );
@@ -62,7 +62,8 @@ static ert_test_context_type * ert_test_context_alloc__( const char * test_name 
     test_work_area_copy_parent_content(test_context->work_area , model_config );
     {
       char * config_file = util_split_alloc_filename( model_config );
-      test_context->enkf_main = enkf_main_bootstrap(config_file , true , false );
+      test_context->site_config = site_config_alloc_model_config(config_file);
+      test_context->enkf_main = enkf_main_alloc(config_file, test_context->site_config, true, false);
       free( config_file );
     }
     test_context->rng = rng_alloc( MZRAN , INIT_DEV_URANDOM );
@@ -70,6 +71,7 @@ static ert_test_context_type * ert_test_context_alloc__( const char * test_name 
     test_context->enkf_main = NULL;
     test_context->work_area = NULL;
     test_context->rng = NULL;
+    test_context->site_config = NULL;
   }
   return test_context;
 }
@@ -106,6 +108,9 @@ void ert_test_context_free( ert_test_context_type * test_context ) {
 
   if (test_context->rng)
     rng_free( test_context->rng );
+
+  if (test_context->site_config)
+    site_config_free(test_context->site_config);
 
   free( test_context );
 }

--- a/libenkf/src/ert_test_context.c
+++ b/libenkf/src/ert_test_context.c
@@ -62,7 +62,7 @@ static ert_test_context_type * ert_test_context_alloc__( const char * test_name 
     test_work_area_copy_parent_content(test_context->work_area , model_config );
     {
       char * config_file = util_split_alloc_filename( model_config );
-      test_context->site_config = site_config_alloc_model_config(config_file);
+      test_context->site_config = site_config_alloc_load_user_config(config_file);
       test_context->enkf_main = enkf_main_alloc(config_file, test_context->site_config, true, false);
       free( config_file );
     }

--- a/libenkf/src/site_config.c
+++ b/libenkf/src/site_config.c
@@ -83,6 +83,9 @@
  */
 
 struct site_config_struct {
+
+  char * config_file;
+
   ext_joblist_type * joblist; /* The list of external jobs which have been installed.
                                                      These jobs will be the parts of the forward model. */
   hash_type * env_variables_user; /* The environment variables set in the user config file. */
@@ -144,6 +147,7 @@ site_config_type * site_config_alloc_empty() {
 
   site_config->joblist = ext_joblist_alloc();
  
+  site_config->config_file = NULL;
   site_config->license_root_path = NULL;
   site_config->license_root_path_site = NULL;
   site_config->__license_root_path = NULL;
@@ -616,6 +620,7 @@ void site_config_free(site_config_type * site_config) {
   if (site_config->__license_root_path != NULL)
     util_clear_directory(site_config->__license_root_path, true, true);
 
+  util_safe_free(site_config->config_file);
   util_safe_free(site_config->manual_url);
   util_safe_free(site_config->default_browser);
   util_safe_free(site_config->license_root_path);
@@ -729,6 +734,14 @@ void site_config_add_config_items(config_parser_type * config, bool site_mode) {
 
   item = config_add_schema_item( config , ANALYSIS_LOAD_KEY , false  );
   config_schema_item_set_argc_minmax( item , 2 , 2);
+}
+
+const char * site_config_get_config_file(const site_config_type * site_config) {
+  return site_config->config_file;
+}
+
+void site_config_set_config_file(site_config_type * site_config, const char * config_file) {
+  site_config->config_file = util_realloc_string_copy(site_config->config_file, config_file);
 }
 
 const char * site_config_get_location() {

--- a/libenkf/src/site_config.c
+++ b/libenkf/src/site_config.c
@@ -173,6 +173,13 @@ site_config_type * site_config_alloc_empty() {
   return site_config;
 }
 
+site_config_type * site_config_alloc_default() {
+  site_config_type * site_config = site_config_alloc_empty();
+  site_config_set_config_file(site_config, site_config_get_location());
+
+  return site_config;
+}
+
 const char * site_config_get_license_root_path(const site_config_type * site_config) {
   return site_config->license_root_path;
 }

--- a/libenkf/src/site_config.c
+++ b/libenkf/src/site_config.c
@@ -138,10 +138,14 @@ static void site_config_set_queue_option(site_config_type * site_config, const c
     fprintf(stderr, "** Warning: Driver:%s not recognized - ignored \n", driver_name);
 }
 
+static void site_config_set_config_file(site_config_type * site_config, const char * config_file) {
+  site_config->config_file = util_realloc_string_copy(site_config->config_file, config_file);
+}
+
 /**
    This site_config object is not really ready for prime time.
  */
-site_config_type * site_config_alloc_empty() {
+static site_config_type * site_config_alloc_empty() {
   site_config_type * site_config = util_malloc(sizeof * site_config);
    
   site_config->queue_config = queue_config_alloc();
@@ -184,7 +188,7 @@ static void site_config_load_config(site_config_type * site_config) {
   config_content_free(content);
 }
 
-site_config_type * site_config_alloc_default() {
+site_config_type * site_config_alloc() {
   site_config_type * site_config = site_config_alloc_empty();
   site_config_set_config_file(site_config, site_config_get_location());
   site_config_load_config(site_config);
@@ -192,9 +196,9 @@ site_config_type * site_config_alloc_default() {
   return site_config;
 }
 
-site_config_type * site_config_alloc_model_config(const char * model_config) {
-  site_config_type * site_config = site_config_alloc_default();
-  site_config_load_user_config(site_config, model_config);
+site_config_type * site_config_alloc_load_user_config(const char * user_config_file) {
+  site_config_type * site_config = site_config_alloc();
+  site_config_load_user_config(site_config, user_config_file);
 
   return site_config;
 }
@@ -782,9 +786,6 @@ const char * site_config_get_config_file(const site_config_type * site_config) {
   return site_config->config_file;
 }
 
-void site_config_set_config_file(site_config_type * site_config, const char * config_file) {
-  site_config->config_file = util_realloc_string_copy(site_config->config_file, config_file);
-}
 
 config_content_type * site_config_alloc_content(
         const site_config_type * site_config,

--- a/libenkf/src/site_config.c
+++ b/libenkf/src/site_config.c
@@ -44,6 +44,7 @@
 #include <ert/enkf/enkf_defaults.h>
 #include <ert/enkf/config_keys.h>
 #include <ert/enkf/ert_workflow_list.h>
+#include <ert/enkf/model_config.h>
 
 /**
    This struct contains information which is specific to the site

--- a/libenkf/src/site_config.c
+++ b/libenkf/src/site_config.c
@@ -192,6 +192,13 @@ site_config_type * site_config_alloc_default() {
   return site_config;
 }
 
+site_config_type * site_config_alloc_model_config(const char * model_config) {
+  site_config_type * site_config = site_config_alloc_default();
+  site_config_load_user_config(site_config, model_config);
+
+  return site_config;
+}
+
 const char * site_config_get_license_root_path(const site_config_type * site_config) {
   return site_config->license_root_path;
 }
@@ -576,6 +583,9 @@ bool site_config_load_user_config(
         site_config_type * site_config,
         const char * user_config_filename) {
 
+  if (user_config_filename == NULL)
+    return false;
+
   site_config_init_user_mode(site_config);
 
   config_parser_type * config = config_alloc();
@@ -629,12 +639,10 @@ bool site_config_init(site_config_type * site_config, const config_content_type 
   }
   
   if (config_content_has_item(config, LICENSE_PATH_KEY))
-  site_config_set_license_root_path(site_config, config_content_get_value_as_abspath(config, LICENSE_PATH_KEY));
-
+    site_config_set_license_root_path(site_config, config_content_get_value_as_abspath(config, LICENSE_PATH_KEY));
   
-  if (config_content_has_item(config, EXT_JOB_SEARCH_PATH_KEY)){
+  if (config_content_has_item(config, EXT_JOB_SEARCH_PATH_KEY))
       site_config_set_ext_job_search_path(site_config, config_content_get_value_as_bool(config, EXT_JOB_SEARCH_PATH_KEY));
-  }
 
 
   return true;
@@ -674,11 +682,6 @@ ext_joblist_type * site_config_get_installed_jobs(const site_config_type * site_
   return site_config->joblist;
 }
 
-
-
-void site_config_set_ens_size(site_config_type * site_config, int ens_size) {
-  //job_queue_set_size( site_config->job_queue , ens_size );
-}
 
 /*****************************************************************/
 

--- a/libenkf/src/site_config.c
+++ b/libenkf/src/site_config.c
@@ -571,6 +571,26 @@ void site_config_init_env(site_config_type * site_config, const config_content_t
   }
 }
 
+bool site_config_load_user_config(
+        site_config_type * site_config,
+        const char * user_config_filename) {
+
+  site_config_init_user_mode(site_config);
+
+  config_parser_type * config = config_alloc();
+  config_content_type * content = model_config_alloc_content(
+                                                    user_config_filename,
+                                                    config
+                                                    );
+
+  bool status = site_config_init(site_config, content);
+
+  config_content_free( content );
+  config_free(config);
+
+  return status;
+}
+
 /**
    This function will be called twice, first when the config instance
    is an internalization of the site-wide configuration file, and

--- a/libenkf/tests/enkf_forward_init_FIELD.c
+++ b/libenkf/tests/enkf_forward_init_FIELD.c
@@ -59,7 +59,7 @@ int main(int argc , char ** argv) {
     test_assert_true( util_sscanf_bool( forward_init_string , &forward_init));
 
     util_clear_directory( "Storage" , true , true );
-    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    site_config_type * site_config = site_config_alloc_load_user_config(config_file);
     enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
     {
       ensemble_config_type * ens_config = enkf_main_get_ensemble_config( enkf_main );

--- a/libenkf/tests/enkf_forward_init_FIELD.c
+++ b/libenkf/tests/enkf_forward_init_FIELD.c
@@ -59,7 +59,8 @@ int main(int argc , char ** argv) {
     test_assert_true( util_sscanf_bool( forward_init_string , &forward_init));
 
     util_clear_directory( "Storage" , true , true );
-    enkf_main = enkf_main_bootstrap( config_file , strict , true );
+    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
     {
       ensemble_config_type * ens_config = enkf_main_get_ensemble_config( enkf_main );
       enkf_config_node_type * field_config_node = ensemble_config_get_node( ens_config , "PORO" );
@@ -157,6 +158,7 @@ int main(int argc , char ** argv) {
       run_arg_free( run_arg );
     }
     enkf_main_free( enkf_main );
+    site_config_free(site_config);
   }
 }
 

--- a/libenkf/tests/enkf_forward_init_GEN_KW.c
+++ b/libenkf/tests/enkf_forward_init_GEN_KW.c
@@ -58,7 +58,7 @@ int main(int argc , char ** argv) {
     test_assert_true( util_sscanf_bool( forward_init_string , &forward_init));
 
     util_clear_directory( "Storage" , true , true );
-    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    site_config_type * site_config = site_config_alloc_load_user_config(config_file);
     enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
     {
       const enkf_config_node_type * gen_kw_config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ) , "MULTFLT" );

--- a/libenkf/tests/enkf_forward_init_GEN_KW.c
+++ b/libenkf/tests/enkf_forward_init_GEN_KW.c
@@ -58,7 +58,8 @@ int main(int argc , char ** argv) {
     test_assert_true( util_sscanf_bool( forward_init_string , &forward_init));
 
     util_clear_directory( "Storage" , true , true );
-    enkf_main = enkf_main_bootstrap( config_file , strict , true );
+    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
     {
       const enkf_config_node_type * gen_kw_config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ) , "MULTFLT" );
       enkf_node_type * gen_kw_node = enkf_node_alloc( gen_kw_config_node );
@@ -164,6 +165,7 @@ int main(int argc , char ** argv) {
       enkf_node_free( gen_kw_node );
     }
     enkf_main_free( enkf_main );
+    site_config_free(site_config);
   }
   test_work_area_free( work_area );
   rng_free( rng );

--- a/libenkf/tests/enkf_forward_init_GEN_PARAM.c
+++ b/libenkf/tests/enkf_forward_init_GEN_PARAM.c
@@ -59,7 +59,8 @@ int main(int argc , char ** argv) {
     test_assert_true( util_sscanf_bool( forward_init_string , &forward_init));
 
     util_clear_directory( "Storage" , true , true );
-    enkf_main = enkf_main_bootstrap( config_file , strict , true );
+    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
     {
       const enkf_config_node_type * config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ) , "PARAM" );
       enkf_node_type * gen_param_node = enkf_node_alloc( config_node );
@@ -155,6 +156,7 @@ int main(int argc , char ** argv) {
       enkf_node_free( gen_param_node );
     }
     enkf_main_free( enkf_main );
+    site_config_free(site_config);
   }
   test_work_area_free( work_area );
   rng_free( rng );

--- a/libenkf/tests/enkf_forward_init_GEN_PARAM.c
+++ b/libenkf/tests/enkf_forward_init_GEN_PARAM.c
@@ -59,7 +59,7 @@ int main(int argc , char ** argv) {
     test_assert_true( util_sscanf_bool( forward_init_string , &forward_init));
 
     util_clear_directory( "Storage" , true , true );
-    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    site_config_type * site_config = site_config_alloc_load_user_config(config_file);
     enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
     {
       const enkf_config_node_type * config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ) , "PARAM" );

--- a/libenkf/tests/enkf_forward_init_SURFACE.c
+++ b/libenkf/tests/enkf_forward_init_SURFACE.c
@@ -62,7 +62,7 @@ int main(int argc , char ** argv) {
     test_assert_true( util_sscanf_bool( forward_init_string , &forward_init));
 
     util_clear_directory( "Storage" , true , true );
-    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    site_config_type * site_config = site_config_alloc_load_user_config(config_file);
     enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
     ensemble_config_type * ens_config = enkf_main_get_ensemble_config( enkf_main );
     {

--- a/libenkf/tests/enkf_forward_init_SURFACE.c
+++ b/libenkf/tests/enkf_forward_init_SURFACE.c
@@ -62,7 +62,8 @@ int main(int argc , char ** argv) {
     test_assert_true( util_sscanf_bool( forward_init_string , &forward_init));
 
     util_clear_directory( "Storage" , true , true );
-    enkf_main = enkf_main_bootstrap( config_file , strict , true );
+    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
     ensemble_config_type * ens_config = enkf_main_get_ensemble_config( enkf_main );
     {
       const enkf_config_node_type * surface_config_node = ensemble_config_get_node( ens_config , "SURFACE");
@@ -161,6 +162,7 @@ int main(int argc , char ** argv) {
       util_clear_directory( "simulations" , true , true );
     }
     enkf_main_free( enkf_main );
+    site_config_free(site_config);
   }
 }
 

--- a/libenkf/tests/enkf_forward_init_transform.c
+++ b/libenkf/tests/enkf_forward_init_transform.c
@@ -77,7 +77,7 @@ int main(int argc , char ** argv) {
   test_work_area_set_store(work_area, true);
 
   bool strict = true;
-  site_config_type * site_config = site_config_alloc_model_config(config_file);
+  site_config_type * site_config = site_config_alloc_load_user_config(config_file);
   enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
   ensemble_config_type * ens_config = enkf_main_get_ensemble_config( enkf_main );
   enkf_fs_type * init_fs = enkf_main_get_fs(enkf_main);

--- a/libenkf/tests/enkf_forward_init_transform.c
+++ b/libenkf/tests/enkf_forward_init_transform.c
@@ -77,7 +77,8 @@ int main(int argc , char ** argv) {
   test_work_area_set_store(work_area, true);
 
   bool strict = true;
-  enkf_main_type * enkf_main = enkf_main_bootstrap( config_file , strict , true );
+  site_config_type * site_config = site_config_alloc_model_config(config_file);
+  enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
   ensemble_config_type * ens_config = enkf_main_get_ensemble_config( enkf_main );
   enkf_fs_type * init_fs = enkf_main_get_fs(enkf_main);
   run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( init_fs , 0 ,0 , "simulations/run0");
@@ -111,6 +112,7 @@ int main(int argc , char ** argv) {
 
   run_arg_free( run_arg );
   enkf_main_free(enkf_main);
+  site_config_free(site_config);
   test_work_area_free(work_area);
 }
 

--- a/libenkf/tests/enkf_main.c
+++ b/libenkf/tests/enkf_main.c
@@ -34,7 +34,7 @@ void test_case_initialized(const char * config_path, const char * config_file) {
   test_work_area_type * work_area = test_work_area_alloc("enkf_main_case_initialized");
   test_work_area_copy_directory_content(work_area, config_path);
   {
-    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    site_config_type * site_config = site_config_alloc_load_user_config(config_file);
     enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
     model_config_type * model_config = enkf_main_get_model_config(enkf_main);
     const char * new_case = "fs/case";
@@ -56,7 +56,7 @@ void test_create(const char * config_path, const char * config_file) {
   test_work_area_type * work_area = test_work_area_alloc("enkf_main_create");
   test_work_area_copy_directory_content(work_area, config_path);
 
-  site_config_type * site_config = site_config_alloc_model_config(config_file);
+  site_config_type * site_config = site_config_alloc_load_user_config(config_file);
   enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
   test_assert_true( enkf_main_is_instance( enkf_main ) );
 

--- a/libenkf/tests/enkf_main.c
+++ b/libenkf/tests/enkf_main.c
@@ -30,10 +30,11 @@
 
 
 
-void test_case_initialized() {
-  test_work_area_type * work_area = test_work_area_alloc("enkf_main_case_initialized" );
+void test_case_initialized(const char * config_path, const char * config_file) {
+  test_work_area_type * work_area = test_work_area_alloc("enkf_main_case_initialized");
+  test_work_area_copy_directory_content(work_area, config_path);
   {
-    enkf_main_type * enkf_main = enkf_main_alloc_empty();
+    enkf_main_type * enkf_main = enkf_main_bootstrap(config_file, true, true);
     model_config_type * model_config = enkf_main_get_model_config(enkf_main);
     const char * new_case = "fs/case";
     char * mount_point = util_alloc_sprintf("%s/%s" , model_config_get_enspath(model_config) , new_case);
@@ -49,18 +50,25 @@ void test_case_initialized() {
 
 
 
-void test_create() {
-  enkf_main_type * enkf_main = enkf_main_alloc_empty();
+void test_create(const char * config_path, const char * config_file) {
+  test_work_area_type * work_area = test_work_area_alloc("enkf_main_create");
+  test_work_area_copy_directory_content(work_area, config_path);
+
+  enkf_main_type * enkf_main = enkf_main_bootstrap(config_file, true, true);
   test_assert_true( enkf_main_is_instance( enkf_main ) );
+
   enkf_main_free( enkf_main );
+  test_work_area_free( work_area );
 }
 
 
 
 int main(int argc , char ** argv) {
+  const char * config_path = argv[1];
+  const char * config_file = argv[2];
   util_install_signals();
-  test_create();
-  test_case_initialized();
+  test_create(config_path, config_file);
+  test_case_initialized(config_path, config_file);
   exit(0);
 }
 

--- a/libenkf/tests/enkf_main.c
+++ b/libenkf/tests/enkf_main.c
@@ -34,7 +34,8 @@ void test_case_initialized(const char * config_path, const char * config_file) {
   test_work_area_type * work_area = test_work_area_alloc("enkf_main_case_initialized");
   test_work_area_copy_directory_content(work_area, config_path);
   {
-    enkf_main_type * enkf_main = enkf_main_bootstrap(config_file, true, true);
+    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
     model_config_type * model_config = enkf_main_get_model_config(enkf_main);
     const char * new_case = "fs/case";
     char * mount_point = util_alloc_sprintf("%s/%s" , model_config_get_enspath(model_config) , new_case);
@@ -44,6 +45,7 @@ void test_case_initialized(const char * config_path, const char * config_file) {
     test_assert_true(enkf_main_case_is_initialized(enkf_main , new_case , NULL));
 
     enkf_main_free(enkf_main);
+    site_config_free(site_config);
   }
   test_work_area_free(work_area);
 }
@@ -54,10 +56,12 @@ void test_create(const char * config_path, const char * config_file) {
   test_work_area_type * work_area = test_work_area_alloc("enkf_main_create");
   test_work_area_copy_directory_content(work_area, config_path);
 
-  enkf_main_type * enkf_main = enkf_main_bootstrap(config_file, true, true);
+  site_config_type * site_config = site_config_alloc_model_config(config_file);
+  enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
   test_assert_true( enkf_main_is_instance( enkf_main ) );
 
   enkf_main_free( enkf_main );
+  site_config_free(site_config);
   test_work_area_free( work_area );
 }
 

--- a/libenkf/tests/enkf_main_fs.c
+++ b/libenkf/tests/enkf_main_fs.c
@@ -40,7 +40,8 @@ int main(int argc, char ** argv) {
   util_alloc_file_components( config_file , NULL , &model_config , NULL);
   test_work_area_copy_parent_content( work_area , config_file );
   {
-    enkf_main_type * enkf_main = enkf_main_bootstrap( model_config , false , false );
+    site_config_type * site_config = site_config_alloc_model_config(model_config);
+    enkf_main_type * enkf_main = enkf_main_alloc(model_config, site_config, false, false);
 
     enkf_main_select_fs( enkf_main , "enkf");
     test_assert_true( enkf_main_case_is_current( enkf_main , "enkf"));
@@ -118,6 +119,7 @@ int main(int argc, char ** argv) {
 
     test_assert_int_equal( 1 , enkf_fs_get_refcount( enkf_main_get_fs( enkf_main )));
     enkf_main_free( enkf_main );
+    site_config_free(site_config);
   }
   test_work_area_free( work_area );
   exit(0);

--- a/libenkf/tests/enkf_main_fs.c
+++ b/libenkf/tests/enkf_main_fs.c
@@ -40,7 +40,7 @@ int main(int argc, char ** argv) {
   util_alloc_file_components( config_file , NULL , &model_config , NULL);
   test_work_area_copy_parent_content( work_area , config_file );
   {
-    site_config_type * site_config = site_config_alloc_model_config(model_config);
+    site_config_type * site_config = site_config_alloc_load_user_config(model_config);
     enkf_main_type * enkf_main = enkf_main_alloc(model_config, site_config, false, false);
 
     enkf_main_select_fs( enkf_main , "enkf");

--- a/libenkf/tests/enkf_main_fs_current_file_test.c
+++ b/libenkf/tests/enkf_main_fs_current_file_test.c
@@ -29,7 +29,7 @@
 void test_current_file_not_present_symlink_present(const char * model_config) {
     test_assert_true(util_file_exists("Storage/enkf"));
     util_make_slink("enkf", "Storage/current" ); 
-    site_config_type * site_config = site_config_alloc_model_config(model_config);
+    site_config_type * site_config = site_config_alloc_load_user_config(model_config);
     enkf_main_type * enkf_main = enkf_main_alloc(model_config, site_config, false, false);
     test_assert_true( enkf_main_case_is_current( enkf_main , "enkf"));
     test_assert_false(util_file_exists("Storage/current"));
@@ -43,7 +43,7 @@ void test_current_file_not_present_symlink_present(const char * model_config) {
 
 void test_current_file_present(const char * model_config) {
     test_assert_true(util_file_exists("Storage/current_case"));
-    site_config_type * site_config = site_config_alloc_model_config(model_config);
+    site_config_type * site_config = site_config_alloc_load_user_config(model_config);
     enkf_main_type * enkf_main = enkf_main_alloc(model_config, site_config, false, false);
     test_assert_true( enkf_main_case_is_current( enkf_main , "enkf"));
     test_assert_false(util_file_exists("Storage/current"));
@@ -56,7 +56,7 @@ void test_current_file_present(const char * model_config) {
 
 
 void test_change_case(const char * model_config) {
-    site_config_type * site_config = site_config_alloc_model_config(model_config);
+    site_config_type * site_config = site_config_alloc_load_user_config(model_config);
     enkf_main_type * enkf_main = enkf_main_alloc(model_config, site_config, false, false);
     enkf_main_select_fs( enkf_main , "default");
     test_assert_true( enkf_main_case_is_current( enkf_main , "default"));

--- a/libenkf/tests/enkf_main_fs_current_file_test.c
+++ b/libenkf/tests/enkf_main_fs_current_file_test.c
@@ -29,7 +29,8 @@
 void test_current_file_not_present_symlink_present(const char * model_config) {
     test_assert_true(util_file_exists("Storage/enkf"));
     util_make_slink("enkf", "Storage/current" ); 
-    enkf_main_type * enkf_main = enkf_main_bootstrap( model_config , false , false );
+    site_config_type * site_config = site_config_alloc_model_config(model_config);
+    enkf_main_type * enkf_main = enkf_main_alloc(model_config, site_config, false, false);
     test_assert_true( enkf_main_case_is_current( enkf_main , "enkf"));
     test_assert_false(util_file_exists("Storage/current"));
     test_assert_true(util_file_exists("Storage/current_case"));
@@ -37,22 +38,26 @@ void test_current_file_not_present_symlink_present(const char * model_config) {
     test_assert_string_equal(current_case, "enkf"); 
     free(current_case);
     enkf_main_free(enkf_main);
+    site_config_free(site_config);
 }
 
 void test_current_file_present(const char * model_config) {
     test_assert_true(util_file_exists("Storage/current_case"));
-    enkf_main_type * enkf_main = enkf_main_bootstrap(  model_config , false , false );
+    site_config_type * site_config = site_config_alloc_model_config(model_config);
+    enkf_main_type * enkf_main = enkf_main_alloc(model_config, site_config, false, false);
     test_assert_true( enkf_main_case_is_current( enkf_main , "enkf"));
     test_assert_false(util_file_exists("Storage/current"));
     char * current_case = enkf_main_read_alloc_current_case_name(enkf_main);
     test_assert_string_equal(current_case, "enkf"); 
     free(current_case); 
     enkf_main_free(enkf_main);
+    site_config_free(site_config);
 }
 
 
 void test_change_case(const char * model_config) {
-    enkf_main_type * enkf_main = enkf_main_bootstrap( model_config , false , false );
+    site_config_type * site_config = site_config_alloc_model_config(model_config);
+    enkf_main_type * enkf_main = enkf_main_alloc(model_config, site_config, false, false);
     enkf_main_select_fs( enkf_main , "default");
     test_assert_true( enkf_main_case_is_current( enkf_main , "default"));
     test_assert_false( enkf_main_case_is_current(enkf_main , "enkf"));
@@ -76,6 +81,7 @@ void test_change_case(const char * model_config) {
     test_assert_true( enkf_main_case_is_current( enkf_main , "default"));
     enkf_fs_decref( enkf_fs );
     enkf_main_free(enkf_main); 
+    site_config_free(site_config);
 }
 
 int main(int argc, char ** argv) {

--- a/libenkf/tests/enkf_plot_data_fs.c
+++ b/libenkf/tests/enkf_plot_data_fs.c
@@ -113,7 +113,7 @@ int main(int argc, char ** argv) {
     test_work_area_set_store( work_area , true );
     test_work_area_copy_parent_content( work_area , config_file );
     {
-      site_config_type * site_config = site_config_alloc_model_config(model_config);
+      site_config_type * site_config = site_config_alloc_load_user_config(model_config);
       enkf_main_type * enkf_main = enkf_main_alloc(model_config, site_config, false, false);
 
       test_load_summary(enkf_main , "WWCT:OP_3");

--- a/libenkf/tests/enkf_plot_data_fs.c
+++ b/libenkf/tests/enkf_plot_data_fs.c
@@ -113,11 +113,13 @@ int main(int argc, char ** argv) {
     test_work_area_set_store( work_area , true );
     test_work_area_copy_parent_content( work_area , config_file );
     {
-      enkf_main_type * enkf_main = enkf_main_bootstrap( model_config , false , false );
+      site_config_type * site_config = site_config_alloc_model_config(model_config);
+      enkf_main_type * enkf_main = enkf_main_alloc(model_config, site_config, false, false);
 
       test_load_summary(enkf_main , "WWCT:OP_3");
       test_load_GEN_KW( enkf_main , "MULTFLT" , "F3");
       enkf_main_free( enkf_main );
+      site_config_free(site_config);
     }
     test_work_area_free( work_area );
     exit(0);

--- a/libenkf/tests/enkf_rng.c
+++ b/libenkf/tests/enkf_rng.c
@@ -37,23 +37,27 @@ int main(int argc , char ** argv) {
     test_work_area_type * work_area = test_work_area_alloc("enkf-rng-0");
     test_work_area_copy_directory_content(work_area, config_path);
     {
-      enkf_main_type * enkf_main = enkf_main_bootstrap(NULL, true, true);
+      site_config_type * site_config = site_config_alloc_model_config(NULL);
+      enkf_main_type * enkf_main = enkf_main_alloc(NULL, site_config, true, true);
       enkf_main_resize_ensemble( enkf_main , 10 );
       {
         enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
         rand1 = enkf_state_get_random( state );
       }
       enkf_main_free( enkf_main );
+      site_config_free(site_config);
     }
     
     {
-      enkf_main_type * enkf_main = enkf_main_bootstrap(NULL, true, true);
+      site_config_type * site_config = site_config_alloc_model_config(NULL);
+      enkf_main_type * enkf_main = enkf_main_alloc(NULL, site_config, true, true);
       enkf_main_resize_ensemble( enkf_main , 10 );
       {
         enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
         rand2 = enkf_state_get_random( state );
       }
       enkf_main_free( enkf_main );
+      site_config_free(site_config);
     }
     test_assert_uint_not_equal( rand1 , rand2 );
     test_work_area_free( work_area );
@@ -67,7 +71,8 @@ int main(int argc , char ** argv) {
 
     const char * seed_file = "seed";
     {
-      enkf_main_type * enkf_main = enkf_main_bootstrap(config_file, true, true);
+      site_config_type * site_config = site_config_alloc_model_config(config_file);
+      enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
       {
         rng_config_type * rng_config = enkf_main_get_rng_config( enkf_main );
         rng_config_set_seed_store_file( rng_config , seed_file );
@@ -80,10 +85,12 @@ int main(int argc , char ** argv) {
         rand1 = enkf_state_get_random( state );
       }
       enkf_main_free( enkf_main );
+      site_config_free(site_config);
     }
     
     {
-      enkf_main_type * enkf_main = enkf_main_bootstrap(config_file, true, true);
+      site_config_type * site_config = site_config_alloc_model_config(config_file);
+      enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
       {
         rng_config_type * rng_config = enkf_main_get_rng_config( enkf_main );
         rng_config_set_seed_load_file( rng_config , seed_file );
@@ -96,6 +103,7 @@ int main(int argc , char ** argv) {
         rand2 = enkf_state_get_random( state );
       }
       enkf_main_free( enkf_main );
+      site_config_free(site_config);
     }
     test_assert_uint_equal( rand1 , rand2 );
     test_work_area_free( work_area );
@@ -106,25 +114,31 @@ int main(int argc , char ** argv) {
     test_work_area_type * work_area = test_work_area_alloc("enkf-rng-2" );
     test_work_area_copy_directory_content( work_area , config_path );
     {
-      enkf_main_type * enkf_main = enkf_main_bootstrap( config_file , true , true );
+      site_config_type * site_config = site_config_alloc_model_config(config_file);
+      enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
       enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
       rand1 = enkf_state_get_random( state );
       enkf_main_free( enkf_main );
+      site_config_free(site_config);
     }
 
     {
-      enkf_main_type * enkf_main = enkf_main_bootstrap( config_file , true , true );
+      site_config_type * site_config = site_config_alloc_model_config(config_file);
+      enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
       enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
       rand2 = enkf_state_get_random( state );
       enkf_main_free( enkf_main );
+      site_config_free(site_config);
     }
     test_assert_uint_equal( rand1 , rand2 );
     
     {
-      enkf_main_type * enkf_main = enkf_main_bootstrap( config_file , true , true );
+      site_config_type * site_config = site_config_alloc_model_config(config_file);
+      enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
       enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
       rand2 = enkf_state_get_random( state );
       enkf_main_free( enkf_main );
+      site_config_free(site_config);
     }
     test_assert_uint_equal( rand1 , rand2 );
     test_work_area_free( work_area );

--- a/libenkf/tests/enkf_rng.c
+++ b/libenkf/tests/enkf_rng.c
@@ -29,11 +29,15 @@
 
 
 int main(int argc , char ** argv) {
+  const char * config_path = argv[1];
+  const char * config_file = argv[2];
+
   unsigned int rand1,rand2;
   {
     test_work_area_type * work_area = test_work_area_alloc("enkf-rng-0");
+    test_work_area_copy_directory_content(work_area, config_path);
     {
-      enkf_main_type * enkf_main = enkf_main_alloc_empty();
+      enkf_main_type * enkf_main = enkf_main_bootstrap(NULL, true, true);
       enkf_main_resize_ensemble( enkf_main , 10 );
       {
         enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
@@ -43,7 +47,7 @@ int main(int argc , char ** argv) {
     }
     
     {
-      enkf_main_type * enkf_main = enkf_main_alloc_empty();
+      enkf_main_type * enkf_main = enkf_main_bootstrap(NULL, true, true);
       enkf_main_resize_ensemble( enkf_main , 10 );
       {
         enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
@@ -59,9 +63,11 @@ int main(int argc , char ** argv) {
 
   {
     test_work_area_type * work_area = test_work_area_alloc("enkf-rng-1" );
+    test_work_area_copy_directory_content( work_area , config_path );
+
     const char * seed_file = "seed";
     {
-      enkf_main_type * enkf_main = enkf_main_alloc_empty();
+      enkf_main_type * enkf_main = enkf_main_bootstrap(config_file, true, true);
       {
         rng_config_type * rng_config = enkf_main_get_rng_config( enkf_main );
         rng_config_set_seed_store_file( rng_config , seed_file );
@@ -77,7 +83,7 @@ int main(int argc , char ** argv) {
     }
     
     {
-      enkf_main_type * enkf_main = enkf_main_alloc_empty();
+      enkf_main_type * enkf_main = enkf_main_bootstrap(config_file, true, true);
       {
         rng_config_type * rng_config = enkf_main_get_rng_config( enkf_main );
         rng_config_set_seed_load_file( rng_config , seed_file );
@@ -97,8 +103,6 @@ int main(int argc , char ** argv) {
   }
   /*****************************************************************/
   {
-    const char * config_path = argv[1];
-    const char * config_file = argv[2];
     test_work_area_type * work_area = test_work_area_alloc("enkf-rng-2" );
     test_work_area_copy_directory_content( work_area , config_path );
     {

--- a/libenkf/tests/enkf_rng.c
+++ b/libenkf/tests/enkf_rng.c
@@ -37,7 +37,7 @@ int main(int argc , char ** argv) {
     test_work_area_type * work_area = test_work_area_alloc("enkf-rng-0");
     test_work_area_copy_directory_content(work_area, config_path);
     {
-      site_config_type * site_config = site_config_alloc_model_config(NULL);
+      site_config_type * site_config = site_config_alloc_load_user_config(NULL);
       enkf_main_type * enkf_main = enkf_main_alloc(NULL, site_config, true, true);
       enkf_main_resize_ensemble( enkf_main , 10 );
       {
@@ -49,7 +49,7 @@ int main(int argc , char ** argv) {
     }
     
     {
-      site_config_type * site_config = site_config_alloc_model_config(NULL);
+      site_config_type * site_config = site_config_alloc_load_user_config(NULL);
       enkf_main_type * enkf_main = enkf_main_alloc(NULL, site_config, true, true);
       enkf_main_resize_ensemble( enkf_main , 10 );
       {
@@ -71,7 +71,7 @@ int main(int argc , char ** argv) {
 
     const char * seed_file = "seed";
     {
-      site_config_type * site_config = site_config_alloc_model_config(config_file);
+      site_config_type * site_config = site_config_alloc_load_user_config(config_file);
       enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
       {
         rng_config_type * rng_config = enkf_main_get_rng_config( enkf_main );
@@ -89,7 +89,7 @@ int main(int argc , char ** argv) {
     }
     
     {
-      site_config_type * site_config = site_config_alloc_model_config(config_file);
+      site_config_type * site_config = site_config_alloc_load_user_config(config_file);
       enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
       {
         rng_config_type * rng_config = enkf_main_get_rng_config( enkf_main );
@@ -114,7 +114,7 @@ int main(int argc , char ** argv) {
     test_work_area_type * work_area = test_work_area_alloc("enkf-rng-2" );
     test_work_area_copy_directory_content( work_area , config_path );
     {
-      site_config_type * site_config = site_config_alloc_model_config(config_file);
+      site_config_type * site_config = site_config_alloc_load_user_config(config_file);
       enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
       enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
       rand1 = enkf_state_get_random( state );
@@ -123,7 +123,7 @@ int main(int argc , char ** argv) {
     }
 
     {
-      site_config_type * site_config = site_config_alloc_model_config(config_file);
+      site_config_type * site_config = site_config_alloc_load_user_config(config_file);
       enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
       enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
       rand2 = enkf_state_get_random( state );
@@ -133,7 +133,7 @@ int main(int argc , char ** argv) {
     test_assert_uint_equal( rand1 , rand2 );
     
     {
-      site_config_type * site_config = site_config_alloc_model_config(config_file);
+      site_config_type * site_config = site_config_alloc_load_user_config(config_file);
       enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, true, true);
       enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
       rand2 = enkf_state_get_random( state );

--- a/libenkf/tests/enkf_site_config.c
+++ b/libenkf/tests/enkf_site_config.c
@@ -45,32 +45,8 @@
 #define DEFINE_KEY  "DEFINE"
 
 
-void test_empty() {
-  site_config_type * site_config = site_config_alloc_empty();
-  site_config_free( site_config );
-}
-
-
 void test_init(const char * config_file) {
-  site_config_type * site_config = site_config_alloc_empty();
-  config_parser_type * config = config_alloc();
-  config_content_type * content;
-
-  site_config_add_config_items( config , true );
-  content = config_parse(config , config_file , "--" , INCLUDE_KEY , DEFINE_KEY , NULL , CONFIG_UNRECOGNIZED_WARN , true);
-  if (!config_content_is_valid(content)) {
-    config_error_type * errors = config_content_get_errors( content );
-    config_error_fprintf( errors , true , stderr );
-    test_assert_true( false );
-  }
-
-  if (!site_config_init( site_config , content )) {
-    printf("Loading site_config from config failed\n");
-    test_assert_true( false );
-  }
-
-  config_content_free( content );
-  config_free( config );
+  site_config_type * site_config = site_config_alloc();
   site_config_free( site_config );
 }
 
@@ -78,7 +54,7 @@ void test_init(const char * config_file) {
 void test_job_script() {
   test_work_area_type * test_area = test_work_area_alloc("site-config");
   {
-    site_config_type * site_config = site_config_alloc_empty();
+    site_config_type * site_config = site_config_alloc();
    
 
     test_assert_false( site_config_set_job_script( site_config , "/does/not/exist" ));
@@ -114,7 +90,6 @@ int main(int argc , char ** argv) {
 
   util_install_signals();
 
-  test_empty();
   test_init( site_config_file );
   test_job_script();
 

--- a/libenkf/tests/enkf_state_manual_load_test.c
+++ b/libenkf/tests/enkf_state_manual_load_test.c
@@ -66,11 +66,13 @@ int main(int argc , char ** argv) {
   test_work_area_copy_directory_content( work_area , root_path );
   {
     bool strict = true;
-    enkf_main_type * enkf_main = enkf_main_bootstrap( config_file , strict , true );
+    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
 
     test_assert_int_equal( 0 , test_load_manually_to_new_case(enkf_main));
 
     enkf_main_free( enkf_main );
+    site_config_free(site_config);
   }
   test_work_area_free(work_area);
 

--- a/libenkf/tests/enkf_state_manual_load_test.c
+++ b/libenkf/tests/enkf_state_manual_load_test.c
@@ -66,7 +66,7 @@ int main(int argc , char ** argv) {
   test_work_area_copy_directory_content( work_area , root_path );
   {
     bool strict = true;
-    site_config_type * site_config = site_config_alloc_model_config(config_file);
+    site_config_type * site_config = site_config_alloc_load_user_config(config_file);
     enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
 
     test_assert_int_equal( 0 , test_load_manually_to_new_case(enkf_main));

--- a/libenkf/tests/enkf_state_report_step_compatible.c
+++ b/libenkf/tests/enkf_state_report_step_compatible.c
@@ -60,11 +60,13 @@ int main(int argc , char ** argv) {
   test_work_area_copy_directory_content( work_area , root_path );
   
   bool strict = true;
-  enkf_main_type * enkf_main = enkf_main_bootstrap( config_file , strict , true );
+  site_config_type * site_config = site_config_alloc_model_config(config_file);
+  enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
   
   
   test_assert_bool_equal(check_compatible , check_ecl_sum_compatible(enkf_main));
   
   enkf_main_free( enkf_main );
+  site_config_free(site_config);
   test_work_area_free(work_area); 
 }

--- a/libenkf/tests/enkf_state_report_step_compatible.c
+++ b/libenkf/tests/enkf_state_report_step_compatible.c
@@ -60,7 +60,7 @@ int main(int argc , char ** argv) {
   test_work_area_copy_directory_content( work_area , root_path );
   
   bool strict = true;
-  site_config_type * site_config = site_config_alloc_model_config(config_file);
+  site_config_type * site_config = site_config_alloc_load_user_config(config_file);
   enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
   
   

--- a/libenkf/tests/enkf_state_skip_summary_load_test.c
+++ b/libenkf/tests/enkf_state_skip_summary_load_test.c
@@ -62,7 +62,7 @@ int main(int argc , char ** argv) {
   test_work_area_copy_directory_content( work_area , root_path );
   
   bool strict = true;
-  site_config_type * site_config = site_config_alloc_model_config(config_file);
+  site_config_type * site_config = site_config_alloc_load_user_config(config_file);
   enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
   
   test_assert_true( check_ecl_sum_loaded(enkf_main) );

--- a/libenkf/tests/enkf_state_skip_summary_load_test.c
+++ b/libenkf/tests/enkf_state_skip_summary_load_test.c
@@ -62,10 +62,12 @@ int main(int argc , char ** argv) {
   test_work_area_copy_directory_content( work_area , root_path );
   
   bool strict = true;
-  enkf_main_type * enkf_main = enkf_main_bootstrap( config_file , strict , true );
+  site_config_type * site_config = site_config_alloc_model_config(config_file);
+  enkf_main_type * enkf_main = enkf_main_alloc(config_file, site_config, strict, true);
   
   test_assert_true( check_ecl_sum_loaded(enkf_main) );
   
   enkf_main_free( enkf_main );
+  site_config_free(site_config);
   test_work_area_free(work_area); 
 }

--- a/python/python/res/enkf/site_config.py
+++ b/python/python/res/enkf/site_config.py
@@ -24,7 +24,7 @@ from ecl.util import StringList, Hash
 class SiteConfig(BaseCClass):
     TYPE_NAME = "site_config"
 
-    _alloc                 = EnkfPrototype("void* site_config_alloc_model_config(char*)", bind=False)
+    _alloc                 = EnkfPrototype("void* site_config_alloc_load_user_config(char*)", bind=False)
     _free                  = EnkfPrototype("void site_config_free( site_config )")
     _get_lsf_queue         = EnkfPrototype("char* site_config_get_lsf_queue(site_config)")
     _set_lsf_queue         = EnkfPrototype("void site_config_set_lsf_queue(site_config, char*)")

--- a/python/tests/res/enkf/CMakeLists.txt
+++ b/python/tests/res/enkf/CMakeLists.txt
@@ -37,11 +37,13 @@ set(TEST_SOURCES
     test_forward_load_context.py
     test_runpath_list.py
     test_queue_config.py
+    test_site_config.py
 )
 
 add_python_package("python.tests.res.enkf" ${PYTHON_INSTALL_PREFIX}/tests/res/enkf "${TEST_SOURCES}" False)
 
 addPythonTest(tests.res.enkf.test_es_update.ESUpdateTest)
+addPythonTest(tests.res.enkf.test_site_config.SiteConfigTest)
 addPythonTest(tests.res.enkf.test_forward_load_context.ForwardLoadContextTest)
 addPythonTest(tests.res.enkf.test_deprecation.DeprecationTest)
 addPythonTest(tests.res.enkf.test_meas_block.MeasBlockTest)

--- a/python/tests/res/enkf/test_enkf.py
+++ b/python/tests/res/enkf/test_enkf.py
@@ -51,10 +51,28 @@ class EnKFTest(ExtendedTestCase):
             self.assertTrue(main, "Load failed")
             main.free()
 
+    def test_site_condif(self):
+        with TestAreaContext("enkf_test", store_area=True) as work_area:
+            work_area.copy_directory(self.case_directory)
+            site_config = SiteConfig("simple_config/minimum_config")
+            main = EnKFMain(
+                    "simple_config/minimum_config",
+                    site_config=site_config
+                    )
+
+            self.assertTrue(main, "Load failed")
+            self.assertEqual(site_config, main.siteConfig())
 
     def test_site_bootstrap( self ):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
-            EnKFMain.loadSiteConfig()
+            EnKFMain(None)
+
+    def test_invalid_site_config(self):
+        with TestAreaContext("enkf_test") as work_area:
+            with self.assertRaises(TypeError):
+                work_area.copy_directory(self.case_directory)
+                main = EnKFMain("simple_config/minimum_config", site_config=self)
+
 
 
     def test_enum(self):

--- a/python/tests/res/enkf/test_enkf_library.py
+++ b/python/tests/res/enkf/test_enkf_library.py
@@ -16,7 +16,7 @@ class EnKFLibraryTest(ExtendedTestCase):
 
     def test_failed_class_creation(self):
         classes = [EnkfConfigNode, EnKFState,
-                   ErtTemplate, ErtTemplates, LocalConfig, ModelConfig, SiteConfig]
+                   ErtTemplate, ErtTemplates, LocalConfig, ModelConfig]
 
         for cls in classes:
             with self.assertRaises(NotImplementedError):

--- a/python/tests/res/enkf/test_site_config.py
+++ b/python/tests/res/enkf/test_site_config.py
@@ -1,0 +1,44 @@
+#  Copyright (C) 2012  Statoil ASA, Norway.
+#
+#  The file 'test_enkf.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+from res.enkf import SiteConfig
+
+from ecl.test import ExtendedTestCase, TestAreaContext
+
+class SiteConfigTest(ExtendedTestCase):
+
+    def setUp(self):
+        self.case_directory = self.createTestPath("local/simple_config/")
+
+    def test_invalid_user_config(self):
+        with TestAreaContext("void land"):
+            with self.assertRaises(IOError):
+                SiteConfig("this/is/not/a/file")
+
+    def test_init(self):
+        with TestAreaContext("site_config_init_test") as work_area:
+            work_area.copy_directory(self.case_directory)
+            site_config = SiteConfig()
+            self.assertIsNotNone(site_config)
+            self.assertIsNotNone(site_config.config_file)
+            
+            config_file = "simple_config/minimum_config"
+            site_config2 = SiteConfig(user_config_file=config_file)
+            self.assertIsNotNone(site_config2)
+
+            self.assertEqual(site_config.config_file, site_config2.config_file)
+
+            self.assertEqual(site_config.__repr__(), site_config2.__repr__())


### PR DESCRIPTION
Enkf_main is now provided a site_config upon allocation. This is to separate how the configurations are retrieved from their applications. At the same time some refactoring is done to ease this work for the other config-objects.