### PR TITLE
Centralized logstash logging from python, part 1

### DIFF
--- a/libjob_queue/src/forward_model.c
+++ b/libjob_queue/src/forward_model.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <unistd.h>
 
 #include <ert/util/util.h>
 #include <ert/util/subst_list.h>
@@ -236,8 +237,9 @@ static void forward_model_json_fprintf(const forward_model_type * forward_model,
   }
   fprintf(stream, "],\n");
 
-  fprintf(stream, "\"ert_version\" : [%d, %d, \"%s\"]\n", version_get_major_ert_version(), version_get_minor_ert_version(), version_get_micro_ert_version());
-
+  fprintf(stream, "\n\"ert_version\" : [%d, %d, \"%s\"],\n", version_get_major_ert_version(), version_get_minor_ert_version(), version_get_micro_ert_version());
+  fprintf(stream, "\"simulation_id\" : \"%ld\",\n", random());
+  fprintf(stream, "\"ert_pid\" : \"%ld\"\n", getpid()); //Long is big enough to hold __pid_t
   fprintf(stream, "}\n");
   fclose(stream);
   free(json_file);


### PR DESCRIPTION
**Task**
Logging information from the *working nodes* to logstash.
This is an early test, just to get a feel for how it works

**Approach**
In this version we send explicit messages using the request library. In the future we might want to instead use the python logging framework with a HTTP or logstash backend. Then we outsource work, and can get logging to both logstash and local files. 

Currently I have only changed job_manager.py and not job_dispatcher.py, since the latter is in ertStatoil, and does not support to be deployed only to testers. But there is WIP to move job_dispatcher into libres, and then some of this code (particularly the LOG_URL) will come from there. And if we use the logging framework it makes sense to have it initialized in job_dispatcher, since it is the one calling job_manager. 

LOG_URL will clearly be changed to wherever we end up having logstash. 

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
