### PR TITLE
Remove Statoil specific site-config setting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ if (EXISTS ${STATOIL_TESTDATA_ROOT})
 endif()
 
 file(COPY bin/job_dispatch.py DESTINATION ${PROJECT_BINARY_DIR}/bin )
+set( ERT_ROOT "${PROJECT_BINARY_DIR}" )
 #-----------------------------------------------------------------
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ option( RST_DOC             "Build RST documentation"               OFF)
 option( USE_RUNPATH         "Should we embed path to libraries"     ON )
 option( INSTALL_ERT_LEGACY  "Install legacy ert code"               OFF)
 option( ERT_LSF_SUBMIT_TEST "Build and run tests of LSF submit"     OFF)
+set( SITE_CONFIG_FILE "${PROJECT_SOURCE_DIR}/share/site-config" CACHE FILEPATH "Path to global ERT Configuration file")
+
+
 
 if (USE_RUNPATH)
     SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
@@ -47,19 +50,6 @@ if (EXISTS ${STATOIL_TESTDATA_ROOT})
 
     execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${STATOIL_TESTDATA_ROOT}" "${LINK}")
     message(STATUS "Linking testdata: ${LINK} -> ${STATOIL_TESTDATA_ROOT}")
-endif()
-
-set(STATOIL_SITE_CONFIG /project/res/etc/ERT/site-config)
-if (STATOIL_TESTDATA_ROOT)
-    set(SITE_CONFIG_FILE ${STATOIL_SITE_CONFIG}
-            CACHE
-            FILEPATH "Path to global ERT Configuration file")
-else()
-    if (EXISTS ${STATOIL_SITE_CONFIG})
-        set(SITE_CONFIG_FILE ${STATOIL_SITE_CONFIG})
-    else()
-        set(SITE_CONFIG_FILE "${PROJECT_SOURCE_DIR}/share/site-config")
-    endif()
 endif()
 
 #-----------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ if (EXISTS ${STATOIL_TESTDATA_ROOT})
     message(STATUS "Linking testdata: ${LINK} -> ${STATOIL_TESTDATA_ROOT}")
 endif()
 
+file(COPY bin/job_dispatch.py DESTINATION ${PROJECT_BINARY_DIR}/bin )
 #-----------------------------------------------------------------
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -290,7 +290,7 @@ add_executable(enkf_ensemble_GEN_PARAM tests/enkf_ensemble_GEN_PARAM.c)
 target_link_libraries(enkf_ensemble_GEN_PARAM enkf)
 add_config_test(enkf_ensemble_GEN_PARAM
                 enkf_ensemble_GEN_PARAM
-                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/ensemble/GEN_PARAM)
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/ensemble/GEN_PARAM)
 
 if (NOT STATOIL_TESTDATA_ROOT)
     return ()

--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -161,6 +161,13 @@ function( add_config_test name command )
 endfunction()
 
 
+add_executable(enkf_magic_string_in_workflows tests/enkf_magic_string_in_workflows.c)
+target_link_libraries(enkf_magic_string_in_workflows enkf)
+add_config_test(enkf_magic_string_in_workflows
+                enkf_magic_string_in_workflows
+                ${CMAKE_SOURCE_DIR}/test-data/local/config/workflows/config)
+
+
 add_executable(enkf_main tests/enkf_main.c)
 target_link_libraries(enkf_main enkf)
 add_config_test(enkf_main
@@ -329,12 +336,6 @@ target_link_libraries(enkf_obs_fs enkf)
 add_statoil_test(enkf_obs_fs
                  enkf_obs_fs
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/obs_testing/config)
-
-add_executable(enkf_magic_string_in_workflows tests/enkf_magic_string_in_workflows.c)
-target_link_libraries(enkf_magic_string_in_workflows enkf)
-add_statoil_test(enkf_magic_string_in_workflows
-                 enkf_magic_string_in_workflows
-                 ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/with_data/config)
 
 add_executable(enkf_obs_vector_fs tests/enkf_obs_vector_fs.c)
 target_link_libraries(enkf_obs_vector_fs enkf)

--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -153,35 +153,43 @@ foreach (test   enkf_active_list
     add_test(NAME ${test} COMMAND ${test})
 endforeach ()
 
+function( add_config_test name command )
+    add_test( NAME ${name}
+              COMMAND ${command} ${ARGN})
+     
+    set_property( TEST ${name} PROPERTY ENVIRONMENT "ERT_ROOT=${ERT_ROOT}")
+endfunction()
+
+
 add_executable(enkf_main tests/enkf_main.c)
 target_link_libraries(enkf_main enkf)
-add_test(NAME enkf_main
-         COMMAND enkf_main
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config rng)
+add_config_test(enkf_main
+                enkf_main
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config rng)
 
 add_executable(enkf_runpath_list tests/enkf_runpath_list.c)
 target_link_libraries(enkf_runpath_list enkf)
-add_test(NAME enkf_runpath_list
-    COMMAND enkf_runpath_list
-            ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/runpath_list/config)
+add_config_test(enkf_runpath_list
+                enkf_runpath_list
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/runpath_list/config)
 
 add_executable(enkf_gen_obs_load tests/enkf_gen_obs_load.c)
 target_link_libraries(enkf_gen_obs_load enkf)
-add_test(NAME enkf_gen_obs_load
-         COMMAND enkf_gen_obs_load
-                 ${CMAKE_SOURCE_DIR}/test-data/local/config/gen_data/config)
+add_config_test(enkf_gen_obs_load
+                enkf_gen_obs_load
+                ${CMAKE_SOURCE_DIR}/test-data/local/config/gen_data/config)
 
 add_executable(enkf_ert_workflow_list tests/enkf_ert_workflow_list.c)
 target_link_libraries(enkf_ert_workflow_list enkf)
-add_test(NAME enkf_ert_workflow_list
-    COMMAND enkf_ert_workflow_list
-            ${CMAKE_SOURCE_DIR}/share/workflows/jobs/internal/config/SCALE_STD)
+add_config_test(enkf_ert_workflow_list
+                enkf_ert_workflow_list
+                ${CMAKE_SOURCE_DIR}/share/workflows/jobs/internal/config/SCALE_STD)
 
 add_executable(enkf_analysis_config_analysis_load tests/enkf_analysis_config_analysis_load.c)
 target_link_libraries(enkf_analysis_config_analysis_load enkf)
-add_test(NAME enkf_analysis_config_analysis_load
-         COMMAND enkf_analysis_config_analysis_load
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/analysis_load_config)
+add_config_test(enkf_analysis_config_analysis_load
+                enkf_analysis_config_analysis_load
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/analysis_load_config)
 
 # It seems necessary to set the LD_LIBRARY_PATH for the loading of the
 # rml_enkf module to work.  Do understand why!
@@ -191,98 +199,98 @@ set_property(TEST enkf_analysis_config_analysis_load PROPERTY
 
 add_executable(enkf_workflow_job_test_version tests/enkf_workflow_job_test_version.c)
 target_link_libraries(enkf_workflow_job_test_version enkf)
-add_test(NAME enkf_workflow_job_test_version
-         COMMAND enkf_workflow_job_test_version
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/workflow_jobs)
+add_config_test(enkf_workflow_job_test_version
+                enkf_workflow_job_test_version
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/workflow_jobs)
 
 add_executable(enkf_ert_test_context tests/enkf_ert_test_context.c)
 target_link_libraries(enkf_ert_test_context enkf)
-add_test(NAME enkf_ert_test_context
-         COMMAND enkf_ert_test_context
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/test_context/config
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/test_context/wf_job
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/test_context/wf_job_fail)
+add_config_test(enkf_ert_test_context
+                enkf_ert_test_context
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/test_context/config
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/test_context/wf_job
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/test_context/wf_job_fail)
 
 add_executable(enkf_plot_gen_kw_fs tests/enkf_plot_gen_kw_fs.c)
 target_link_libraries(enkf_plot_gen_kw_fs enkf )
-add_test(NAME enkf_plot_gen_kw_fs
-         COMMAND enkf_plot_gen_kw_fs
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/gen_kw_plot/config)
+add_config_test(enkf_plot_gen_kw_fs
+                enkf_plot_gen_kw_fs
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/gen_kw_plot/config)
 
 add_executable(gen_kw_test tests/gen_kw_test.c)
 target_link_libraries(gen_kw_test enkf)
-add_test(NAME gen_kw_test
-         COMMAND gen_kw_test
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/forward/ert/config_GEN_KW_true)
+add_config_test(gen_kw_test
+                gen_kw_test
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/forward/ert/config_GEN_KW_true)
 
 
 add_executable(gen_kw_logarithmic_test tests/gen_kw_logarithmic_test.c)
 target_link_libraries(gen_kw_logarithmic_test enkf)
-add_test(NAME gen_kw_logarithmic_test
-         COMMAND gen_kw_logarithmic_test
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/gen_kw_logarithmic/config_GEN_KW_logarithmic)
+add_config_test(gen_kw_logarithmic_test
+                gen_kw_logarithmic_test
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/gen_kw_logarithmic/config_GEN_KW_logarithmic)
 
 add_executable(enkf_forward_init_GEN_KW tests/enkf_forward_init_GEN_KW.c)
 target_link_libraries(enkf_forward_init_GEN_KW enkf)
-add_test(NAME enkf_forward_init_GEN_KW_TRUE
-         COMMAND enkf_forward_init_GEN_KW
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/forward/ert
-                 config_GEN_KW_true
-                 TRUE)
+add_config_test(enkf_forward_init_GEN_KW_TRUE
+                enkf_forward_init_GEN_KW
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/forward/ert
+                config_GEN_KW_true
+                TRUE)
 
-add_test(NAME enkf_forward_init_GEN_KW_FALSE
-         COMMAND enkf_forward_init_GEN_KW
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/forward/ert
-                 config_GEN_KW_false
-                 FALSE)
+add_config_test(enkf_forward_init_GEN_KW_FALSE
+                enkf_forward_init_GEN_KW
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/forward/ert
+                config_GEN_KW_false
+                FALSE)
 
 
 add_executable(enkf_select_case_job tests/enkf_select_case_job.c)
 target_link_libraries(enkf_select_case_job enkf)
-add_test(NAME enkf_select_case_job
-         COMMAND enkf_select_case_job
-                 ${CMAKE_SOURCE_DIR}/test-data/local/snake_oil/snake_oil.ert
-                 ${CMAKE_SOURCE_DIR}/share/workflows/jobs/internal-tui/config/SELECT_CASE)
+add_config_test(enkf_select_case_job
+                enkf_select_case_job
+                ${CMAKE_SOURCE_DIR}/test-data/local/snake_oil/snake_oil.ert
+                ${CMAKE_SOURCE_DIR}/share/workflows/jobs/internal-tui/config/SELECT_CASE)
 
 
 add_executable(enkf_forward_init_GEN_PARAM tests/enkf_forward_init_GEN_PARAM.c)
 target_link_libraries(enkf_forward_init_GEN_PARAM enkf)
 
-add_test(NAME enkf_forward_init_GEN_PARAM_TRUE
-              COMMAND enkf_forward_init_GEN_PARAM
-              ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/forward/ert
-              config_GEN_PARAM_true
-              TRUE)
+add_config_test(enkf_forward_init_GEN_PARAM_TRUE
+                enkf_forward_init_GEN_PARAM
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/forward/ert
+                config_GEN_PARAM_true
+                TRUE)
 
-add_test(NAME enkf_forward_init_GEN_PARAM_FALSE
-         COMMAND enkf_forward_init_GEN_PARAM
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/forward/ert
-                 config_GEN_PARAM_false
-                 FALSE)
+add_config_test(enkf_forward_init_GEN_PARAM_FALSE
+                enkf_forward_init_GEN_PARAM
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/forward/ert
+                config_GEN_PARAM_false
+                FALSE)
 
 add_executable(enkf_umask_config_test tests/enkf_umask_config_test.c)
 target_link_libraries(enkf_umask_config_test enkf)
-add_test(NAME enkf_umask_config_test
-         COMMAND enkf_umask_config_test
-                 ${CMAKE_SOURCE_DIR}/test-data/local/simple_config/config_umask)
+add_config_test(enkf_umask_config_test
+                enkf_umask_config_test
+                ${CMAKE_SOURCE_DIR}/test-data/local/simple_config/config_umask)
 
 add_executable(enkf_rng tests/enkf_rng.c)
 target_link_libraries(enkf_rng enkf)
-add_test(NAME enkf_rng
-         COMMAND enkf_rng ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config rng)
+add_config_test(enkf_rng
+                enkf_rng ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config rng)
 
 add_executable(enkf_forward_load_context tests/enkf_forward_load_context.c)
 target_link_libraries(enkf_forward_load_context enkf)
-add_test(NAME enkf_forward_load_context
-         COMMAND enkf_forward_load_context
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config
-                 forward_load_context)
+add_config_test(enkf_forward_load_context
+                enkf_forward_load_context
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config
+                forward_load_context)
 
 add_executable(enkf_ensemble_GEN_PARAM tests/enkf_ensemble_GEN_PARAM.c)
 target_link_libraries(enkf_ensemble_GEN_PARAM enkf)
-add_test(NAME enkf_ensemble_GEN_PARAM
-         COMMAND enkf_ensemble_GEN_PARAM
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/ensemble/GEN_PARAM)
+add_config_test(enkf_ensemble_GEN_PARAM
+                enkf_ensemble_GEN_PARAM
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/config/ensemble/GEN_PARAM)
 
 if (NOT STATOIL_TESTDATA_ROOT)
     return ()

--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -288,53 +288,62 @@ if (NOT STATOIL_TESTDATA_ROOT)
     return ()
 endif ()
 
+
+function( add_statoil_test name command )
+    add_test( NAME ${name}
+              COMMAND ${command} ${ARGN})
+     
+    set_property( TEST ${name} PROPERTY LABELS StatoilData)
+endfunction()
+              
+
 add_executable(enkf_site_config tests/enkf_site_config.c)
 target_link_libraries(enkf_site_config enkf)
-add_test(NAME enkf_site_config
-         COMMAND enkf_site_config /project/res/etc/ERT/site-config)
+add_statoil_test(enkf_site_config
+                 enkf_site_config /project/res/etc/ERT/site-config)
 
 add_executable(enkf_gen_data_config tests/enkf_gen_data_config.c)
 target_link_libraries(enkf_gen_data_config enkf)
-add_test(NAME enkf_gen_data_config
-         COMMAND enkf_gen_data_config
+add_statoil_test(enkf_gen_data_config
+                 enkf_gen_data_config
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/gendata_test/RFT_E-3H_21
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/gendata_test/RFT_E-3H_21_empty)
 
 add_executable(enkf_block_obs tests/enkf_block_obs.c)
 target_link_libraries(enkf_block_obs enkf)
-add_test(NAME enkf_block_obs
-         COMMAND enkf_block_obs
+add_statoil_test(enkf_block_obs
+                 enkf_block_obs
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Gurbat/ECLIPSE.EGRID)
 
 add_executable(enkf_obs_fs tests/enkf_obs_fs.c)
 target_link_libraries(enkf_obs_fs enkf)
-add_test(NAME enkf_obs_fs
-         COMMAND enkf_obs_fs
+add_statoil_test(enkf_obs_fs
+                 enkf_obs_fs
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/obs_testing/config)
 
 add_executable(enkf_magic_string_in_workflows tests/enkf_magic_string_in_workflows.c)
 target_link_libraries(enkf_magic_string_in_workflows enkf)
-add_test(NAME enkf_magic_string_in_workflows
-         COMMAND enkf_magic_string_in_workflows
+add_statoil_test(enkf_magic_string_in_workflows
+                 enkf_magic_string_in_workflows
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/with_data/config)
 
 add_executable(enkf_obs_vector_fs tests/enkf_obs_vector_fs.c)
 target_link_libraries(enkf_obs_vector_fs enkf)
-add_test(NAME enkf_obs_vector_fs
-         COMMAND enkf_obs_vector_fs
+add_statoil_test(enkf_obs_vector_fs
+                 enkf_obs_vector_fs
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/obs_testing/config)
 
 add_executable(enkf_plot_data_fs tests/enkf_plot_data_fs.c)
 target_link_libraries(enkf_plot_data_fs enkf)
-add_test(NAME enkf_plot_data_fs
-         COMMAND enkf_plot_data_fs
+add_statoil_test(enkf_plot_data_fs
+                 enkf_plot_data_fs
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/plotData/config)
 
 add_executable(enkf_time_map tests/enkf_time_map.c)
 target_link_libraries(enkf_time_map enkf)
-add_test(NAME enkf_time_map1 COMMAND enkf_time_map)
-add_test(NAME enkf_time_map2
-         COMMAND enkf_time_map
+add_statoil_test(enkf_time_map1 enkf_time_map)
+        add_statoil_test(enkf_time_map2
+                 enkf_time_map
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Gurbat/ECLIPSE
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/ECLIPSE/ModifiedSummary/EXTRA_TSTEP
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/ECLIPSE/ModifiedSummary/SHORT
@@ -342,68 +351,68 @@ add_test(NAME enkf_time_map2
 
 add_executable(enkf_main_fs tests/enkf_main_fs.c)
 target_link_libraries(enkf_main_fs enkf)
-add_test(NAME enkf_main_fs
-         COMMAND enkf_main_fs
+add_statoil_test(enkf_main_fs
+                 enkf_main_fs
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/plotData/config)
 
 add_executable(enkf_main_fs_current_file_test tests/enkf_main_fs_current_file_test.c)
 target_link_libraries(enkf_main_fs_current_file_test enkf)
-add_test(NAME enkf_main_fs_current_file_test
-         COMMAND enkf_main_fs_current_file_test
+add_statoil_test(enkf_main_fs_current_file_test
+                 enkf_main_fs_current_file_test
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/plotData/config)
 
 add_executable(enkf_scale_correlated_std tests/enkf_scale_correlated_std.c)
 target_link_libraries(enkf_scale_correlated_std enkf)
-add_test(NAME enkf_scale_correlated_std
-         COMMAND enkf_scale_correlated_std
+add_statoil_test(enkf_scale_correlated_std
+                 enkf_scale_correlated_std
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/with_data/config
                  ${CMAKE_SOURCE_DIR}/share/workflows/jobs/internal/config/STD_SCALE_CORRELATED_OBS)
 
 add_executable(enkf_plot_gendata_fs tests/enkf_plot_gendata_fs.c)
 target_link_libraries(enkf_plot_gendata_fs  enkf)
-add_test(NAME enkf_plot_gendata_fs
-         COMMAND enkf_plot_gendata_fs
+add_statoil_test(enkf_plot_gendata_fs
+                 enkf_plot_gendata_fs
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/with_GEN_DATA/config)
 
 add_executable(enkf_state_report_step_compatible
                tests/enkf_state_report_step_compatible.c)
 target_link_libraries(enkf_state_report_step_compatible  enkf)
-add_test(NAME enkf_state_report_step_compatible_TRUE
-         COMMAND enkf_state_report_step_compatible
+add_statoil_test(enkf_state_report_step_compatible_TRUE
+                 enkf_state_report_step_compatible
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/ecl_sum_compatible_true
                  config_ecl_sum_compatible_true
                  TRUE)
 
-add_test(NAME enkf_state_report_step_compatible_FALSE
-         COMMAND enkf_state_report_step_compatible
+add_statoil_test(enkf_state_report_step_compatible_FALSE
+                 enkf_state_report_step_compatible
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/ecl_sum_compatible_false
                  config_ecl_sum_compatible_false
                  FALSE)
 
 add_executable(enkf_state_manual_load_test tests/enkf_state_manual_load_test.c)
 target_link_libraries(enkf_state_manual_load_test enkf)
-add_test(NAME enkf_state_manual_load_test
-         COMMAND enkf_state_manual_load_test
+add_statoil_test(enkf_state_manual_load_test
+                 enkf_state_manual_load_test
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/ecl_sum_compatible_true
                  config_ecl_sum_compatible_true)
 
 add_executable(enkf_state_skip_summary_load_test tests/enkf_state_skip_summary_load_test.c)
 target_link_libraries(enkf_state_skip_summary_load_test enkf)
 
-add_test(NAME enkf_state_summary_vars_present
-         COMMAND enkf_state_skip_summary_load_test
+add_statoil_test(enkf_state_summary_vars_present
+                 enkf_state_skip_summary_load_test
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/ecl_summary_vars_config
                  config_summary_vars)
 
-add_test(NAME enkf_state_no_summary_vars_present
-         COMMAND enkf_state_skip_summary_load_test
+add_statoil_test(enkf_state_no_summary_vars_present
+                 enkf_state_skip_summary_load_test
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/ecl_no_summary_vars_config
                  config_no_summary_vars)
 
 add_executable(enkf_export_field_test tests/enkf_export_field_test.c)
 target_link_libraries(enkf_export_field_test enkf)
-add_test(NAME enkf_export_field_test
-         COMMAND enkf_export_field_test
+add_statoil_test(enkf_export_field_test
+                 enkf_export_field_test
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/export_fields/config
                  ${CMAKE_SOURCE_DIR}/share/workflows/jobs/internal/config/EXPORT_FIELD
                  ${CMAKE_SOURCE_DIR}/share/workflows/jobs/internal/config/EXPORT_FIELD_ECL_GRDECL
@@ -411,8 +420,8 @@ add_test(NAME enkf_export_field_test
 
 add_executable(enkf_workflow_job_test tests/enkf_workflow_job_test.c)
 target_link_libraries(enkf_workflow_job_test enkf)
-add_test(NAME enkf_workflow_job_test
-         COMMAND enkf_workflow_job_test
+add_statoil_test(enkf_workflow_job_test
+                 enkf_workflow_job_test
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/with_data/config
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/enkf_state_runpath/config_runpath_multiple_iterations
                  ${CMAKE_SOURCE_DIR}/share/workflows/jobs/internal-tui/config/CREATE_CASE
@@ -427,74 +436,74 @@ add_test(NAME enkf_workflow_job_test
 
 add_executable(enkf_forward_init_SURFACE tests/enkf_forward_init_SURFACE.c)
 target_link_libraries(enkf_forward_init_SURFACE enkf)
-add_test(NAME enkf_forward_init_SURFACE_TRUE
-         COMMAND enkf_forward_init_SURFACE
+add_statoil_test(enkf_forward_init_SURFACE_TRUE
+                 enkf_forward_init_SURFACE
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/forward_init/surface config_surface_true
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/forward_init/surface/Surface.irap
                  TRUE)
 
-add_test(NAME enkf_forward_init_SURFACE_FALSE
-         COMMAND enkf_forward_init_SURFACE
+add_statoil_test(enkf_forward_init_SURFACE_FALSE
+                 enkf_forward_init_SURFACE
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/forward_init/surface config_surface_false
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/forward_init/surface/Surface.irap
                  FALSE)
 
 add_executable(enkf_forward_init_FIELD tests/enkf_forward_init_FIELD.c)
 target_link_libraries(enkf_forward_init_FIELD enkf)
-add_test(NAME enkf_forward_init_FIELD_TRUE
-         COMMAND enkf_forward_init_FIELD
+add_statoil_test(enkf_forward_init_FIELD_TRUE
+                 enkf_forward_init_FIELD
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/forward_init/field config_field_true
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/forward_init/field/petro.grdecl
                  TRUE)
 
-add_test(NAME enkf_forward_init_FIELD_FALSE
-         COMMAND enkf_forward_init_FIELD
+add_statoil_test(enkf_forward_init_FIELD_FALSE
+                 enkf_forward_init_FIELD
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/forward_init/field config_field_false
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/forward_init/field/petro.grdecl
                  FALSE)
 
 add_executable(enkf_forward_init_transform tests/enkf_forward_init_transform.c)
 target_link_libraries(enkf_forward_init_transform enkf)
-add_test(NAME enkf_forward_init_transform_TRUE
-         COMMAND enkf_forward_init_transform
+add_statoil_test(enkf_forward_init_transform_TRUE
+                 enkf_forward_init_transform
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/transform transform_forward_init_true
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/transform/petro.grdecl
                  TRUE)
 
-add_test(NAME enkf_forward_init_transform_FALSE
-         COMMAND enkf_forward_init_transform
+add_statoil_test(enkf_forward_init_transform_FALSE
+                 enkf_forward_init_transform
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/transform transform_forward_init_false
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/transform/petro.grdecl
                  FALSE)
 
 add_executable(enkf_export_inactive_cells tests/enkf_export_inactive_cells.c)
 target_link_libraries(enkf_export_inactive_cells enkf)
-add_test(NAME enkf_export_inactive_cells
-         COMMAND enkf_export_inactive_cells
+add_statoil_test(enkf_export_inactive_cells
+                 enkf_export_inactive_cells
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/export_inactive_cells/config
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/export_inactive_cells/petro.grdecl)
 
 add_executable(enkf_refcase_list tests/enkf_refcase_list.c)
 target_link_libraries(enkf_refcase_list enkf)
-add_test(NAME enkf_refcase_list
-         COMMAND enkf_refcase_list
+add_statoil_test(enkf_refcase_list
+                 enkf_refcase_list
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Gurbat/ECLIPSE
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Gurbat*/ECLIPSE)
 
-add_test(NAME enkf_refcase_list2
-         COMMAND enkf_refcase_list
+add_statoil_test(enkf_refcase_list2
+                 enkf_refcase_list
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Gurbat/ECLIPSE
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Gurbat*/ECLIPSE.*)
 
 add_executable(enkf_ecl_config tests/enkf_ecl_config.c)
 target_link_libraries(enkf_ecl_config enkf)
-add_test(NAME enkf_ecl_config1 COMMAND enkf_ecl_config)
-add_test(NAME enkf_ecl_config2
-         COMMAND enkf_ecl_config
+add_statoil_test(enkf_ecl_config1 enkf_ecl_config)
+        add_statoil_test(enkf_ecl_config2
+                 enkf_ecl_config
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/ECLIPSE/Gurbat/ECLIPSE)
 
 add_executable(enkf_ecl_config_config tests/enkf_ecl_config_config.c)
 target_link_libraries(enkf_ecl_config_config enkf)
-add_test(NAME enkf_ecl_config_config
-         COMMAND enkf_ecl_config_config
+add_statoil_test(enkf_ecl_config_config
+                 enkf_ecl_config_config
                  ${CMAKE_SOURCE_DIR}/test-data/Statoil/config/ecl_config)

--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -294,6 +294,7 @@ function( add_statoil_test name command )
               COMMAND ${command} ${ARGN})
      
     set_property( TEST ${name} PROPERTY LABELS StatoilData)
+    set_property( TEST ${name} PROPERTY ENVIRONMENT "ERT_ROOT=${ERT_ROOT}")
 endfunction()
               
 

--- a/libenkf/tests/enkf_ensemble_GEN_PARAM.c
+++ b/libenkf/tests/enkf_ensemble_GEN_PARAM.c
@@ -48,6 +48,11 @@ int main(int argc , char ** argv) {
   enkf_config_node_add_GEN_PARAM_config_schema( config );
 
   content = config_parse( config , config_file , "--" , NULL , NULL , NULL , CONFIG_UNRECOGNIZED_WARN , true );
+  {
+    config_error_type * errors = config_content_get_errors( content );
+    config_error_fprintf( errors , true , stdout );
+  }
+
   test_assert_true( config_content_is_valid( content ) );
 
   ensemble_config_init_GEN_PARAM( ensemble, content );

--- a/test-data/local/config/workflows/config
+++ b/test-data/local/config/workflows/config
@@ -1,0 +1,10 @@
+DEFINE                    __NAME__           EXAMPLE_01_BASE 
+DEFINE                    __GRID__           __NAME__.EGRID
+DEFINE                    MULTIR_FILE        MULTIR.INC
+
+
+DEFINE                    __MAGIC__         MagicAllTheWayToWorkFlow
+NUM_REALIZATIONS  25
+LOAD_WORKFLOW_JOB workflowjobs/MAGIC_PRINT  
+LOAD_WORKFLOW     workflows/MAGIC_PRINT
+DATA_KW      <INCLUDE_PATH>       $PWD/include

--- a/test-data/local/config/workflows/workflowjobs/MAGIC_PRINT
+++ b/test-data/local/config/workflows/workflowjobs/MAGIC_PRINT
@@ -1,0 +1,3 @@
+INTERNAL   False
+EXECUTABLE bin/magic_print.py
+MIN_ARG 1

--- a/test-data/local/config/workflows/workflowjobs/bin/magic_print.py
+++ b/test-data/local/config/workflows/workflowjobs/bin/magic_print.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import sys
+fileH = open(sys.argv[1] , "w")
+for arg in sys.argv[2:]:
+    fileH.write("%s\n" % arg)
+fileH.close()
+
+

--- a/test-data/local/config/workflows/workflows/MAGIC_PRINT
+++ b/test-data/local/config/workflows/workflows/MAGIC_PRINT
@@ -1,0 +1,1 @@
+MAGIC_PRINT  magic-list.txt  <ERTCASE>  __MAGIC__


### PR DESCRIPTION
**Task**
The build system will "compile in" the default path to a site-config file. That would previously check for a Statoil specific file - that Statoil-ism has been removed. 

If this is merged we must pass `-DSITE_CONFIG_FILE=/path/to/statoil/site-config` when building for deploy.

**Approach**
Minor updates in root CMakeLists.txt


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps


