### PR TITLE
Move all configuration structs into res_config

### DIFF
--- a/libconfig/src/config_settings.c
+++ b/libconfig/src/config_settings.c
@@ -15,6 +15,7 @@
    See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
    for more details.
 */
+
 #include <stdlib.h>
 
 #include <ert/util/type_macros.h>

--- a/libenkf/include/ert/enkf/config_keys.h
+++ b/libenkf/include/ert/enkf/config_keys.h
@@ -46,6 +46,7 @@ extern "C" {
 #define  REPORT_STEPS_KEY                  "REPORT_STEPS"
 #define  RESULT_FILE_KEY                   "RESULT_FILE"
 #define  TEMPLATE_KEY                      "TEMPLATE"
+#define  PRED_KEY                          "PRED_KEY"
 
 
 #define  ADD_FIXED_LENGTH_SCHEDULE_KW_KEY  "ADD_FIXED_LENGTH_SCHEDULE_KW"

--- a/libenkf/include/ert/enkf/ecl_config.h
+++ b/libenkf/include/ert/enkf/ecl_config.h
@@ -104,6 +104,7 @@ extern "C" {
   stringlist_type     * ecl_config_get_static_kw_list( const ecl_config_type * ecl_config );
   void                  ecl_config_fprintf_config( const ecl_config_type * ecl_config , FILE * stream );
   ecl_config_type     * ecl_config_alloc( );
+  ecl_config_type     * ecl_config_alloc_load(const char * user_config_file);
   void                  ecl_config_add_config_items( config_parser_type * config );
   const char          * ecl_config_get_depth_unit( const ecl_config_type * ecl_config );
   const char          * ecl_config_get_pressure_unit( const ecl_config_type * ecl_config );

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -75,7 +75,6 @@ extern "C" {
   const char                  * enkf_main_get_user_config_file( const enkf_main_type * enkf_main );
   void                          enkf_main_set_rft_config_file( enkf_main_type * enkf_main , const char * rft_config_file );
   const char                  * enkf_main_get_rft_config_file( const enkf_main_type * enkf_main );
-  bool                          enkf_main_set_refcase( enkf_main_type * enkf_main , const char * refcase_path);
   ui_return_type              * enkf_main_validata_refcase( const enkf_main_type * enkf_main , const char * refcase_path);
 
   ert_templates_type          * enkf_main_get_templates( enkf_main_type * enkf_main );
@@ -130,7 +129,7 @@ extern "C" {
   const enkf_config_node_type * enkf_main_get_config_node(const enkf_main_type * , const char *);
   const sched_file_type       * enkf_main_get_sched_file(const enkf_main_type *);
   ranking_table_type          * enkf_main_get_ranking_table( const enkf_main_type * enkf_main );
-  ecl_config_type             * enkf_main_get_ecl_config(const enkf_main_type * enkf_main);
+  const ecl_config_type       * enkf_main_get_ecl_config(const enkf_main_type * enkf_main);
   ensemble_config_type        * enkf_main_get_ensemble_config(const enkf_main_type * enkf_main);
   int                           enkf_main_get_ensemble_size( const enkf_main_type * enkf_main );
   int                           enkf_main_get_history_length( const enkf_main_type * );

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -138,7 +138,7 @@ extern "C" {
   //const enkf_sched_type       * enkf_main_get_enkf_sched(const enkf_main_type *);
   model_config_type           * enkf_main_get_model_config( const enkf_main_type * );
   local_config_type           * enkf_main_get_local_config( const enkf_main_type * enkf_main );
-  config_settings_type        * enkf_main_get_plot_config( const enkf_main_type * enkf_main );
+  const config_settings_type  * enkf_main_get_plot_config( const enkf_main_type * enkf_main );
   void                          enkf_main_load_obs( enkf_main_type * enkf_main , const char * obs_config_file , bool clear_existing);
   enkf_obs_type               * enkf_main_get_obs(const enkf_main_type * );
   bool                          enkf_main_have_obs( const enkf_main_type * enkf_main );

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -174,7 +174,7 @@ extern "C" {
   void                        enkf_main_add_node(enkf_main_type * enkf_main, enkf_config_node_type * enkf_config_node);
   int_vector_type           * enkf_main_update_alloc_step_list( const enkf_main_type * enkf_main , int load_start , int step2 , int stride);
 
-  hook_manager_type         * enkf_main_get_hook_manager( const enkf_main_type * enkf_main );
+  const hook_manager_type   * enkf_main_get_hook_manager( const enkf_main_type * enkf_main );
 
   void enkf_main_get_PC( const matrix_type * S,
                          const matrix_type * dObs,

--- a/libenkf/include/ert/enkf/ensemble_config.h
+++ b/libenkf/include/ert/enkf/ensemble_config.h
@@ -82,6 +82,7 @@ typedef struct ensemble_config_struct ensemble_config_type;
   stringlist_type                * ensemble_config_alloc_keylist_from_impl_type(const ensemble_config_type *, ert_impl_type);
   bool                             ensemble_config_iget_keep_runpath(const ensemble_config_type * , int );
   ensemble_config_type           * ensemble_config_alloc( );
+  ensemble_config_type           * ensemble_config_alloc_load(const char * user_config_file, ecl_grid_type * grid, const ecl_sum_type * refcase);
   void                             ensemble_config_fprintf_config( ensemble_config_type * ensemble_config , FILE * stream );
   const summary_key_matcher_type * ensemble_config_get_summary_key_matcher(const ensemble_config_type * ensemble_config);
   int                      ensemble_config_get_size(const ensemble_config_type * ensemble_config );

--- a/libenkf/include/ert/enkf/ert_template.h
+++ b/libenkf/include/ert/enkf/ert_template.h
@@ -44,6 +44,7 @@ void                ert_templates_clear( ert_templates_type * ert_templates );
 ert_template_type * ert_templates_get_template( ert_templates_type * ert_templates , const char * key);
 
 ert_templates_type * ert_templates_alloc(subst_list_type * parent_subst);
+ert_templates_type * ert_templates_alloc_load(subst_list_type * parent_subst, const char * config_file);
 void                 ert_templates_free( ert_templates_type * ert_templates );
 ert_template_type  * ert_templates_add_template( ert_templates_type * ert_templates , const char * key , const char * template_file , const char * target_file , const char * arg_string);
 void                 ert_templates_instansiate( ert_templates_type * ert_templates , const char * path , const subst_list_type * arg_list);

--- a/libenkf/include/ert/enkf/hook_manager.h
+++ b/libenkf/include/ert/enkf/hook_manager.h
@@ -32,12 +32,16 @@ extern "C" {
   typedef struct hook_manager_struct hook_manager_type;
 
   hook_manager_type   * hook_manager_alloc(ert_workflow_list_type * workflow_list);
+  hook_manager_type * hook_manager_alloc_load(
+        ert_workflow_list_type * workflow_list,
+        const char * user_config_file, const char * working_dir);
+
   void                  hook_manager_free();
 
-  void                  hook_manager_init( hook_manager_type * hook_manager , const config_content_type * config);
+  void                  hook_manager_init( hook_manager_type * hook_manager , const config_content_type * config, const char * working_dir);
   void                  hook_manager_add_config_items( config_parser_type * config );
 
-  runpath_list_type   * hook_manager_get_runpath_list( hook_manager_type * hook_manager );
+  runpath_list_type   * hook_manager_get_runpath_list(const hook_manager_type * hook_manager);
   void                  hook_manager_export_runpath_list( const hook_manager_type * hook_manager );
   void                  hook_manager_set_runpath_list_file( hook_manager_type * hook_manager , const char * path, const char * filename);
   const char          * hook_manager_get_runpath_list_file(const hook_manager_type * hook_manager);

--- a/libenkf/include/ert/enkf/model_config.h
+++ b/libenkf/include/ert/enkf/model_config.h
@@ -85,6 +85,7 @@ extern "C" {
   void                   model_config_set_refcase( model_config_type * model_config , const ecl_sum_type * refcase );
   void                   model_config_fprintf_config( const model_config_type * model_config , int ens_size ,FILE * stream );
   model_config_type    * model_config_alloc();
+  model_config_type    * model_config_alloc_load(const char * user_config_file, const ext_joblist_type * joblist, int last_history_restart, const sched_file_type * sched_file, const ecl_sum_type * refcase);
   bool                   model_config_select_history( model_config_type * model_config , history_source_type source_type, const sched_file_type * schede_file , const ecl_sum_type * refcase);
   void                   model_config_set_runpath(model_config_type * model_config , const char * fmt);
   void                   model_config_set_gen_kw_export_file( model_config_type * model_config, const char * file_name);

--- a/libenkf/include/ert/enkf/plot_settings.h
+++ b/libenkf/include/ert/enkf/plot_settings.h
@@ -22,6 +22,8 @@
 #include <ert/config/config_parser.h>
 #include <ert/config/config_settings.h>
 
+config_settings_type * plot_settings_alloc_load(const char * config_file);
+
 void               plot_settings_init(config_settings_type * setting);
 void               plot_settings_add_config_items( config_parser_type * config );
 

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -22,6 +22,8 @@
 #include <ert/util/subst_list.h>
 #include <ert/util/subst_func.h>
 
+#include <ert/config/config_settings.h>
+
 #include <ert/enkf/site_config.h>
 #include <ert/enkf/rng_config.h>
 #include <ert/enkf/analysis_config.h>
@@ -42,6 +44,7 @@ ert_workflow_list_type       * res_config_get_workflow_list(const res_config_typ
 subst_config_type            * res_config_get_subst_config(const res_config_type * res_config);
 const hook_manager_type      * res_config_get_hook_manager(const res_config_type * res_config);
 ert_templates_type           * res_config_get_templates(const res_config_type * res_config);
+const config_settings_type   * res_config_get_plot_config(const res_config_type * res_config);
 
 const char * res_config_get_working_directory(const res_config_type *);
 const char * res_config_get_user_config_file(const res_config_type *);

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -33,6 +33,7 @@
 #include <ert/enkf/ert_template.h>
 #include <ert/enkf/ecl_config.h>
 #include <ert/enkf/ensemble_config.h>
+#include <ert/enkf/model_config.h>
 
 typedef struct res_config_struct res_config_type;
 
@@ -49,6 +50,7 @@ ert_templates_type           * res_config_get_templates(const res_config_type * 
 const config_settings_type   * res_config_get_plot_config(const res_config_type * res_config);
 const ecl_config_type        * res_config_get_ecl_config(const res_config_type * res_config);
 ensemble_config_type         * res_config_get_ensemble_config(const res_config_type * res_config);
+model_config_type            * res_config_get_model_config(const res_config_type * res_config);
 
 const char * res_config_get_working_directory(const res_config_type *);
 const char * res_config_get_user_config_file(const res_config_type *);

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -31,6 +31,7 @@
 #include <ert/enkf/subst_config.h>
 #include <ert/enkf/hook_manager.h>
 #include <ert/enkf/ert_template.h>
+#include <ert/enkf/ecl_config.h>
 
 typedef struct res_config_struct res_config_type;
 
@@ -45,6 +46,7 @@ subst_config_type            * res_config_get_subst_config(const res_config_type
 const hook_manager_type      * res_config_get_hook_manager(const res_config_type * res_config);
 ert_templates_type           * res_config_get_templates(const res_config_type * res_config);
 const config_settings_type   * res_config_get_plot_config(const res_config_type * res_config);
+const ecl_config_type        * res_config_get_ecl_config(const res_config_type * res_config);
 
 const char * res_config_get_working_directory(const res_config_type *);
 const char * res_config_get_user_config_file(const res_config_type *);

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -28,6 +28,7 @@
 #include <ert/enkf/ert_workflow_list.h>
 #include <ert/enkf/subst_config.h>
 #include <ert/enkf/hook_manager.h>
+#include <ert/enkf/ert_template.h>
 
 typedef struct res_config_struct res_config_type;
 
@@ -40,6 +41,7 @@ const analysis_config_type   * res_config_get_analysis_config(const res_config_t
 ert_workflow_list_type       * res_config_get_workflow_list(const res_config_type *);
 subst_config_type            * res_config_get_subst_config(const res_config_type * res_config);
 const hook_manager_type      * res_config_get_hook_manager(const res_config_type * res_config);
+ert_templates_type           * res_config_get_templates(const res_config_type * res_config);
 
 const char * res_config_get_working_directory(const res_config_type *);
 const char * res_config_get_user_config_file(const res_config_type *);

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -27,6 +27,7 @@
 #include <ert/enkf/analysis_config.h>
 #include <ert/enkf/ert_workflow_list.h>
 #include <ert/enkf/subst_config.h>
+#include <ert/enkf/hook_manager.h>
 
 typedef struct res_config_struct res_config_type;
 
@@ -38,6 +39,7 @@ rng_config_type              * res_config_get_rng_config(const res_config_type *
 const analysis_config_type   * res_config_get_analysis_config(const res_config_type *);
 ert_workflow_list_type       * res_config_get_workflow_list(const res_config_type *);
 subst_config_type            * res_config_get_subst_config(const res_config_type * res_config);
+const hook_manager_type      * res_config_get_hook_manager(const res_config_type * res_config);
 
 const char * res_config_get_working_directory(const res_config_type *);
 const char * res_config_get_user_config_file(const res_config_type *);

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -32,6 +32,7 @@
 #include <ert/enkf/hook_manager.h>
 #include <ert/enkf/ert_template.h>
 #include <ert/enkf/ecl_config.h>
+#include <ert/enkf/ensemble_config.h>
 
 typedef struct res_config_struct res_config_type;
 
@@ -47,6 +48,7 @@ const hook_manager_type      * res_config_get_hook_manager(const res_config_type
 ert_templates_type           * res_config_get_templates(const res_config_type * res_config);
 const config_settings_type   * res_config_get_plot_config(const res_config_type * res_config);
 const ecl_config_type        * res_config_get_ecl_config(const res_config_type * res_config);
+ensemble_config_type         * res_config_get_ensemble_config(const res_config_type * res_config);
 
 const char * res_config_get_working_directory(const res_config_type *);
 const char * res_config_get_user_config_file(const res_config_type *);

--- a/libenkf/include/ert/enkf/subst_config.h
+++ b/libenkf/include/ert/enkf/subst_config.h
@@ -27,7 +27,6 @@ void                subst_config_free(subst_config_type * subst_config);
 subst_func_pool_type * subst_config_get_subst_func_pool(subst_config_type * subst_type);
 subst_list_type      * subst_config_get_subst_list(subst_config_type * subst_type);
 
-void subst_config_install_rng(subst_config_type * subst_config, rng_type * rng);
 void subst_config_add_internal_subst_kw(subst_config_type *, const char *, const char *, const char *);
 void subst_config_add_subst_kw(subst_config_type * subst_config , const char * key , const char * value);
 void subst_config_clear(subst_config_type * subst_config);

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -152,7 +152,6 @@ struct enkf_main_struct {
   ecl_config_type        * ecl_config;
   const res_config_type  * res_config;
   local_config_type      * local_config;       /* Holding all the information about local analysis. */
-  ert_templates_type     * templates;          /* Run time templates */
   config_settings_type   * plot_config;        /* Information about plotting. */
   rng_type               * rng;
   ranking_table_type     * ranking_table;
@@ -376,7 +375,6 @@ void enkf_main_free(enkf_main_type * enkf_main){
 
   int_vector_free( enkf_main->keep_runpath );
   config_settings_free( enkf_main->plot_config );
-  ert_templates_free( enkf_main->templates );
 
   util_safe_free( enkf_main->user_config_file );
   util_safe_free( enkf_main->rft_config_file );
@@ -2023,8 +2021,6 @@ static enkf_main_type * enkf_main_alloc_empty( ) {
   enkf_main->plot_config        = config_settings_alloc( PLOT_SETTING_KEY );
   plot_settings_init( enkf_main->plot_config );
 
-  enkf_main->templates          = NULL;
-
   enkf_main_set_verbose( enkf_main , true );
   enkf_main_init_fs( enkf_main );
 
@@ -2336,9 +2332,6 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
 
   ecl_config_static_kw_init(enkf_main->ecl_config, content);
 
-  /* Installing templates */
-  ert_templates_init(enkf_main->templates, content);
-
   enkf_main_init_rft_config(enkf_main, content);
 
   enkf_main_user_select_initial_fs( enkf_main );
@@ -2401,10 +2394,6 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
 enkf_main_type * enkf_main_alloc(const char * model_config, const res_config_type * res_config, bool strict , bool verbose) {
   enkf_main_type * enkf_main = enkf_main_alloc_empty();
   enkf_main->res_config = res_config;
-
-  /*****************************************************************/
-  enkf_main->templates          = ert_templates_alloc( enkf_main_get_data_kw(enkf_main) );
-  /*****************************************************************/
 
   enkf_main_rng_init( enkf_main );
   subst_config_install_rng(res_config_get_subst_config(res_config), enkf_main->rng);
@@ -2616,7 +2605,7 @@ void enkf_main_install_SIGNALS(void) {
 
 
 ert_templates_type * enkf_main_get_templates( enkf_main_type * enkf_main ) {
-  return enkf_main->templates;
+  return res_config_get_templates(enkf_main->res_config);
 }
 
 

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -152,7 +152,6 @@ struct enkf_main_struct {
   ecl_config_type        * ecl_config;
   const res_config_type  * res_config;
   local_config_type      * local_config;       /* Holding all the information about local analysis. */
-  config_settings_type   * plot_config;        /* Information about plotting. */
   rng_type               * rng;
   ranking_table_type     * ranking_table;
 
@@ -267,8 +266,8 @@ model_config_type * enkf_main_get_model_config( const enkf_main_type * enkf_main
   return enkf_main->model_config;
 }
 
-config_settings_type * enkf_main_get_plot_config( const enkf_main_type * enkf_main ) {
-  return enkf_main->plot_config;
+const config_settings_type * enkf_main_get_plot_config( const enkf_main_type * enkf_main ) {
+  return res_config_get_plot_config(enkf_main->res_config);
 }
 
 ranking_table_type * enkf_main_get_ranking_table( const enkf_main_type * enkf_main ) {
@@ -374,7 +373,6 @@ void enkf_main_free(enkf_main_type * enkf_main){
   local_config_free( enkf_main->local_config );
 
   int_vector_free( enkf_main->keep_runpath );
-  config_settings_free( enkf_main->plot_config );
 
   util_safe_free( enkf_main->user_config_file );
   util_safe_free( enkf_main->rft_config_file );
@@ -2010,16 +2008,13 @@ static enkf_main_type * enkf_main_alloc_empty( ) {
   enkf_main->rng                = NULL;
   enkf_main->ens_size           = 0;
   enkf_main->keep_runpath       = int_vector_alloc( 0 , DEFAULT_KEEP );
-  enkf_main->res_config        = NULL;
+  enkf_main->res_config         = NULL;
   enkf_main->ensemble_config    = ensemble_config_alloc();
   enkf_main->ecl_config         = ecl_config_alloc();
   enkf_main->ranking_table      = ranking_table_alloc( 0 );
   enkf_main->obs                = NULL;
   enkf_main->model_config       = model_config_alloc( );
   enkf_main->local_config       = local_config_alloc( );
-
-  enkf_main->plot_config        = config_settings_alloc( PLOT_SETTING_KEY );
-  plot_settings_init( enkf_main->plot_config );
 
   enkf_main_set_verbose( enkf_main , true );
   enkf_main_init_fs( enkf_main );
@@ -2307,8 +2302,6 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
 
   ecl_config_init(enkf_main->ecl_config, content);
   enkf_main_update_num_cpu(enkf_main);
-
-  config_settings_apply(enkf_main->plot_config, content);
 
   ensemble_config_init(enkf_main->ensemble_config, content,
                        ecl_config_get_grid(enkf_main->ecl_config),

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -2353,7 +2353,6 @@ enkf_main_type * enkf_main_alloc(const char * model_config, const res_config_typ
   enkf_main->res_config = res_config;
 
   enkf_main_rng_init( enkf_main );
-  subst_config_install_rng(res_config_get_subst_config(res_config), enkf_main->rng);
 
   enkf_main_set_verbose(enkf_main, verbose);
 

--- a/libenkf/src/enkf_main_ensemble.c
+++ b/libenkf/src/enkf_main_ensemble.c
@@ -67,7 +67,7 @@ void enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size ) 
                                                    enkf_main->pre_clear_runpath,
                                                    int_vector_safe_iget(enkf_main->keep_runpath, iens),
                                                    enkf_main->model_config,
-                                                   enkf_main->ensemble_config,
+                                                   enkf_main_get_ensemble_config(enkf_main),
                                                    enkf_main_get_site_config(enkf_main),
                                                    enkf_main_get_ecl_config(enkf_main),
                                                    enkf_main_get_templates(enkf_main),

--- a/libenkf/src/enkf_main_ensemble.c
+++ b/libenkf/src/enkf_main_ensemble.c
@@ -62,15 +62,15 @@ void enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size ) 
 
       /* Observe that due to the initialization of the rng - this function is currently NOT thread safe. */
       enkf_main->ensemble[iens] = enkf_state_alloc(iens,
-                                                   enkf_main->rng ,
-                                                   model_config_iget_casename( enkf_main->model_config , iens ) ,
-                                                   enkf_main->pre_clear_runpath                                 ,
-                                                   int_vector_safe_iget( enkf_main->keep_runpath , iens)        ,
-                                                   enkf_main->model_config                                      ,
-                                                   enkf_main->ensemble_config                                   ,
-                                                   enkf_main_get_site_config(enkf_main)                         ,
-                                                   enkf_main->ecl_config                                        ,
-                                                   enkf_main->templates                                         ,
+                                                   enkf_main->rng,
+                                                   model_config_iget_casename(enkf_main->model_config, iens),
+                                                   enkf_main->pre_clear_runpath,
+                                                   int_vector_safe_iget(enkf_main->keep_runpath, iens),
+                                                   enkf_main->model_config,
+                                                   enkf_main->ensemble_config,
+                                                   enkf_main_get_site_config(enkf_main),
+                                                   enkf_main->ecl_config,
+                                                   enkf_main_get_templates(enkf_main),
                                                    enkf_main_get_data_kw(enkf_main));
     enkf_main->ens_size = new_ens_size;
     return;

--- a/libenkf/src/enkf_main_ensemble.c
+++ b/libenkf/src/enkf_main_ensemble.c
@@ -69,7 +69,7 @@ void enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size ) 
                                                    enkf_main->model_config,
                                                    enkf_main->ensemble_config,
                                                    enkf_main_get_site_config(enkf_main),
-                                                   enkf_main->ecl_config,
+                                                   enkf_main_get_ecl_config(enkf_main),
                                                    enkf_main_get_templates(enkf_main),
                                                    enkf_main_get_data_kw(enkf_main));
     enkf_main->ens_size = new_ens_size;

--- a/libenkf/src/enkf_main_ensemble.c
+++ b/libenkf/src/enkf_main_ensemble.c
@@ -63,10 +63,10 @@ void enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size ) 
       /* Observe that due to the initialization of the rng - this function is currently NOT thread safe. */
       enkf_main->ensemble[iens] = enkf_state_alloc(iens,
                                                    enkf_main->rng,
-                                                   model_config_iget_casename(enkf_main->model_config, iens),
+                                                   model_config_iget_casename(enkf_main_get_model_config(enkf_main), iens),
                                                    enkf_main->pre_clear_runpath,
                                                    int_vector_safe_iget(enkf_main->keep_runpath, iens),
-                                                   enkf_main->model_config,
+                                                   enkf_main_get_model_config(enkf_main),
                                                    enkf_main_get_ensemble_config(enkf_main),
                                                    enkf_main_get_site_config(enkf_main),
                                                    enkf_main_get_ecl_config(enkf_main),

--- a/libenkf/src/enkf_main_jobs.c
+++ b/libenkf/src/enkf_main_jobs.c
@@ -405,7 +405,7 @@ static void enkf_main_export_runpath_file(enkf_main_type * enkf_main,
                                           const int_vector_type * realizations,
                                           const int_vector_type * iterations) {
 
-  ecl_config_type * ecl_config            = enkf_main_get_ecl_config(enkf_main);
+  const ecl_config_type * ecl_config      = enkf_main_get_ecl_config(enkf_main);
   const model_config_type * model_config  = enkf_main_get_model_config(enkf_main);
   const char * basename_fmt               = ecl_config_get_eclbase(ecl_config);
   const char * runpath_fmt                = model_config_get_runpath_as_char(model_config);

--- a/libenkf/src/enkf_main_manage_fs.c
+++ b/libenkf/src/enkf_main_manage_fs.c
@@ -46,7 +46,7 @@ bool enkf_main_case_is_current(const enkf_main_type * enkf_main , const char * c
 }
 
 static bool enkf_main_current_case_file_exists( const enkf_main_type * enkf_main) {
-  const char * ens_path = model_config_get_enspath( enkf_main->model_config);
+  const char * ens_path = model_config_get_enspath(enkf_main_get_model_config(enkf_main));
   char * current_case_file = util_alloc_filename(ens_path, CURRENT_CASE_FILE, NULL);
   bool exists = util_file_exists(current_case_file);
   free(current_case_file);
@@ -55,7 +55,7 @@ static bool enkf_main_current_case_file_exists( const enkf_main_type * enkf_main
 
 char* enkf_main_read_alloc_current_case_name(const enkf_main_type * enkf_main) {
   char * current_case = NULL;
-  const char * ens_path = model_config_get_enspath( enkf_main->model_config);
+  const char * ens_path = model_config_get_enspath(enkf_main_get_model_config(enkf_main));
   char * current_case_file = util_alloc_filename(ens_path, CURRENT_CASE_FILE, NULL);
   if (enkf_main_current_case_file_exists(enkf_main)) {
     FILE * stream = util_fopen( current_case_file  , "r");
@@ -75,7 +75,7 @@ char* enkf_main_read_alloc_current_case_name(const enkf_main_type * enkf_main) {
 stringlist_type * enkf_main_alloc_caselist( const enkf_main_type * enkf_main ) {
   stringlist_type * case_list = stringlist_alloc_new( );
   {
-    const char * ens_path = model_config_get_enspath( enkf_main->model_config );
+    const char * ens_path = model_config_get_enspath(enkf_main_get_model_config(enkf_main));
     DIR * ens_dir = opendir( ens_path );
     if (ens_dir != NULL) {
       int ens_fd = dirfd( ens_dir );
@@ -103,7 +103,7 @@ stringlist_type * enkf_main_alloc_caselist( const enkf_main_type * enkf_main ) {
 
 
 void enkf_main_set_case_table( enkf_main_type * enkf_main , const char * case_table_file ) {
-  model_config_set_case_table( enkf_main->model_config , enkf_main->ens_size , case_table_file );
+  model_config_set_case_table(enkf_main_get_model_config(enkf_main), enkf_main->ens_size , case_table_file );
 }
 
 
@@ -353,7 +353,7 @@ static void update_case_log(enkf_main_type * enkf_main , const char * case_path)
         of 'w'.
   */
 
-  const char * ens_path = model_config_get_enspath( enkf_main->model_config);
+  const char * ens_path = model_config_get_enspath(enkf_main_get_model_config(enkf_main));
 
   {
     int buffer_size = 256;
@@ -385,7 +385,7 @@ static void update_case_log(enkf_main_type * enkf_main , const char * case_path)
 
 
 static void enkf_main_write_current_case_file( const enkf_main_type * enkf_main, const char * case_path) {
-  const char * ens_path = model_config_get_enspath( enkf_main->model_config);
+  const char * ens_path = model_config_get_enspath(enkf_main_get_model_config(enkf_main));
   const char * base = CURRENT_CASE_FILE;
   char * current_case_file = util_alloc_filename(ens_path , base, NULL);
   FILE * stream = util_fopen( current_case_file  , "w");
@@ -428,8 +428,8 @@ static void enkf_main_create_fs( const enkf_main_type * enkf_main , const char *
   char * new_mount_point = enkf_main_alloc_mount_point( enkf_main , case_path );
 
   enkf_fs_create_fs( new_mount_point,
-                     model_config_get_dbase_type( enkf_main->model_config ) ,
-                     model_config_get_dbase_args( enkf_main->model_config ) ,
+                     model_config_get_dbase_type(enkf_main_get_model_config(enkf_main)),
+                     model_config_get_dbase_args(enkf_main_get_model_config(enkf_main)),
                      false );
 
   free( new_mount_point );
@@ -437,7 +437,7 @@ static void enkf_main_create_fs( const enkf_main_type * enkf_main , const char *
 
 
 const char * enkf_main_get_mount_root( const enkf_main_type * enkf_main) {
-  return model_config_get_enspath( enkf_main->model_config);
+  return model_config_get_enspath(enkf_main_get_model_config(enkf_main));
 }
 
 
@@ -447,7 +447,7 @@ char * enkf_main_alloc_mount_point( const enkf_main_type * enkf_main , const cha
   if (util_is_abs_path( case_path ))
     mount_point = util_alloc_string_copy( case_path );
   else
-    mount_point = util_alloc_filename( model_config_get_enspath( enkf_main->model_config) , case_path , NULL);
+    mount_point = util_alloc_filename( model_config_get_enspath(enkf_main_get_model_config(enkf_main)) , case_path , NULL);
   return mount_point;
 }
 
@@ -611,7 +611,7 @@ void enkf_main_select_fs( enkf_main_type * enkf_main , const char * case_path ) 
     if (new_fs != NULL)
       enkf_main_set_fs( enkf_main , new_fs , case_path);
     else {
-      const char * ens_path = model_config_get_enspath( enkf_main->model_config );
+      const char * ens_path = model_config_get_enspath(enkf_main_get_model_config(enkf_main));
       util_exit("%s: select filesystem %s:%s failed \n",__func__ , ens_path , case_path );
     }
     enkf_fs_decref( new_fs );
@@ -620,7 +620,7 @@ void enkf_main_select_fs( enkf_main_type * enkf_main , const char * case_path ) 
 
 
 static void enkf_main_user_select_initial_fs(enkf_main_type * enkf_main) {
-  const char * ens_path = model_config_get_enspath( enkf_main->model_config);
+  const char * ens_path = model_config_get_enspath(enkf_main_get_model_config(enkf_main));
   int root_version = enkf_fs_get_version104( ens_path );
   if (root_version == -1 || root_version == 105) {
     char * current_mount_point = util_alloc_filename( ens_path , CURRENT_CASE , NULL);

--- a/libenkf/src/enkf_main_manage_fs.c
+++ b/libenkf/src/enkf_main_manage_fs.c
@@ -294,7 +294,8 @@ void enkf_main_init_case_from_existing_custom(const enkf_main_type * enkf_main,
 */
 
 static bool enkf_main_case_is_initialized__( const enkf_main_type * enkf_main , enkf_fs_type * fs , bool_vector_type * __mask) {
-  stringlist_type  * parameter_keys = ensemble_config_alloc_keylist_from_var_type( enkf_main->ensemble_config , PARAMETER );
+  ensemble_config_type * ensemble_config = enkf_main_get_ensemble_config(enkf_main);
+  stringlist_type  * parameter_keys = ensemble_config_alloc_keylist_from_var_type(ensemble_config, PARAMETER);
   bool_vector_type * mask;
   bool initialized = true;
   int ikey = 0;
@@ -304,7 +305,7 @@ static bool enkf_main_case_is_initialized__( const enkf_main_type * enkf_main , 
     mask = bool_vector_alloc(0 , true );
 
   while ((ikey < stringlist_get_size( parameter_keys )) && (initialized)) {
-    const enkf_config_node_type * config_node = ensemble_config_get_node( enkf_main->ensemble_config , stringlist_iget( parameter_keys , ikey) );
+    const enkf_config_node_type * config_node = ensemble_config_get_node(ensemble_config , stringlist_iget( parameter_keys , ikey) );
     int iens = 0;
     do {
       if (bool_vector_safe_iget( mask , iens)) {
@@ -395,9 +396,10 @@ static void enkf_main_write_current_case_file( const enkf_main_type * enkf_main,
 
 
 static void enkf_main_gen_data_special( enkf_main_type * enkf_main , enkf_fs_type * fs ) {
-  stringlist_type * gen_data_keys = ensemble_config_alloc_keylist_from_impl_type( enkf_main->ensemble_config , GEN_DATA);
+  ensemble_config_type * ensemble_config = enkf_main_get_ensemble_config(enkf_main);
+  stringlist_type * gen_data_keys = ensemble_config_alloc_keylist_from_impl_type(ensemble_config, GEN_DATA);
   for (int i=0; i < stringlist_get_size( gen_data_keys ); i++) {
-    enkf_config_node_type * config_node = ensemble_config_get_node( enkf_main->ensemble_config , stringlist_iget( gen_data_keys , i));
+    enkf_config_node_type * config_node = ensemble_config_get_node(ensemble_config, stringlist_iget( gen_data_keys , i));
     gen_data_config_type * gen_data_config = enkf_config_node_get_ref( config_node );
 
     if (gen_data_config_is_dynamic( gen_data_config )) 

--- a/libenkf/src/ert_template.c
+++ b/libenkf/src/ert_template.c
@@ -26,6 +26,7 @@
 #include <ert/enkf/ert_template.h>
 #include <ert/enkf/config_keys.h>
 #include <ert/enkf/enkf_defaults.h>
+#include <ert/enkf/model_config.h>
 
 
 #define ERT_TEMPLATE_TYPE_ID  7731963
@@ -139,6 +140,24 @@ ert_templates_type * ert_templates_alloc( subst_list_type * parent_subst  ) {
   UTIL_TYPE_ID_INIT( templates , ERT_TEMPLATES_TYPE_ID );
   templates->templates       = hash_alloc();
   templates->parent_subst    = parent_subst;
+  return templates;
+}
+
+ert_templates_type * ert_templates_alloc_load(subst_list_type * parent_subst,
+        const char * config_file)
+{
+  ert_templates_type * templates = ert_templates_alloc(parent_subst);
+
+  if(config_file) {
+    config_parser_type * config = config_alloc();
+    config_content_type * content = model_config_alloc_content(config_file, config);
+
+    ert_templates_init(templates, content);
+
+    config_content_free(content);
+    config_free(config);
+  }
+
   return templates;
 }
 

--- a/libenkf/src/hook_manager.c
+++ b/libenkf/src/hook_manager.c
@@ -31,6 +31,7 @@
 #include <ert/enkf/hook_manager.h>
 #include <ert/enkf/ert_workflow_list.h>
 #include <ert/enkf/runpath_list.h>
+#include <ert/enkf/model_config.h>
 
 #define HOOK_MANAGER_NAME             "HOOK MANAGER"
 #define QC_WORKFLOW_NAME              "QC WORKFLOW"
@@ -64,6 +65,27 @@ hook_manager_type * hook_manager_alloc( ert_workflow_list_type * workflow_list )
   return hook_manager;
 }
 
+hook_manager_type * hook_manager_alloc_load(
+        ert_workflow_list_type * workflow_list,
+        const char * user_config_file,
+        const char * working_dir)
+{
+  hook_manager_type * hook_manager = hook_manager_alloc(workflow_list);
+
+  if(user_config_file) {
+    config_parser_type * config = config_alloc();
+    config_content_type * content = model_config_alloc_content(user_config_file, config);
+
+    hook_manager_init(hook_manager, content, working_dir);
+
+    config_content_free(content);
+    config_free(config);
+  }
+
+  return hook_manager;
+}
+
+
 
 void hook_manager_free( hook_manager_type * hook_manager ) {
   runpath_list_free( hook_manager->runpath_list );
@@ -80,7 +102,7 @@ void hook_manager_add_input_context( hook_manager_type * hook_manager, const cha
 
 
 
-runpath_list_type * hook_manager_get_runpath_list( hook_manager_type * hook_manager ) {
+runpath_list_type * hook_manager_get_runpath_list(const hook_manager_type * hook_manager) {
   return hook_manager->runpath_list;
 }
 
@@ -98,7 +120,7 @@ static void hook_manager_add_workflow( hook_manager_type * hook_manager , const 
 
 
 
-void hook_manager_init( hook_manager_type * hook_manager , const config_content_type * config_content) {
+void hook_manager_init( hook_manager_type * hook_manager , const config_content_type * config_content, const char * working_dir) {
 
   /* Old stuff explicitly prefixed with QC  */
   {
@@ -126,7 +148,7 @@ void hook_manager_init( hook_manager_type * hook_manager , const config_content_
 
 
   if (config_content_has_item( config_content , RUNPATH_FILE_KEY))
-    hook_manager_set_runpath_list_file( hook_manager, NULL, config_content_get_value( config_content , RUNPATH_FILE_KEY));
+    hook_manager_set_runpath_list_file( hook_manager, working_dir, config_content_get_value( config_content , RUNPATH_FILE_KEY));
 }
 
 

--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -343,6 +343,35 @@ model_config_type * model_config_alloc() {
   return model_config;
 }
 
+model_config_type * model_config_alloc_load(const char * user_config_file,
+        const ext_joblist_type * joblist,
+        int last_history_restart,
+        const sched_file_type * sched_file,
+        const ecl_sum_type * refcase)
+{
+  model_config_type * model_config = model_config_alloc();
+
+  if(user_config_file) {
+    config_parser_type * config = config_alloc();
+    config_content_type * content = model_config_alloc_content(user_config_file, config);
+
+    model_config_init(model_config,
+                      content,
+                      0,
+                      joblist,
+                      last_history_restart,
+                      sched_file,
+                      refcase
+                      );
+
+    config_content_free(content);
+    config_free(config);
+  }
+
+  return model_config;
+}
+
+
 
 bool model_config_select_history( model_config_type * model_config , history_source_type source_type, const sched_file_type * sched_file , const ecl_sum_type * refcase) {
   bool selectOK = false;

--- a/libenkf/src/plot_settings.c
+++ b/libenkf/src/plot_settings.c
@@ -28,6 +28,7 @@
 #include <ert/enkf/plot_settings.h>
 #include <ert/enkf/enkf_defaults.h>
 #include <ert/enkf/config_keys.h>
+#include <ert/enkf/model_config.h>
 
 #define TRUE_STRING              "True"
 #define FALSE_STRING             "False"
@@ -40,6 +41,22 @@
 #define DEFAULT_SHOW_REFCASE     FALSE_STRING
 #define DEFAULT_SHOW_HISTORY     FALSE_STRING
 
+config_settings_type * plot_settings_alloc_load(const char * config_file) {
+  config_settings_type * plot_config = config_settings_alloc(PLOT_SETTING_KEY);
+  plot_settings_init(plot_config);
+
+  if(config_file) {
+    config_parser_type * config = config_alloc();
+    config_content_type * content = model_config_alloc_content(config_file, config);
+
+    config_settings_apply(plot_config, content);
+
+    config_content_free(content);
+    config_free(config);
+  }
+
+  return plot_config;
+}
 
 void plot_settings_init(config_settings_type * settings) {
 

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -26,6 +26,7 @@
 #include <ert/enkf/ert_workflow_list.h>
 #include <ert/enkf/subst_config.h>
 #include <ert/enkf/hook_manager.h>
+#include <ert/enkf/ert_template.h>
 
 struct res_config_struct {
 
@@ -38,6 +39,7 @@ struct res_config_struct {
   ert_workflow_list_type * workflow_list;
   subst_config_type      * subst_config;
   hook_manager_type      * hook_manager;
+  ert_templates_type     * templates;
 
 };
 
@@ -54,6 +56,7 @@ static res_config_type * res_config_alloc_empty() {
   res_config->workflow_list     = NULL;
   res_config->subst_config      = NULL;
   res_config->hook_manager      = NULL;
+  res_config->templates         = NULL;
 
   return res_config;
 }
@@ -79,6 +82,11 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                     res_config->working_dir
                                     );
 
+  res_config->templates      = ert_templates_alloc_load(
+                                    subst_config_get_subst_list(res_config->subst_config),
+                                    config_file
+                                    );
+
   return res_config;
 }
 
@@ -92,6 +100,7 @@ void res_config_free(res_config_type * res_config) {
   ert_workflow_list_free(res_config->workflow_list);
   subst_config_free(res_config->subst_config);
   hook_manager_free(res_config->hook_manager);
+  ert_templates_free(res_config->templates);
 
   free(res_config->user_config_file);
   free(res_config->working_dir);
@@ -132,6 +141,12 @@ const hook_manager_type * res_config_get_hook_manager(
                     const res_config_type * res_config
                    ) {
   return res_config->hook_manager;
+}
+
+ert_templates_type * res_config_get_templates(
+                    const res_config_type * res_config
+                  ) {
+  return res_config->templates;
 }
 
 static char * res_config_alloc_working_directory(const char * user_config_file) {

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -30,6 +30,7 @@
 #include <ert/enkf/hook_manager.h>
 #include <ert/enkf/ert_template.h>
 #include <ert/enkf/plot_settings.h>
+#include <ert/enkf/ecl_config.h>
 
 struct res_config_struct {
 
@@ -44,6 +45,7 @@ struct res_config_struct {
   hook_manager_type      * hook_manager;
   ert_templates_type     * templates;
   config_settings_type   * plot_config;
+  ecl_config_type        * ecl_config;
 
 };
 
@@ -62,6 +64,7 @@ static res_config_type * res_config_alloc_empty() {
   res_config->hook_manager      = NULL;
   res_config->templates         = NULL;
   res_config->plot_config       = NULL;
+  res_config->ecl_config        = NULL;
 
   return res_config;
 }
@@ -93,6 +96,7 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                     );
 
   res_config->plot_config     = plot_settings_alloc_load(config_file);
+  res_config->ecl_config      = ecl_config_alloc_load(config_file);
 
   return res_config;
 }
@@ -109,6 +113,7 @@ void res_config_free(res_config_type * res_config) {
   hook_manager_free(res_config->hook_manager);
   ert_templates_free(res_config->templates);
   config_settings_free(res_config->plot_config);
+  ecl_config_free(res_config->ecl_config);
 
   free(res_config->user_config_file);
   free(res_config->working_dir);
@@ -161,6 +166,12 @@ const config_settings_type * res_config_get_plot_config(
                     const res_config_type * res_config
                   ) {
   return res_config->plot_config;
+}
+
+const ecl_config_type * res_config_get_ecl_config(
+                    const res_config_type * res_config
+                  ) {
+  return res_config->ecl_config;
 }
 
 static char * res_config_alloc_working_directory(const char * user_config_file) {

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -32,6 +32,7 @@
 #include <ert/enkf/plot_settings.h>
 #include <ert/enkf/ecl_config.h>
 #include <ert/enkf/ensemble_config.h>
+#include <ert/enkf/model_config.h>
 
 struct res_config_struct {
 
@@ -48,6 +49,7 @@ struct res_config_struct {
   config_settings_type   * plot_config;
   ecl_config_type        * ecl_config;
   ensemble_config_type   * ensemble_config;
+  model_config_type      * model_config;
 
 };
 
@@ -68,6 +70,7 @@ static res_config_type * res_config_alloc_empty() {
   res_config->plot_config       = NULL;
   res_config->ecl_config        = NULL;
   res_config->ensemble_config   = NULL;
+  res_config->model_config      = NULL;
 
   return res_config;
 }
@@ -106,6 +109,13 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                             ecl_config_get_refcase(res_config->ecl_config)
                                     );
 
+  res_config->model_config    = model_config_alloc_load(config_file,
+                                        site_config_get_installed_jobs(res_config->site_config),
+                                        ecl_config_get_last_history_restart(res_config->ecl_config),
+                                        ecl_config_get_sched_file(res_config->ecl_config),
+                                        ecl_config_get_refcase(res_config->ecl_config)
+                                   );
+
   return res_config;
 }
 
@@ -123,6 +133,7 @@ void res_config_free(res_config_type * res_config) {
   config_settings_free(res_config->plot_config);
   ecl_config_free(res_config->ecl_config);
   ensemble_config_free(res_config->ensemble_config);
+  model_config_free(res_config->model_config);
 
   free(res_config->user_config_file);
   free(res_config->working_dir);
@@ -187,6 +198,12 @@ ensemble_config_type * res_config_get_ensemble_config(
                     const res_config_type * res_config
                   ) {
   return res_config->ensemble_config;
+}
+
+model_config_type * res_config_get_model_config(
+                    const res_config_type * res_config
+                  ) {
+  return res_config->model_config;
 }
 
 static char * res_config_alloc_working_directory(const char * user_config_file) {

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -25,6 +25,7 @@
 #include <ert/enkf/analysis_config.h>
 #include <ert/enkf/ert_workflow_list.h>
 #include <ert/enkf/subst_config.h>
+#include <ert/enkf/hook_manager.h>
 
 struct res_config_struct {
 
@@ -36,6 +37,7 @@ struct res_config_struct {
   analysis_config_type   * analysis_config;
   ert_workflow_list_type * workflow_list;
   subst_config_type      * subst_config;
+  hook_manager_type      * hook_manager;
 
 };
 
@@ -51,6 +53,7 @@ static res_config_type * res_config_alloc_empty() {
   res_config->analysis_config   = NULL;
   res_config->workflow_list     = NULL;
   res_config->subst_config      = NULL;
+  res_config->hook_manager      = NULL;
 
   return res_config;
 }
@@ -70,6 +73,12 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                     config_file
                                     );
 
+  res_config->hook_manager    = hook_manager_alloc_load(
+                                    res_config->workflow_list,
+                                    config_file,
+                                    res_config->working_dir
+                                    );
+
   return res_config;
 }
 
@@ -82,6 +91,7 @@ void res_config_free(res_config_type * res_config) {
   analysis_config_free(res_config->analysis_config);
   ert_workflow_list_free(res_config->workflow_list);
   subst_config_free(res_config->subst_config);
+  hook_manager_free(res_config->hook_manager);
 
   free(res_config->user_config_file);
   free(res_config->working_dir);
@@ -108,7 +118,7 @@ const analysis_config_type * res_config_get_analysis_config(
 
 ert_workflow_list_type * res_config_get_workflow_list(
                     const res_config_type * res_config
-        ) {
+                    ) {
   return res_config->workflow_list;
 }
 
@@ -116,6 +126,12 @@ subst_config_type * res_config_get_subst_config(
                     const res_config_type * res_config
                    ) {
   return res_config->subst_config;
+}
+
+const hook_manager_type * res_config_get_hook_manager(
+                    const res_config_type * res_config
+                   ) {
+  return res_config->hook_manager;
 }
 
 static char * res_config_alloc_working_directory(const char * user_config_file) {

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -19,6 +19,8 @@
 #include <ert/util/subst_list.h>
 #include <ert/util/subst_func.h>
 
+#include <ert/config/config_settings.h>
+
 #include <ert/enkf/res_config.h>
 #include <ert/enkf/site_config.h>
 #include <ert/enkf/rng_config.h>
@@ -27,6 +29,7 @@
 #include <ert/enkf/subst_config.h>
 #include <ert/enkf/hook_manager.h>
 #include <ert/enkf/ert_template.h>
+#include <ert/enkf/plot_settings.h>
 
 struct res_config_struct {
 
@@ -40,6 +43,7 @@ struct res_config_struct {
   subst_config_type      * subst_config;
   hook_manager_type      * hook_manager;
   ert_templates_type     * templates;
+  config_settings_type   * plot_config;
 
 };
 
@@ -57,6 +61,7 @@ static res_config_type * res_config_alloc_empty() {
   res_config->subst_config      = NULL;
   res_config->hook_manager      = NULL;
   res_config->templates         = NULL;
+  res_config->plot_config       = NULL;
 
   return res_config;
 }
@@ -82,10 +87,12 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                     res_config->working_dir
                                     );
 
-  res_config->templates      = ert_templates_alloc_load(
+  res_config->templates       = ert_templates_alloc_load(
                                     subst_config_get_subst_list(res_config->subst_config),
                                     config_file
                                     );
+
+  res_config->plot_config     = plot_settings_alloc_load(config_file);
 
   return res_config;
 }
@@ -101,6 +108,7 @@ void res_config_free(res_config_type * res_config) {
   subst_config_free(res_config->subst_config);
   hook_manager_free(res_config->hook_manager);
   ert_templates_free(res_config->templates);
+  config_settings_free(res_config->plot_config);
 
   free(res_config->user_config_file);
   free(res_config->working_dir);
@@ -147,6 +155,12 @@ ert_templates_type * res_config_get_templates(
                     const res_config_type * res_config
                   ) {
   return res_config->templates;
+}
+
+const config_settings_type * res_config_get_plot_config(
+                    const res_config_type * res_config
+                  ) {
+  return res_config->plot_config;
 }
 
 static char * res_config_alloc_working_directory(const char * user_config_file) {

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -31,6 +31,7 @@
 #include <ert/enkf/ert_template.h>
 #include <ert/enkf/plot_settings.h>
 #include <ert/enkf/ecl_config.h>
+#include <ert/enkf/ensemble_config.h>
 
 struct res_config_struct {
 
@@ -46,6 +47,7 @@ struct res_config_struct {
   ert_templates_type     * templates;
   config_settings_type   * plot_config;
   ecl_config_type        * ecl_config;
+  ensemble_config_type   * ensemble_config;
 
 };
 
@@ -65,6 +67,7 @@ static res_config_type * res_config_alloc_empty() {
   res_config->templates         = NULL;
   res_config->plot_config       = NULL;
   res_config->ecl_config        = NULL;
+  res_config->ensemble_config   = NULL;
 
   return res_config;
 }
@@ -98,6 +101,11 @@ res_config_type * res_config_alloc_load(const char * config_file) {
   res_config->plot_config     = plot_settings_alloc_load(config_file);
   res_config->ecl_config      = ecl_config_alloc_load(config_file);
 
+  res_config->ensemble_config = ensemble_config_alloc_load(config_file,
+                                            ecl_config_get_grid(res_config->ecl_config),
+                                            ecl_config_get_refcase(res_config->ecl_config)
+                                    );
+
   return res_config;
 }
 
@@ -114,6 +122,7 @@ void res_config_free(res_config_type * res_config) {
   ert_templates_free(res_config->templates);
   config_settings_free(res_config->plot_config);
   ecl_config_free(res_config->ecl_config);
+  ensemble_config_free(res_config->ensemble_config);
 
   free(res_config->user_config_file);
   free(res_config->working_dir);
@@ -172,6 +181,12 @@ const ecl_config_type * res_config_get_ecl_config(
                     const res_config_type * res_config
                   ) {
   return res_config->ecl_config;
+}
+
+ensemble_config_type * res_config_get_ensemble_config(
+                    const res_config_type * res_config
+                  ) {
+  return res_config->ensemble_config;
 }
 
 static char * res_config_alloc_working_directory(const char * user_config_file) {

--- a/libenkf/src/subst_config.c
+++ b/libenkf/src/subst_config.c
@@ -96,14 +96,6 @@ subst_list_type * subst_config_get_subst_list(subst_config_type * subst_type) {
   return subst_type->subst_list;
 }
 
-void subst_config_install_rng(subst_config_type * subst_config, rng_type * rng) {
-  subst_func_pool_add_func(subst_config->subst_func_pool, "RANDINT",   "Returns a random integer - 32 bit", subst_func_randint,   false, 0, 0, rng);
-  subst_func_pool_add_func(subst_config->subst_func_pool, "RANDFLOAT", "Returns a random float 0-1.",       subst_func_randfloat, false, 0, 0, rng);
-
-  subst_list_insert_func(subst_config->subst_list, "RANDINT",   "__RANDINT__");
-  subst_list_insert_func(subst_config->subst_list, "RANDFLOAT", "__RANDFLOAT__");
-}
-
 void subst_config_add_internal_subst_kw(subst_config_type * subst_config, const char * key , const char * value, const char * help_text) {
   char * tagged_key = util_alloc_sprintf(INTERNAL_DATA_KW_TAG_FORMAT, key);
   subst_list_append_copy(subst_config_get_subst_list(subst_config), tagged_key, value, help_text);

--- a/libenkf/tests/enkf_runpath_list.c
+++ b/libenkf/tests/enkf_runpath_list.c
@@ -120,7 +120,7 @@ void test_runpath_list() {
 void test_config( const char * config_file ) {
   ert_test_context_type * test_context = ert_test_context_alloc( "RUNPATH_FILE" , config_file );
   enkf_main_type * enkf_main = ert_test_context_get_main( test_context );
-  hook_manager_type * hook_manager = enkf_main_get_hook_manager( enkf_main );
+  const hook_manager_type * hook_manager = enkf_main_get_hook_manager( enkf_main );
 
   ert_test_context_run_worklow( test_context , "ARGECHO_WF");
   {

--- a/libenkf/tests/enkf_workflow_job_test.c
+++ b/libenkf/tests/enkf_workflow_job_test.c
@@ -245,7 +245,7 @@ static void test_export_runpath_file(ert_test_context_type * test_context,
 
   {
     const enkf_main_type * enkf_main = ert_test_context_get_main(test_context);
-    hook_manager_type * hook_manager       = enkf_main_get_hook_manager( enkf_main );
+    const hook_manager_type * hook_manager       = enkf_main_get_hook_manager( enkf_main );
     const char * runpath_file_name   = hook_manager_get_runpath_list_file(hook_manager);
 
     ecl_config_type * ecl_config            = enkf_main_get_ecl_config(enkf_main);

--- a/libenkf/tests/enkf_workflow_job_test.c
+++ b/libenkf/tests/enkf_workflow_job_test.c
@@ -248,7 +248,7 @@ static void test_export_runpath_file(ert_test_context_type * test_context,
     const hook_manager_type * hook_manager       = enkf_main_get_hook_manager( enkf_main );
     const char * runpath_file_name   = hook_manager_get_runpath_list_file(hook_manager);
 
-    ecl_config_type * ecl_config            = enkf_main_get_ecl_config(enkf_main);
+    const ecl_config_type * ecl_config      = enkf_main_get_ecl_config(enkf_main);
     const model_config_type * model_config  = enkf_main_get_model_config(enkf_main);
     const char * base_fmt                   = ecl_config_get_eclbase(ecl_config);
     const char * runpath_fmt                = model_config_get_runpath_as_char(model_config);

--- a/python/python/res/enkf/enkf_main.py
+++ b/python/python/res/enkf/enkf_main.py
@@ -46,7 +46,6 @@ class EnKFMain(BaseCClass):
     _get_ecl_config = EnkfPrototype("ecl_config_ref enkf_main_get_ecl_config( enkf_main)")
     _get_plot_config = EnkfPrototype("plot_settings_ref enkf_main_get_plot_config( enkf_main)")
     _get_schedule_prediction_file = EnkfPrototype("char* enkf_main_get_schedule_prediction_file( enkf_main )")
-    _set_schedule_prediction_file = EnkfPrototype("void enkf_main_set_schedule_prediction_file( enkf_main , char*)")
     _get_data_kw = EnkfPrototype("subst_list_ref enkf_main_get_data_kw(enkf_main)")
     _clear_data_kw = EnkfPrototype("void enkf_main_clear_data_kw(enkf_main)")
     _add_data_kw = EnkfPrototype("void enkf_main_add_data_kw(enkf_main, char*, char*)")
@@ -190,9 +189,6 @@ class EnKFMain(BaseCClass):
     def get_schedule_prediction_file(self):
         schedule_prediction_file = self._get_schedule_prediction_file( )
         return schedule_prediction_file
-
-    def set_schedule_prediction_file(self, file):
-        self._set_schedule_prediction_file(file)
 
     def getDataKW(self):
         """ @rtype: SubstitutionList """

--- a/python/python/res/enkf/enkf_main.py
+++ b/python/python/res/enkf/enkf_main.py
@@ -45,7 +45,6 @@ class EnKFMain(BaseCClass):
     _get_site_config = EnkfPrototype("site_config_ref enkf_main_get_site_config( enkf_main)")
     _get_ecl_config = EnkfPrototype("ecl_config_ref enkf_main_get_ecl_config( enkf_main)")
     _get_plot_config = EnkfPrototype("plot_settings_ref enkf_main_get_plot_config( enkf_main)")
-    _set_datafile = EnkfPrototype("void enkf_main_set_data_file( enkf_main, char*)")
     _get_schedule_prediction_file = EnkfPrototype("char* enkf_main_get_schedule_prediction_file( enkf_main )")
     _set_schedule_prediction_file = EnkfPrototype("void enkf_main_set_schedule_prediction_file( enkf_main , char*)")
     _get_data_kw = EnkfPrototype("subst_list_ref enkf_main_get_data_kw(enkf_main)")
@@ -187,10 +186,6 @@ class EnKFMain(BaseCClass):
     def plotConfig(self):
         """ @rtype: PlotConfig """
         return self._get_plot_config( ).setParent(self)
-
-    def set_datafile(self, datafile):
-        self._set_datafile(datafile)
-
 
     def get_schedule_prediction_file(self):
         schedule_prediction_file = self._get_schedule_prediction_file( )


### PR DESCRIPTION
**Task**
-Continuing the work of https://github.com/Statoil/libres/pull/10, https://github.com/Statoil/libres/pull/14, and https://github.com/Statoil/libres/pull/27 extracting the loading of a res configuration from enkf_main.

The following configurations are moved into res_config:

- hook_manager,
- templates_config,
- plot_config,
- ecl_config,
- ensemble_config and
- model_config.

In addition I've removed the obsolete possibility of substituting in random numbers with a substitution_list and ensembles config loads PRED directly from the configuration files.

enkf_main still loads some configurations from the model_config. Removing this will be the work of a final PR completing this series of configuration PR's.

**Approach**
_Divide and conquer!_


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps
