### PR TITLE
Logging in job_queue

### DIFF
--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1538,7 +1538,7 @@ static void enkf_main_start_queue(enkf_main_type * enkf_main,
   enkf_main_submit_jobs( enkf_main , run_context, job_queue);
 
   job_queue_submit_complete( job_queue );
-  res_log_add_message( 1 , NULL , "All jobs submitted to internal queue - waiting for completion" ,  false);
+  res_log_add_message_str(LOG_INFO , "All jobs submitted to internal queue - waiting for completion");
 
   int max_runtime = analysis_config_get_max_runtime(enkf_main_get_analysis_config( enkf_main ));
   job_queue_set_max_job_duration(job_queue, max_runtime);

--- a/libenkf/src/ert_workflow_list.c
+++ b/libenkf/src/ert_workflow_list.c
@@ -257,7 +257,7 @@ void ert_workflow_list_add_jobs_in_directory( ert_workflow_list_type * workflow_
 	    if (full_path) {
 	      set_add_key( names , root_name );
 	      if (res_log_is_open())
-		res_log_add_message( 1 , NULL , util_alloc_sprintf("Adding workflow job:%s " , full_path ), true);
+            res_log_add_fmt_message(LOG_INFO , NULL , "Adding workflow job:%s " , full_path);
 
 	      ert_workflow_list_add_job( workflow_list , root_name , full_path );
 	    }

--- a/libenkf/src/time_map.c
+++ b/libenkf/src/time_map.c
@@ -206,7 +206,7 @@ static bool time_map_update__( time_map_type * map , int step , time_t update_ti
 
         if (ref_time != update_time) {
           updateOK = false;
-          res_log_add_message( 1 ,  NULL , "Tried to load data where report step/data is incompatible with refcase - ignored" , false);
+          res_log_add_message_str(LOG_ERROR , "Tried to load data where report step/data is incompatible with refcase - ignored");
         }
       }
     }
@@ -373,7 +373,7 @@ bool time_map_update( time_map_type * map , int step , time_t time) {
     if (map->strict)
       time_map_update_abort(map , step , time);
     else
-      res_log_add_message(1 , NULL , "Report step/true time inconsistency - data will be ignored" , false);
+      res_log_add_message_str(LOG_ERROR ,"Report step/true time inconsistency - data will be ignored");
   }
   return updateOK;
 }
@@ -399,7 +399,7 @@ bool time_map_summary_update( time_map_type * map , const ecl_sum_type * ecl_sum
     if (map->strict)
       time_map_summary_update_abort( map , ecl_sum );
     else
-      res_log_add_message(1 , NULL , "Report step/true time inconsistency - data will be ignored" , false);
+      res_log_add_message_str(LOG_ERROR ,"Report step/true time inconsistency - data will be ignored");
   }
 
   return updateOK;
@@ -693,7 +693,7 @@ int_vector_type * time_map_alloc_index_map( time_map_type * map , const ecl_sum_
         if (sum_time == map_time)
           int_vector_iset( index_map , time_map_index , sum_index);
         else {
-          res_log_add_message(1 , NULL , "Inconsistency in time_map - data will be ignored" , false);
+          res_log_add_message_str(LOG_ERROR , "Inconsistency in time_map - data will be ignored");
           break;
         }
 

--- a/libenkf/tests/enkf_time_map.c
+++ b/libenkf/tests/enkf_time_map.c
@@ -32,6 +32,7 @@
 
 #include <ert/enkf/time_map.h>
 #include <ert/enkf/enkf_fs.h>
+#include <ert/res_util/res_log.h>
 #include <ert/enkf/enkf_main.h>
 
 void ecl_test( const char * ecl_case ) {

--- a/libjob_queue/CMakeLists.txt
+++ b/libjob_queue/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(job_queue src/ext_job.c
                       ${lsb}
 )
 
-target_link_libraries(job_queue PUBLIC config ecl ${lsf})
+target_link_libraries(job_queue PUBLIC res_util config ecl ${lsf})
 target_include_directories(job_queue
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include>

--- a/libres_util/include/ert/res_util/res_log.h
+++ b/libres_util/include/ert/res_util/res_log.h
@@ -28,6 +28,7 @@ extern "C" {
 
 #include <ert/util/log.h>
 
+void res_log_add_message_str(message_level_type message_level, const char* message);
 void res_log_init_log(int log_level,const char * log_file_name, bool verbose);
 void res_log_init_log_default_log_level(const char * log_file_name, bool verbose);
 void res_log_init_log_default( bool verbose);


### PR DESCRIPTION
**Task**
Improve (or add) logging to `job_queue`


**Approach**
- Adding a simpler log-method ```  res_log_add_message_str``` which only takes log-level and a string. 
- Replaced several uses of ``` res_log_add_message``` with the simpler ```  res_log_add_message_str```
- Added some log-lines to job_queue.c
- Added some log-lines to lsf_driver.c
- Replaced use of ```res_log_add_message``` with string-formating and free=true with ```res_log_add_fmt_message.``` which does the formating, allocation and freeing itself. 
- Replacing some fprints to sterr with logcalls in lsf_driver



**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps
