### PR TITLE
Disable proxy for centralized logging

### DIFF
--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -344,9 +344,14 @@ class JobManager(object):
                 sys.stderr.flush()
             else:
                 data = json.dumps(payload)
+                #Disabling proxies
+                proxies = {
+                    "http": None,
+                    "https": None,
+                }
                 res = requests.post(url, timeout=3,
                               headers={"Content-Type": "application/json"},
-                              data=data)
+                                    data=data,proxies=proxies)
                 # sys.stdout.write("Response status %s\n"%res.status_code)
                 # sys.stdout.write("Request url %s\n"%res.url)
                 # sys.stdout.write("Response headers %s\n"%res.headers)


### PR DESCRIPTION
**Task**
By default every http request out of Statoil machines go through a proxy. There is no reason for putting that load on the proxy when the log requests are going to an internal server anyway, so here we tell python to ignore the proxy directives given in the environment. 


**Approach**



**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps