### PR TITLE
Add repr for JobManager, debug purposes

### DIFF
--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -191,6 +191,17 @@ class JobManager(object):
     def __len__(self):
         return len(self.job_list)
 
+    def __repr__(self):
+        st = self.start_time
+        fs = self.file_server
+        is_node = self.isilon_node
+        fu = self.fs_use
+        node = self.node
+        us = self.user
+        cnt = 'len=%d, start=%s, file_server=%s, fs_use=%s, node=%s, isilon_node=%s, user=%s'
+        cnt = cnt % (len(self), st, fs, fu, node, is_node, us)
+        return 'JobManager(%s)' % cnt
+
 
     def __getitem__(self, index):
         if isinstance(index, int):

--- a/python/tests/res/job_queue/test_jobmanager.py
+++ b/python/tests/res/job_queue/test_jobmanager.py
@@ -88,6 +88,15 @@ class JobManagerTest(TestCase):
                 jobm = JobManager(module_file="Does/not/exist",
                                   json_file="Neither/does/this/one")
 
+    def test_repr(self):
+        with TestAreaContext("jobman_repr"):
+            self.assert_clean_slate()
+            create_jobs_json([{'name' : 'COPY_FILE', 'executable' : 'XYZ'}])
+            jobm = JobManager()
+            self.assertIn('len=1', repr(jobm))
+            self.assertTrue(repr(jobm).startswith('JobManager('))
+
+
     def test_invalid_jobs_json(self):
         with TestAreaContext("invalid_jobs_json"):
             self.assert_clean_slate()


### PR DESCRIPTION
**Task**
During debugging of some jobs, we needed to runtime inspect a job manager.


**Approach**
Implemented a `repr` function for job manager to expose number of jobs and some other fields.

Added unit tests for the `repr` function as well.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps