### PR TITLE
Extract substitution list and their dependencies

### DIFF
--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(enkf src/active_list.c
                  src/surface.c
                  src/surface_config.c
                  src/trans_func.c
+                 src/subst_config.c
 )
 
 target_include_directories(enkf

--- a/libenkf/include/ert/enkf/analysis_config.h
+++ b/libenkf/include/ert/enkf/analysis_config.h
@@ -42,8 +42,8 @@ extern "C" {
 typedef struct analysis_config_struct analysis_config_type;
 
 analysis_iter_config_type * analysis_config_get_iter_config( const analysis_config_type * config );
-analysis_module_type * analysis_config_get_module( analysis_config_type * config , const char * module_name );
-bool                   analysis_config_has_module( analysis_config_type * config , const char * module_name );
+analysis_module_type * analysis_config_get_module(const analysis_config_type * config , const char * module_name );
+bool                   analysis_config_has_module(const analysis_config_type * config , const char * module_name );
 void                   analysis_config_load_internal_module( analysis_config_type * config , const char * symbol_table );
 void                   analysis_config_load_internal_modules( analysis_config_type * analysis );
 void                   analysis_config_reload_module( analysis_config_type * config , const char * module_name);
@@ -90,7 +90,7 @@ void                   analysis_config_add_config_items( config_parser_type * co
 void                   analysis_config_fprintf_config( analysis_config_type * config , FILE * stream);
 
 bool                   analysis_config_select_module( analysis_config_type * config , const char * module_name );
-analysis_module_type * analysis_config_get_active_module( analysis_config_type * config );
+analysis_module_type * analysis_config_get_active_module(const analysis_config_type * config );
 void                   analysis_config_set_single_node_update(analysis_config_type * config , bool single_node_update);
 bool                   analysis_config_get_single_node_update(const analysis_config_type * config);
 

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -120,7 +120,7 @@ extern "C" {
   void                          enkf_main_set_state_run_path(const enkf_main_type * , int );
   void                          enkf_main_set_state_eclbase(const enkf_main_type * , int );
   void                          enkf_main_interactive_set_runpath__(void * );
-  enkf_main_type              * enkf_main_alloc(const char *, res_config_type *, bool, bool);
+  enkf_main_type              * enkf_main_alloc(const char *, const res_config_type *, bool, bool);
   void                          enkf_main_create_new_config( const char * config_file , const char * storage_path , const char * dbase_type , int num_realizations);
 
 

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -120,7 +120,7 @@ extern "C" {
   void                          enkf_main_set_state_run_path(const enkf_main_type * , int );
   void                          enkf_main_set_state_eclbase(const enkf_main_type * , int );
   void                          enkf_main_interactive_set_runpath__(void * );
-  enkf_main_type              * enkf_main_alloc(const char *, const res_config_type *, bool, bool);
+  enkf_main_type              * enkf_main_alloc(const char *, res_config_type *, bool, bool);
   void                          enkf_main_create_new_config( const char * config_file , const char * storage_path , const char * dbase_type , int num_realizations);
 
 

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -156,6 +156,7 @@ extern "C" {
   void                     enkf_main_list_users(  set_type * users , const char * executable );
   const ext_joblist_type * enkf_main_get_installed_jobs( const enkf_main_type * enkf_main );
 
+  subst_config_type      * enkf_main_get_subst_config(const enkf_main_type * enkf_main);
   subst_list_type        * enkf_main_get_data_kw( const enkf_main_type * enkf_main );
   void                     enkf_main_clear_data_kw( enkf_main_type * enkf_main );
   const site_config_type * enkf_main_get_site_config( const enkf_main_type * enkf_main );

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -142,7 +142,7 @@ extern "C" {
   void                          enkf_main_load_obs( enkf_main_type * enkf_main , const char * obs_config_file , bool clear_existing);
   enkf_obs_type               * enkf_main_get_obs(const enkf_main_type * );
   bool                          enkf_main_have_obs( const enkf_main_type * enkf_main );
-  analysis_config_type        * enkf_main_get_analysis_config(const enkf_main_type * );
+  const analysis_config_type  * enkf_main_get_analysis_config(const enkf_main_type * );
 
   void       * enkf_main_get_enkf_config_node_type(const ensemble_config_type *, const char *);
   void         enkf_main_set_field_config_iactive(const ensemble_config_type *, int);

--- a/libenkf/include/ert/enkf/ert_workflow_list.h
+++ b/libenkf/include/ert/enkf/ert_workflow_list.h
@@ -41,6 +41,8 @@ extern "C" {
   workflow_type           *  ert_workflow_list_add_workflow( ert_workflow_list_type * workflow_list , const char * workflow_file , const char * workflow_name);
   void                       ert_workflow_list_free( ert_workflow_list_type * workflow_list );
   ert_workflow_list_type  *  ert_workflow_list_alloc( const subst_list_type * subst_list );
+  ert_workflow_list_type  *  ert_workflow_list_alloc_load_site_config(const subst_list_type *);
+  ert_workflow_list_type  *  ert_workflow_list_alloc_load(const subst_list_type * context, const char * user_config_file);
   void                       ert_workflow_list_add_jobs_in_directory( ert_workflow_list_type * workflow_list , const char * path );
   void                       ert_workflow_list_add_job( ert_workflow_list_type * workflow_list , const char * job_name , const char * config_file );
   bool                       ert_workflow_list_has_job( const ert_workflow_list_type * workflow_list , const char * job_name);

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -26,6 +26,7 @@
 #include <ert/enkf/rng_config.h>
 #include <ert/enkf/analysis_config.h>
 #include <ert/enkf/ert_workflow_list.h>
+#include <ert/enkf/subst_config.h>
 
 typedef struct res_config_struct res_config_type;
 
@@ -36,9 +37,12 @@ site_config_type       * res_config_get_site_config(const res_config_type *);
 rng_config_type        * res_config_get_rng_config(const res_config_type *);
 analysis_config_type   * res_config_get_analysis_config(const res_config_type *);
 ert_workflow_list_type * res_config_get_workflow_list(const res_config_type *);
+subst_config_type      * res_config_get_subst_config(const res_config_type * res_config);
 
 subst_list_type      * res_config_get_subst_list(const res_config_type *);
 subst_func_pool_type * res_config_get_subst_func_pool(const res_config_type *);
+
+char * res_config_alloc_working_directory(const char * user_config_file);
 
 const char * res_config_get_user_config_file(const res_config_type *);
 const char * res_config_get_site_config_file(const res_config_type *);

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -19,6 +19,9 @@
 #ifndef ERT_RES_CONFIG_H
 #define ERT_RES_CONFIG_H
 
+#include <ert/util/subst_list.h>
+#include <ert/util/subst_func.h>
+
 #include <ert/enkf/site_config.h>
 #include <ert/enkf/rng_config.h>
 #include <ert/enkf/analysis_config.h>
@@ -31,6 +34,9 @@ void              res_config_free(res_config_type *);
 site_config_type     * res_config_get_site_config(const res_config_type *);
 rng_config_type      * res_config_get_rng_config(const res_config_type *);
 analysis_config_type * res_config_get_analysis_config(const res_config_type *);
+
+subst_list_type      * res_config_get_subst_list(const res_config_type *);
+subst_func_pool_type * res_config_get_subst_func_pool(const res_config_type *);
 
 const char * res_config_get_user_config_file(const res_config_type *);
 const char * res_config_get_site_config_file(const res_config_type *);

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -25,15 +25,17 @@
 #include <ert/enkf/site_config.h>
 #include <ert/enkf/rng_config.h>
 #include <ert/enkf/analysis_config.h>
+#include <ert/enkf/ert_workflow_list.h>
 
 typedef struct res_config_struct res_config_type;
 
 res_config_type * res_config_alloc_load(const char *);
 void              res_config_free(res_config_type *);
 
-site_config_type     * res_config_get_site_config(const res_config_type *);
-rng_config_type      * res_config_get_rng_config(const res_config_type *);
-analysis_config_type * res_config_get_analysis_config(const res_config_type *);
+site_config_type       * res_config_get_site_config(const res_config_type *);
+rng_config_type        * res_config_get_rng_config(const res_config_type *);
+analysis_config_type   * res_config_get_analysis_config(const res_config_type *);
+ert_workflow_list_type * res_config_get_workflow_list(const res_config_type *);
 
 subst_list_type      * res_config_get_subst_list(const res_config_type *);
 subst_func_pool_type * res_config_get_subst_func_pool(const res_config_type *);

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -39,11 +39,7 @@ analysis_config_type   * res_config_get_analysis_config(const res_config_type *)
 ert_workflow_list_type * res_config_get_workflow_list(const res_config_type *);
 subst_config_type      * res_config_get_subst_config(const res_config_type * res_config);
 
-subst_list_type      * res_config_get_subst_list(const res_config_type *);
-subst_func_pool_type * res_config_get_subst_func_pool(const res_config_type *);
-
-char * res_config_alloc_working_directory(const char * user_config_file);
-
+const char * res_config_get_working_directory(const res_config_type *);
 const char * res_config_get_user_config_file(const res_config_type *);
 const char * res_config_get_site_config_file(const res_config_type *);
 

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -33,11 +33,11 @@ typedef struct res_config_struct res_config_type;
 res_config_type * res_config_alloc_load(const char *);
 void              res_config_free(res_config_type *);
 
-site_config_type       * res_config_get_site_config(const res_config_type *);
-rng_config_type        * res_config_get_rng_config(const res_config_type *);
-analysis_config_type   * res_config_get_analysis_config(const res_config_type *);
-ert_workflow_list_type * res_config_get_workflow_list(const res_config_type *);
-subst_config_type      * res_config_get_subst_config(const res_config_type * res_config);
+const site_config_type       * res_config_get_site_config(const res_config_type *);
+rng_config_type              * res_config_get_rng_config(const res_config_type *);
+const analysis_config_type   * res_config_get_analysis_config(const res_config_type *);
+ert_workflow_list_type       * res_config_get_workflow_list(const res_config_type *);
+subst_config_type            * res_config_get_subst_config(const res_config_type * res_config);
 
 const char * res_config_get_working_directory(const res_config_type *);
 const char * res_config_get_user_config_file(const res_config_type *);

--- a/libenkf/include/ert/enkf/runpath_list.h
+++ b/libenkf/include/ert/enkf/runpath_list.h
@@ -41,6 +41,7 @@ extern "C" {
   void                runpath_list_fprintf( runpath_list_type * list);
   const char *        runpath_list_get_export_file( const runpath_list_type * list );
   void                runpath_list_set_export_file( runpath_list_type * list , const char * export_file );
+  char              * runpath_list_alloc_filename(const char * basepath, const char * filename);
 
   
 

--- a/libenkf/include/ert/enkf/subst_config.h
+++ b/libenkf/include/ert/enkf/subst_config.h
@@ -1,0 +1,37 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   The file 'subst_config.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#ifndef ERT_SUBST_CONFIG_H
+#define ERT_SUBST_CONFIG_H
+
+typedef struct subst_config_struct subst_config_type;
+
+subst_config_type * subst_config_alloc_load(const char * user_config_file);
+void                subst_config_free(subst_config_type * subst_config);
+
+subst_func_pool_type * subst_config_get_subst_func_pool(subst_config_type * subst_type);
+subst_list_type      * subst_config_get_subst_list(subst_config_type * subst_type);
+
+void subst_config_install_rng(subst_config_type * subst_config, rng_type * rng);
+void subst_config_add_internal_subst_kw(subst_config_type *, const char *, const char *, const char *);
+void subst_config_add_subst_kw(subst_config_type * subst_config , const char * key , const char * value);
+void subst_config_clear(subst_config_type * subst_config);
+
+void subst_config_fprintf(const subst_config_type * subst_config, FILE * stream);
+
+#endif

--- a/libenkf/include/ert/enkf/subst_config.h
+++ b/libenkf/include/ert/enkf/subst_config.h
@@ -21,7 +21,7 @@
 
 typedef struct subst_config_struct subst_config_type;
 
-subst_config_type * subst_config_alloc_load(const char * user_config_file);
+subst_config_type * subst_config_alloc_load(const char * user_config_file, const char * working_dir);
 void                subst_config_free(subst_config_type * subst_config);
 
 subst_func_pool_type * subst_config_get_subst_func_pool(subst_config_type * subst_type);

--- a/libenkf/src/analysis_config.c
+++ b/libenkf/src/analysis_config.c
@@ -377,11 +377,11 @@ void analysis_config_reload_module( analysis_config_type * config , const char *
 }
 
 
-analysis_module_type * analysis_config_get_module( analysis_config_type * config , const char * module_name ) {
+analysis_module_type * analysis_config_get_module(const analysis_config_type * config , const char * module_name ) {
   return hash_get( config->analysis_modules , module_name );
 }
 
-bool analysis_config_has_module(analysis_config_type * config , const char * module_name) {
+bool analysis_config_has_module(const analysis_config_type * config , const char * module_name) {
   return hash_has_key( config->analysis_modules , module_name );
 }
 
@@ -419,7 +419,7 @@ bool analysis_config_select_module( analysis_config_type * config , const char *
 }
 
 
-analysis_module_type * analysis_config_get_active_module( analysis_config_type * config ) {
+analysis_module_type * analysis_config_get_active_module(const analysis_config_type * config ) {
   return config->analysis_module;
 }
 

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -199,7 +199,7 @@ static void enkf_main_analysis_update( enkf_main_type * enkf_main ,
 UTIL_SAFE_CAST_FUNCTION(enkf_main , ENKF_MAIN_ID)
 UTIL_IS_INSTANCE_FUNCTION(enkf_main , ENKF_MAIN_ID)
 
-analysis_config_type * enkf_main_get_analysis_config(const enkf_main_type * enkf_main) {
+const analysis_config_type * enkf_main_get_analysis_config(const enkf_main_type * enkf_main) {
   return res_config_get_analysis_config(enkf_main->res_config);
 }
 
@@ -1120,7 +1120,7 @@ static void enkf_main_analysis_update( enkf_main_type * enkf_main ,
   matrix_type * localA  = NULL;
   int_vector_type * iens_active_index = bool_vector_alloc_active_index_list(ens_mask , -1);
 
-  analysis_config_type * analysis_config = enkf_main_get_analysis_config(enkf_main);
+  const analysis_config_type * analysis_config = enkf_main_get_analysis_config(enkf_main);
   analysis_module_type * module = analysis_config_get_active_module(analysis_config);
   if ( local_ministep_has_analysis_module (ministep))
     module = local_ministep_get_analysis_module (ministep);
@@ -1317,7 +1317,7 @@ bool enkf_main_smoother_update(enkf_main_type * enkf_main , enkf_fs_type * sourc
 
 
 static void enkf_main_monitor_job_queue ( const enkf_main_type * enkf_main, job_queue_type * job_queue) {
-  analysis_config_type * analysis_config = enkf_main_get_analysis_config( enkf_main );
+  const analysis_config_type * analysis_config = enkf_main_get_analysis_config( enkf_main );
   if (analysis_config_get_stop_long_running(analysis_config)) {
     bool cont = true;
     while (cont) {
@@ -1722,7 +1722,7 @@ int enkf_main_run_simple_step(enkf_main_type * enkf_main,
 
 
 void enkf_main_run_smoother(enkf_main_type * enkf_main , job_queue_type * job_queue, enkf_fs_type * source_fs, const char * target_fs_name , bool_vector_type * iactive , int iter , bool rerun) {
-  analysis_config_type * analysis_config = enkf_main_get_analysis_config( enkf_main );
+  const analysis_config_type * analysis_config = enkf_main_get_analysis_config( enkf_main );
   if (!analysis_config_get_module_option( analysis_config , ANALYSIS_ITERABLE)) {
     if (enkf_main_run_simple_step( enkf_main , job_queue, iactive , INIT_CONDITIONAL, iter)) {
       hook_manager_type * hook_manager = enkf_main_get_hook_manager(enkf_main);
@@ -1755,7 +1755,7 @@ static bool enkf_main_run_simulation_and_postworkflow(enkf_main_type * enkf_main
                                                       ert_run_context_type * run_context,
                                                       job_queue_type * job_queue) {
   bool ret = true;
-  analysis_config_type * analysis_config = enkf_main_get_analysis_config(enkf_main);
+  const analysis_config_type * analysis_config = enkf_main_get_analysis_config(enkf_main);
 
   int active_after_step = enkf_main_run_step(enkf_main , run_context, job_queue);
   if (analysis_config_have_enough_realisations(analysis_config, active_after_step, enkf_main_get_ensemble_size(enkf_main))) {
@@ -1772,7 +1772,7 @@ static bool enkf_main_run_simulation_and_postworkflow(enkf_main_type * enkf_main
 
 static bool enkf_main_run_analysis(enkf_main_type * enkf_main, enkf_fs_type * source_fs ,const char * target_fs_name, int iteration_number) {
   bool updateOK                          = false;
-  analysis_config_type * analysis_config = enkf_main_get_analysis_config(enkf_main);
+  const analysis_config_type * analysis_config = enkf_main_get_analysis_config(enkf_main);
   analysis_module_type * analysis_module = analysis_config_get_active_module(analysis_config);
   int pre_iteration_number               = analysis_module_get_int(analysis_module, "ITER");
 

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -151,7 +151,7 @@ struct enkf_main_struct {
   hook_manager_type      * hook_manager;
   model_config_type      * model_config;
   ecl_config_type        * ecl_config;
-  res_config_type        * res_config;
+  const res_config_type  * res_config;
   local_config_type      * local_config;       /* Holding all the information about local analysis. */
   ert_templates_type     * templates;          /* Run time templates */
   config_settings_type   * plot_config;        /* Information about plotting. */
@@ -257,7 +257,7 @@ subst_config_type * enkf_main_get_subst_config(const enkf_main_type * enkf_main)
 }
 
 subst_list_type * enkf_main_get_data_kw( const enkf_main_type * enkf_main ) {
-  return res_config_get_subst_list(enkf_main_get_res_config(enkf_main));
+  return subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
 }
 
 
@@ -2411,7 +2411,7 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
 */
 
 
-enkf_main_type * enkf_main_alloc(const char * model_config, res_config_type * res_config, bool strict , bool verbose) {
+enkf_main_type * enkf_main_alloc(const char * model_config, const res_config_type * res_config, bool strict , bool verbose) {
   enkf_main_type * enkf_main = enkf_main_alloc_empty();
   enkf_main->res_config = res_config;
 

--- a/libenkf/src/enkf_main_ensemble.c
+++ b/libenkf/src/enkf_main_ensemble.c
@@ -71,7 +71,7 @@ void enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size ) 
                                                    enkf_main_get_site_config(enkf_main)                         ,
                                                    enkf_main->ecl_config                                        ,
                                                    enkf_main->templates                                         ,
-                                                   enkf_main->subst_list);
+                                                   enkf_main_get_data_kw(enkf_main));
     enkf_main->ens_size = new_ens_size;
     return;
   }

--- a/libenkf/src/enkf_main_jobs.c
+++ b/libenkf/src/enkf_main_jobs.c
@@ -140,27 +140,6 @@ void * enkf_main_iterated_smoother_JOB( void * self , const stringlist_type * ar
 }
 
 
-void * enkf_main_select_module_JOB( void * self , const stringlist_type * args ) {
-  enkf_main_type   * enkf_main = enkf_main_safe_cast( self );
-  analysis_config_type * analysis_config = enkf_main_get_analysis_config( enkf_main );
-
-  analysis_config_select_module( analysis_config , stringlist_iget( args , 0 ));
-
-  return NULL;
-}
-
-
-void * enkf_main_scale_obs_std_JOB(void * self, const stringlist_type * args ) {
-  enkf_main_type   * enkf_main = enkf_main_safe_cast( self );
-
-  double scale_factor;
-  if (util_sscanf_double(stringlist_iget(args, 0), &scale_factor)) {
-    analysis_config_type * analysis_config = enkf_main_get_analysis_config( enkf_main );
-    analysis_config_set_global_std_scaling( analysis_config , scale_factor );
-  }
-  return NULL;
-}
-
 /*****************************************************************/
 
 /*
@@ -467,7 +446,7 @@ static void enkf_main_export_runpath_file(enkf_main_type * enkf_main,
 void * enkf_main_export_runpath_file_JOB(void * self, const stringlist_type * args)  {
   enkf_main_type * enkf_main              = enkf_main_safe_cast( self );
   int ensemble_size                       = enkf_main_get_ensemble_size(enkf_main);
-  analysis_config_type * analysis_config  = enkf_main_get_analysis_config(enkf_main);
+  const analysis_config_type * analysis_config = enkf_main_get_analysis_config(enkf_main);
   analysis_iter_config_type * iter_config = analysis_config_get_iter_config(analysis_config);
   int num_iterations                      = analysis_iter_config_get_num_iterations(iter_config);
   const model_config_type * model_config  = enkf_main_get_model_config(enkf_main);

--- a/libenkf/src/enkf_main_manage_fs.c
+++ b/libenkf/src/enkf_main_manage_fs.c
@@ -416,8 +416,8 @@ static void enkf_main_update_current_case( enkf_main_type * enkf_main , const ch
   update_case_log(enkf_main , case_path);
 
   enkf_main_gen_data_special( enkf_main , enkf_main_get_fs( enkf_main ));
-  enkf_main_add_subst_kw( enkf_main , "ERT-CASE" , enkf_main_get_current_fs( enkf_main ) , "Current case" , true );
-  enkf_main_add_subst_kw( enkf_main , "ERTCASE"  , enkf_main_get_current_fs( enkf_main ) , "Current case" , true );
+  enkf_main_add_internal_subst_kw( enkf_main , "ERT-CASE" , enkf_main_get_current_fs( enkf_main ) , "Current case");
+  enkf_main_add_internal_subst_kw( enkf_main , "ERTCASE"  , enkf_main_get_current_fs( enkf_main ) , "Current case");
 }
 
 

--- a/libenkf/src/ert_workflow_list.c
+++ b/libenkf/src/ert_workflow_list.c
@@ -92,6 +92,7 @@ ert_workflow_list_type * ert_workflow_list_alloc_load_site_config(const subst_li
 ert_workflow_list_type * ert_workflow_list_alloc_load(
         const subst_list_type * context,
         const char * user_config_file) {
+
   ert_workflow_list_type * workflow_list = ert_workflow_list_alloc_load_site_config(context);
 
   if(user_config_file) {

--- a/libenkf/src/ert_workflow_list.c
+++ b/libenkf/src/ert_workflow_list.c
@@ -39,11 +39,13 @@
 #include <ert/job_queue/workflow_job.h>
 #include <ert/job_queue/workflow_joblist.h>
 
+#include <ert/res_util/res_log.h>
+
 #include <ert/enkf/ert_workflow_list.h>
 #include <ert/enkf/config_keys.h>
 #include <ert/enkf/enkf_defaults.h>
-#include <ert/res_util/res_log.h>
-
+#include <ert/enkf/site_config.h>
+#include <ert/enkf/model_config.h>
 
 #define ERT_WORKFLOW_LIST_TYPE_ID 8856275
 
@@ -73,6 +75,37 @@ ert_workflow_list_type * ert_workflow_list_alloc(const subst_list_type * context
   return workflow_list;
 }
 
+ert_workflow_list_type * ert_workflow_list_alloc_load_site_config(const subst_list_type * context) {
+  ert_workflow_list_type * workflow_list = ert_workflow_list_alloc(context);
+
+  config_parser_type * config = config_alloc();
+  config_content_type * content = site_config_alloc_content(config);
+
+  ert_workflow_list_init(workflow_list, content);
+
+  config_free(config);
+  config_content_free(content);
+
+  return workflow_list;
+}
+
+ert_workflow_list_type * ert_workflow_list_alloc_load(
+        const subst_list_type * context,
+        const char * user_config_file) {
+  ert_workflow_list_type * workflow_list = ert_workflow_list_alloc_load_site_config(context);
+
+  if(user_config_file) {
+    config_parser_type * config = config_alloc();
+    config_content_type * content = model_config_alloc_content(user_config_file, config);
+
+    ert_workflow_list_init(workflow_list, content);
+
+    config_free(config);
+    config_content_free(content);
+  }
+
+  return workflow_list;
+}
 
 
 UTIL_IS_INSTANCE_FUNCTION( ert_workflow_list , ERT_WORKFLOW_LIST_TYPE_ID )

--- a/libenkf/src/hook_manager.c
+++ b/libenkf/src/hook_manager.c
@@ -33,7 +33,6 @@
 #include <ert/enkf/runpath_list.h>
 
 #define HOOK_MANAGER_NAME             "HOOK MANAGER"
-#define RUNPATH_LIST_FILE             ".ert_runpath_list"
 #define QC_WORKFLOW_NAME              "QC WORKFLOW"
 #define RUN_MODE_PRE_SIMULATION_NAME  "PRE_SIMULATION"
 #define RUN_MODE_POST_SIMULATION_NAME "POST_SIMULATION"
@@ -58,7 +57,7 @@ hook_manager_type * hook_manager_alloc( ert_workflow_list_type * workflow_list )
   hook_manager->workflow_list = workflow_list;
 
   hook_manager->runpath_list = runpath_list_alloc( NULL );
-  hook_manager_set_runpath_list_file( hook_manager, NULL, RUNPATH_LIST_FILE );
+  hook_manager_set_runpath_list_file(hook_manager, NULL, NULL);
 
   hook_manager->input_context = hash_alloc();
 
@@ -183,29 +182,9 @@ static void hook_manager_set_runpath_list_file__( hook_manager_type * hook_manag
 }
 
 void hook_manager_set_runpath_list_file( hook_manager_type * hook_manager , const char * basepath, const char * filename) {
-  if (filename && util_is_abs_path( filename ))
-    hook_manager_set_runpath_list_file__( hook_manager , filename );
-  else {
-    const char * file = RUNPATH_LIST_FILE;
-
-    if (filename != NULL)
-      file = filename;
-
-    char * file_with_path_prefix = NULL;
-    if (basepath != NULL) {
-      file_with_path_prefix = util_alloc_filename(basepath, file, NULL);
-    }
-    else
-      file_with_path_prefix = util_alloc_string_copy(file);
-
-    {
-      char * absolute_path = util_alloc_abs_path(file_with_path_prefix);
-      hook_manager_set_runpath_list_file__( hook_manager , absolute_path );
-      free( absolute_path );
-    }
-
-    free(file_with_path_prefix);
-  }
+  char * runpath_list_file = runpath_list_alloc_filename(basepath, filename);
+  hook_manager_set_runpath_list_file__(hook_manager, runpath_list_file);
+  free(runpath_list_file);
 }
 
 
@@ -249,6 +228,3 @@ bool hook_manager_run_post_hook_workflow( const hook_manager_type * hook_manager
 
   return hook_workflow_run_workflow(hook_manager->post_hook_workflow, hook_manager->workflow_list, self);
 }
-
-
-

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -23,6 +23,7 @@
 #include <ert/enkf/site_config.h>
 #include <ert/enkf/rng_config.h>
 #include <ert/enkf/analysis_config.h>
+#include <ert/enkf/ert_workflow_list.h>
 
 struct res_config_struct {
 
@@ -31,9 +32,10 @@ struct res_config_struct {
   subst_func_pool_type * subst_func_pool;
   subst_list_type      * subst_list;
 
-  site_config_type     * site_config;
-  rng_config_type      * rng_config;
-  analysis_config_type * analysis_config;
+  site_config_type       * site_config;
+  rng_config_type        * rng_config;
+  analysis_config_type   * analysis_config;
+  ert_workflow_list_type * workflow_list;
 
 };
 
@@ -44,9 +46,10 @@ static res_config_type * res_config_alloc_empty() {
   res_config->subst_func_pool = NULL;
   res_config->subst_list      = NULL;
 
-  res_config->site_config     = NULL;
-  res_config->rng_config      = NULL;
-  res_config->analysis_config = NULL;
+  res_config->site_config       = NULL;
+  res_config->rng_config        = NULL;
+  res_config->analysis_config   = NULL;
+  res_config->workflow_list     = NULL;
 
   return res_config;
 }
@@ -55,12 +58,14 @@ res_config_type * res_config_alloc_load(const char * config_file) {
   res_config_type * res_config = res_config_alloc_empty(); 
 
   res_config->user_config_file = util_alloc_string_copy(config_file);
+
   res_config->subst_func_pool = subst_func_pool_alloc();
   res_config->subst_list      = subst_list_alloc(res_config->subst_func_pool);
 
   res_config->site_config     = site_config_alloc_load_user_config(config_file);
   res_config->rng_config      = rng_config_alloc_load_user_config(config_file);
   res_config->analysis_config = analysis_config_alloc_load(config_file);
+  res_config->workflow_list   = ert_workflow_list_alloc_load(res_config->subst_list, config_file);
 
   return res_config;
 }
@@ -72,6 +77,7 @@ void res_config_free(res_config_type * res_config) {
   site_config_free(res_config->site_config);
   rng_config_free(res_config->rng_config);
   analysis_config_free(res_config->analysis_config);
+  ert_workflow_list_free(res_config->workflow_list);
 
   free(res_config->subst_list);
   free(res_config->subst_func_pool);
@@ -96,6 +102,12 @@ analysis_config_type * res_config_get_analysis_config(
                     const res_config_type * res_config
                     ) {
   return res_config->analysis_config;
+}
+
+ert_workflow_list_type * res_config_get_workflow_list(
+                    const res_config_type * res_config
+        ) {
+  return res_config->workflow_list;
 }
 
 subst_list_type * res_config_get_subst_list(

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -16,21 +16,33 @@
    for more details.
 */
 
+#include <ert/util/subst_list.h>
+#include <ert/util/subst_func.h>
+
 #include <ert/enkf/res_config.h>
 #include <ert/enkf/site_config.h>
 #include <ert/enkf/rng_config.h>
 #include <ert/enkf/analysis_config.h>
 
 struct res_config_struct {
+
   char * user_config_file;
+
+  subst_func_pool_type * subst_func_pool;
+  subst_list_type      * subst_list;
+
   site_config_type     * site_config;
   rng_config_type      * rng_config;
   analysis_config_type * analysis_config;
+
 };
 
 static res_config_type * res_config_alloc_empty() {
   res_config_type * res_config = util_malloc(sizeof * res_config);
   res_config->user_config_file = NULL;
+
+  res_config->subst_func_pool = NULL;
+  res_config->subst_list      = NULL;
 
   res_config->site_config     = NULL;
   res_config->rng_config      = NULL;
@@ -43,9 +55,11 @@ res_config_type * res_config_alloc_load(const char * config_file) {
   res_config_type * res_config = res_config_alloc_empty(); 
 
   res_config->user_config_file = util_alloc_string_copy(config_file);
+  res_config->subst_func_pool = subst_func_pool_alloc();
+  res_config->subst_list      = subst_list_alloc(res_config->subst_func_pool);
 
-  res_config->site_config = site_config_alloc_load_user_config(config_file);
-  res_config->rng_config  = rng_config_alloc_load_user_config(config_file);
+  res_config->site_config     = site_config_alloc_load_user_config(config_file);
+  res_config->rng_config      = rng_config_alloc_load_user_config(config_file);
   res_config->analysis_config = analysis_config_alloc_load(config_file);
 
   return res_config;
@@ -58,6 +72,9 @@ void res_config_free(res_config_type * res_config) {
   site_config_free(res_config->site_config);
   rng_config_free(res_config->rng_config);
   analysis_config_free(res_config->analysis_config);
+
+  free(res_config->subst_list);
+  free(res_config->subst_func_pool);
 
   free(res_config->user_config_file);
   free(res_config);
@@ -79,6 +96,18 @@ analysis_config_type * res_config_get_analysis_config(
                     const res_config_type * res_config
                     ) {
   return res_config->analysis_config;
+}
+
+subst_list_type * res_config_get_subst_list(
+                    const res_config_type * res_config
+                    ) {
+  return res_config->subst_list;
+}
+
+subst_func_pool_type * res_config_get_subst_func_pool(
+                    const res_config_type * res_config
+                    ) {
+  return res_config->subst_func_pool;
 }
 
 const char * res_config_get_user_config_file(const res_config_type * res_config) {

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -88,7 +88,7 @@ void res_config_free(res_config_type * res_config) {
   free(res_config);
 }
 
-site_config_type * res_config_get_site_config(
+const site_config_type * res_config_get_site_config(
                     const res_config_type * res_config
                     ) {
   return res_config->site_config;
@@ -100,7 +100,7 @@ rng_config_type * res_config_get_rng_config(
   return res_config->rng_config;
 }
 
-analysis_config_type * res_config_get_analysis_config(
+const analysis_config_type * res_config_get_analysis_config(
                     const res_config_type * res_config
                     ) {
   return res_config->analysis_config;

--- a/libenkf/src/runpath_list.c
+++ b/libenkf/src/runpath_list.c
@@ -27,6 +27,8 @@
 
 #include <ert/enkf/runpath_list.h>
 
+#define RUNPATH_LIST_FILE ".ert_runpath_list"
+
 typedef struct runpath_node_struct runpath_node_type;
 
 
@@ -233,4 +235,18 @@ const char * runpath_list_get_export_file( const runpath_list_type * list ) {
 
 void runpath_list_set_export_file( runpath_list_type * list , const char * export_file ) {
   list->export_file = util_realloc_string_copy( list->export_file , export_file );
+}
+
+char * runpath_list_alloc_filename(const char * basepath, const char * filename) {
+  if (filename && util_is_abs_path(filename))
+    return util_alloc_string_copy(filename);
+
+  if(!filename)
+    filename = RUNPATH_LIST_FILE;
+
+  char * file_with_prefix = util_alloc_filename(basepath, filename, NULL);
+  char * absolute_path    = util_alloc_abs_path(file_with_prefix);
+  free(file_with_prefix);
+
+  return absolute_path;
 }


### PR DESCRIPTION
**Task**
_Continuing the work of https://github.com/Statoil/libres/pull/14 by extracting more of the configurations. In particular the substitution list and function, together with the ert workflow list is moved into res_config._

**Approach**
- A new configuration struct named subst_config is introduced. It encapsulates the substitution list and function and their logic respectively,
- res_config now holds the logic to extract the working directory,
- runpath_list holds the logic for identifying the path to the runpath_list_file and
- as a consequence of this work ert_workflow_list can be loaded in res_config.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps
