### PR TITLE
Move all runpath configurations to model_config

### DIFF
--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(enkf src/active_list.c
                  src/surface_config.c
                  src/trans_func.c
                  src/subst_config.c
+                 src/log_config.c
 )
 
 target_include_directories(enkf

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -142,6 +142,7 @@ extern "C" {
   enkf_obs_type               * enkf_main_get_obs(const enkf_main_type * );
   bool                          enkf_main_have_obs( const enkf_main_type * enkf_main );
   const analysis_config_type  * enkf_main_get_analysis_config(const enkf_main_type * );
+  const log_config_type       * enkf_main_get_log_config(const enkf_main_type *);
 
   void       * enkf_main_get_enkf_config_node_type(const ensemble_config_type *, const char *);
   void         enkf_main_set_field_config_iactive(const ensemble_config_type *, int);

--- a/libenkf/include/ert/enkf/log_config.h
+++ b/libenkf/include/ert/enkf/log_config.h
@@ -1,0 +1,32 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   The file 'log_config.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#ifndef ERT_LOG_CONFIG_H
+#define ERT_LOG_CONFIG_H
+
+#include <ert/util/log.h>
+
+typedef struct log_config_struct log_config_type;
+
+log_config_type * log_config_alloc_load(const char *);
+void              log_config_free(log_config_type *);
+
+const char *             log_config_get_log_file(const log_config_type *);
+const message_level_type log_config_get_log_level(const log_config_type *);
+
+#endif

--- a/libenkf/include/ert/enkf/model_config.h
+++ b/libenkf/include/ert/enkf/model_config.h
@@ -68,6 +68,7 @@ extern "C" {
   void                   model_config_init(model_config_type * model_config , const config_content_type * , int ens_size , const ext_joblist_type * , int , const sched_file_type * , const ecl_sum_type * refcase);
   void                   model_config_free(model_config_type *);
   bool                   model_config_runpath_requires_iter( const model_config_type * model_config );
+  bool                   model_config_get_pre_clear_runpath(const model_config_type * model_config);
   path_fmt_type        * model_config_get_runpath_fmt(const model_config_type * );
   history_type         * model_config_get_history(const model_config_type * );
   forward_model_type   * model_config_get_forward_model( const model_config_type * );

--- a/libenkf/include/ert/enkf/model_config.h
+++ b/libenkf/include/ert/enkf/model_config.h
@@ -70,6 +70,7 @@ extern "C" {
   bool                   model_config_runpath_requires_iter( const model_config_type * model_config );
   bool                   model_config_get_pre_clear_runpath(const model_config_type * model_config);
   path_fmt_type        * model_config_get_runpath_fmt(const model_config_type * );
+  int                    model_config_iget_keep_runpath(const model_config_type * model_config, const size_t iens);
   history_type         * model_config_get_history(const model_config_type * );
   forward_model_type   * model_config_get_forward_model( const model_config_type * );
   bool                   model_config_internalize_state( const model_config_type *, int );

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -34,6 +34,7 @@
 #include <ert/enkf/ecl_config.h>
 #include <ert/enkf/ensemble_config.h>
 #include <ert/enkf/model_config.h>
+#include <ert/enkf/log_config.h>
 
 typedef struct res_config_struct res_config_type;
 
@@ -51,6 +52,7 @@ const config_settings_type   * res_config_get_plot_config(const res_config_type 
 const ecl_config_type        * res_config_get_ecl_config(const res_config_type * res_config);
 ensemble_config_type         * res_config_get_ensemble_config(const res_config_type * res_config);
 model_config_type            * res_config_get_model_config(const res_config_type * res_config);
+const log_config_type        * res_config_get_log_config(const res_config_type * res_config);
 
 const char * res_config_get_working_directory(const res_config_type *);
 const char * res_config_get_user_config_file(const res_config_type *);

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -235,6 +235,10 @@ const res_config_type * enkf_main_get_res_config(const enkf_main_type * enkf_mai
   return enkf_main->res_config;
 }
 
+const log_config_type * enkf_main_get_log_config(const enkf_main_type * enkf_main) {
+  return res_config_get_log_config(enkf_main->res_config);
+}
+
 subst_config_type * enkf_main_get_subst_config(const enkf_main_type * enkf_main) {
   return res_config_get_subst_config(enkf_main->res_config);
 }
@@ -2087,17 +2091,13 @@ static char * enkf_main_alloc_model_config_filename(const char * model_config) {
   return rel_model_config;
 }
 
-static void enkf_main_init_log(
-        const enkf_main_type * enkf_main,
-        const config_content_type * content) {
-  char * log_file=NULL;
-  if (config_content_has_item( content , LOG_FILE_KEY))
-    log_file = util_alloc_string_copy( config_content_get_value(content , LOG_FILE_KEY));
-  if(config_content_has_item( content , LOG_LEVEL_KEY))
-    res_log_init_log(res_log_level_parser(config_content_get_value(content , LOG_LEVEL_KEY)), log_file ,  enkf_main->verbose);
-  else
-    res_log_init_log_default_log_level(log_file ,  enkf_main->verbose);
-  free( log_file );
+static void enkf_main_init_log(const enkf_main_type * enkf_main) {
+  const log_config_type * log_config = enkf_main_get_log_config(enkf_main);
+  res_log_init_log(
+          log_config_get_log_level(log_config),
+          log_config_get_log_file(log_config),
+          enkf_main->verbose
+          );
 }
 
 
@@ -2174,8 +2174,6 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
   config_parser_type * config = config_alloc();
   config_content_type * content = model_config_alloc_content(enkf_main->user_config_file, config);
 
-  enkf_main_init_log(enkf_main, content);
-
   enkf_main_init_delete_runpath(enkf_main, content);
 
   enkf_main_init_pre_clear_runpath(enkf_main, content);
@@ -2244,6 +2242,8 @@ enkf_main_type * enkf_main_alloc(const char * model_config, const res_config_typ
   enkf_main_rng_init( enkf_main );
 
   enkf_main_set_verbose(enkf_main, verbose);
+
+  enkf_main_init_log(enkf_main);
 
   char * user_config_file = enkf_main_alloc_model_config_filename(model_config);
   if(user_config_file) {

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -153,8 +153,6 @@ struct enkf_main_struct {
   rng_type               * rng;
   ranking_table_type     * ranking_table;
 
-  int_vector_type        * keep_runpath;       /* HACK: This is only used in the initialization period - afterwards the data is held by the enkf_state object. */
-
   char                   * user_config_file;
   char                   * rft_config_file;       /* File giving the configuration to the RFTwells*/
   enkf_obs_type          * obs;
@@ -333,8 +331,6 @@ void enkf_main_free(enkf_main_type * enkf_main){
   res_log_close();
 
   local_config_free( enkf_main->local_config );
-
-  int_vector_free( enkf_main->keep_runpath );
 
   util_safe_free( enkf_main->user_config_file );
   util_safe_free( enkf_main->rft_config_file );
@@ -1913,31 +1909,6 @@ bool enkf_main_get_verbose( const enkf_main_type * enkf_main ) {
   return enkf_main->verbose;
 }
 
-/**
-   Observe that this function parses and TEMPORARILY stores the keep_runpath
-   information ion the enkf_main object. This is subsequently passed on the
-   enkf_state members, and the functions enkf_main_iget_keep_runpath() and
-   enkf_main_iset_keep_runpath() act on the enkf_state objects, and not on the
-   internal keep_runpath field of the enkf_main object (what a fxxxing mess).
-*/
-
-
-void enkf_main_parse_keep_runpath(enkf_main_type * enkf_main , const char * delete_runpath_string , int ens_size ) {
-
-  int i;
-  for (i = 0; i < ens_size; i++)
-    int_vector_iset( enkf_main->keep_runpath , i , DEFAULT_KEEP);
-
-  {
-    int_vector_type * active_list = string_util_alloc_active_list(delete_runpath_string);
-
-    for (i = 0; i < int_vector_size( active_list ); i++)
-      int_vector_iset( enkf_main->keep_runpath , int_vector_iget( active_list , i ) , EXPLICIT_DELETE);
-
-    int_vector_free( active_list );
-  }
-}
-
 
 
 /**
@@ -1968,7 +1939,6 @@ static enkf_main_type * enkf_main_alloc_empty( ) {
   enkf_main->local_config       = NULL;
   enkf_main->rng                = NULL;
   enkf_main->ens_size           = 0;
-  enkf_main->keep_runpath       = int_vector_alloc( 0 , DEFAULT_KEEP );
   enkf_main->res_config         = NULL;
   enkf_main->ranking_table      = ranking_table_alloc( 0 );
   enkf_main->obs                = NULL;
@@ -2100,32 +2070,6 @@ static void enkf_main_init_log(const enkf_main_type * enkf_main) {
 }
 
 
-/**
-   By default the simulation directories are left intact when
-   the simulations re complete, but using the keyword
-   DELETE_RUNPATH you can request (some of) the directories to
-   be wiped after the simulations are complete.
-*/
-static void enkf_main_init_delete_runpath(
-                enkf_main_type * enkf_main,
-                const config_content_type * content) {
-
-  char * delete_runpath_string = NULL;
-  int ens_size = config_content_get_value_as_int(content, NUM_REALIZATIONS_KEY);
-
-  if (config_content_has_item(content, DELETE_RUNPATH_KEY))
-    delete_runpath_string = config_content_alloc_joined_string(
-                                                          content,
-                                                          DELETE_RUNPATH_KEY,
-                                                          ""
-                                                          );
-
-  enkf_main_parse_keep_runpath(enkf_main, delete_runpath_string, ens_size);
-
-  util_safe_free(delete_runpath_string);
-}
-
-
 static void enkf_main_init_rft_config(
                 enkf_main_type * enkf_main,
                 const config_content_type * content) {
@@ -2160,8 +2104,6 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
 
   config_parser_type * config = config_alloc();
   config_content_type * content = model_config_alloc_content(enkf_main->user_config_file, config);
-
-  enkf_main_init_delete_runpath(enkf_main, content);
 
   enkf_main_init_rft_config(enkf_main, content);
 

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -154,7 +154,6 @@ struct enkf_main_struct {
   ranking_table_type     * ranking_table;
 
   int_vector_type        * keep_runpath;       /* HACK: This is only used in the initialization period - afterwards the data is held by the enkf_state object. */
-  bool                     pre_clear_runpath;  /* HACK: This is only used in the initialization period - afterwards the data is held by the enkf_state object. */
 
   char                   * user_config_file;
   char                   * rft_config_file;       /* File giving the configuration to the RFTwells*/
@@ -2126,18 +2125,6 @@ static void enkf_main_init_delete_runpath(
   util_safe_free(delete_runpath_string);
 }
 
-static void enkf_main_init_pre_clear_runpath(
-                enkf_main_type * enkf_main,
-                const config_content_type * content) {
-
-  enkf_main->pre_clear_runpath = DEFAULT_PRE_CLEAR_RUNPATH;
-  if (config_content_has_item(content, PRE_CLEAR_RUNPATH_KEY))
-    enkf_main->pre_clear_runpath = config_content_get_value_as_bool(
-                                                         content,
-                                                         PRE_CLEAR_RUNPATH_KEY
-                                                         );
-}
-
 
 static void enkf_main_init_rft_config(
                 enkf_main_type * enkf_main,
@@ -2175,8 +2162,6 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
   config_content_type * content = model_config_alloc_content(enkf_main->user_config_file, config);
 
   enkf_main_init_delete_runpath(enkf_main, content);
-
-  enkf_main_init_pre_clear_runpath(enkf_main, content);
 
   enkf_main_init_rft_config(enkf_main, content);
 

--- a/libenkf/src/enkf_main_ensemble.c
+++ b/libenkf/src/enkf_main_ensemble.c
@@ -64,7 +64,7 @@ void enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size ) 
       enkf_main->ensemble[iens] = enkf_state_alloc(iens,
                                                    enkf_main->rng,
                                                    model_config_iget_casename(enkf_main_get_model_config(enkf_main), iens),
-                                                   enkf_main->pre_clear_runpath,
+                                                   model_config_get_pre_clear_runpath(enkf_main_get_model_config(enkf_main)),
                                                    int_vector_safe_iget(enkf_main->keep_runpath, iens),
                                                    enkf_main_get_model_config(enkf_main),
                                                    enkf_main_get_ensemble_config(enkf_main),

--- a/libenkf/src/enkf_main_ensemble.c
+++ b/libenkf/src/enkf_main_ensemble.c
@@ -57,16 +57,18 @@ void enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size ) 
     /*1: Grow the ensemble pointer. */
     enkf_main->ensemble = util_realloc(enkf_main->ensemble , new_ens_size * sizeof * enkf_main->ensemble );
 
+
     /*2: Allocate the new ensemble members. */
+    model_config_type * model_config = enkf_main_get_model_config(enkf_main);
     for (iens = enkf_main->ens_size; iens < new_ens_size; iens++)
 
       /* Observe that due to the initialization of the rng - this function is currently NOT thread safe. */
       enkf_main->ensemble[iens] = enkf_state_alloc(iens,
                                                    enkf_main->rng,
-                                                   model_config_iget_casename(enkf_main_get_model_config(enkf_main), iens),
-                                                   model_config_get_pre_clear_runpath(enkf_main_get_model_config(enkf_main)),
-                                                   int_vector_safe_iget(enkf_main->keep_runpath, iens),
-                                                   enkf_main_get_model_config(enkf_main),
+                                                   model_config_iget_casename(model_config, iens),
+                                                   model_config_get_pre_clear_runpath(model_config),
+                                                   model_config_iget_keep_runpath(model_config, iens),
+                                                   model_config,
                                                    enkf_main_get_ensemble_config(enkf_main),
                                                    enkf_main_get_site_config(enkf_main),
                                                    enkf_main_get_ecl_config(enkf_main),

--- a/libenkf/src/log_config.c
+++ b/libenkf/src/log_config.c
@@ -1,0 +1,177 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   The file 'log_config.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <ert/res_util/res_util_defaults.h>
+#include <ert/util/util.h>
+
+#include <ert/enkf/log_config.h>
+#include <ert/enkf/config_keys.h>
+#include <ert/enkf/model_config.h>
+
+struct log_config_struct {
+
+  char * log_file;
+  message_level_type message_level;
+
+};
+
+
+static void log_config_init(log_config_type *, const config_content_type *);
+
+
+static log_config_type * log_config_alloc_default() {
+  log_config_type * log_config = util_malloc(sizeof * log_config);
+
+  log_config->log_file = util_alloc_string_copy(DEFAULT_LOG_FILE);
+  log_config->message_level = DEFAULT_LOG_LEVEL;
+
+  return log_config;
+}
+
+
+log_config_type * log_config_alloc_load(const char * config_file) {
+  log_config_type * log_config = log_config_alloc_default();
+
+  if(config_file) {
+    config_parser_type * config = config_alloc();
+    config_content_type * content = model_config_alloc_content(config_file, config);
+
+    log_config_init(log_config, content);
+
+    config_content_free(content);
+    config_free(config);
+  }
+
+  return log_config;
+}
+
+
+const char * log_config_get_log_file(const log_config_type * log_config) {
+  return log_config->log_file;
+}
+
+
+const message_level_type log_config_get_log_level(
+        const log_config_type * log_config
+        ) {
+
+  return log_config->message_level;
+}
+
+
+static void log_config_set_log_file(
+        log_config_type * log_config,
+        const char * log_file
+        ) {
+
+  free(log_config->log_file);
+  log_config->log_file = util_alloc_string_copy(log_file);
+}
+
+
+/**
+ * This method parses the 'LOG_LEVEL_KEY' value according to the following
+ * rules:
+ *
+ * - If it is an integer 0 <= i <= 4 then it issues an deprecation warning and
+ *   uses the approximately correct enum of message_level_type.
+ *
+ * - If it is one of the strings CRITICAL, ERROR, WARNING, INFO, DEBUG it
+ *   returns the corresponding enum of message_level_type
+ *
+ * - Else it returns the DEFAULT_LOG_LEVEL
+ */
+static message_level_type log_config_level_parser(const char * level) {
+
+  typedef struct {
+    const char * log_keyword; // The keyword written in the config file
+    const char * log_old_numeric_str; // The *old* integer value
+    const message_level_type log_enum; // The enum for the new log-level
+  } log_tupple;
+
+  log_tupple log_levels[] = {
+          {"CRITICAL", "0", LOG_CRITICAL},
+          {"ERROR",    "1", LOG_ERROR},
+          {"WARNING",  "2", LOG_WARNING},
+          {"INFO",     "3", LOG_INFO},
+          {"DEBUG",    "4", LOG_DEBUG}};
+  const int nr_of_log_levels = 5;
+
+  for (int i = 0; i < nr_of_log_levels; i++) {
+    log_tupple curr_log_level = log_levels[i];
+
+    // We found a new proper name
+    if (strcmp(level, curr_log_level.log_keyword)==0)
+      return curr_log_level.log_enum;
+
+    // We found an old integer level
+    else if (strcmp(level, curr_log_level.log_old_numeric_str)==0) {
+      fprintf(stderr,
+              "** Deprecation warning: Use of %s %s is deprecated, use %s %s instead\n",
+              LOG_LEVEL_KEY, curr_log_level.log_old_numeric_str,
+              LOG_LEVEL_KEY, curr_log_level.log_keyword
+              );
+
+      return curr_log_level.log_enum;
+    }
+  }
+
+  fprintf(stderr, "** The log_level: %s is not valid, using default log level\n", level);
+  return DEFAULT_LOG_LEVEL;
+}
+
+
+static void log_config_init(
+        log_config_type * log_config,
+        const config_content_type * content
+        ) {
+
+  if (config_content_has_item(content, LOG_FILE_KEY)) {
+    const char * log_file = config_content_get_value_as_abspath(content, LOG_FILE_KEY);
+    log_config_set_log_file(log_config, log_file);
+  }
+
+  // If no log file, make default log file relative to config file
+  else if(!util_is_abs_path(log_config->log_file)) {
+    char * working_dir;
+    util_alloc_file_components(
+            config_content_get_config_file(content, true),
+            &working_dir, NULL, NULL);
+
+    char * abs_default_log_file = util_alloc_filename(working_dir, log_config->log_file, NULL);
+
+    log_config_set_log_file(log_config, abs_default_log_file);
+
+    free(working_dir);
+    free(abs_default_log_file);
+  }
+
+  if(config_content_has_item(content, LOG_LEVEL_KEY)) {
+    const char * log_level_str = config_content_get_value(content, LOG_LEVEL_KEY);
+    log_config->message_level = log_config_level_parser(log_level_str);
+  }
+}
+
+
+void log_config_free(log_config_type * log_config) {
+  if(!log_config)
+    return;
+
+  free(log_config->log_file);
+  free(log_config);
+}

--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -723,7 +723,7 @@ static void model_config_init_user_config(config_parser_type * config ) {
   config_schema_item_iset_type(item, 0, CONFIG_EXISTING_PATH);
 
   config_add_key_value(config, LOG_LEVEL_KEY, false, CONFIG_STRING);
-  config_add_key_value(config, LOG_FILE_KEY, false, CONFIG_STRING);
+  config_add_key_value(config, LOG_FILE_KEY, false, CONFIG_PATH);
 
   config_add_key_value(config, MAX_RESAMPLE_KEY, false, CONFIG_INT);
 

--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -92,6 +92,7 @@ struct model_config_struct {
   path_fmt_type        * current_runpath;           /* path_fmt instance for runpath - runtime the call gets arguments: (iens, report_step1 , report_step2) - i.e. at least one %d must be present.*/
   char                 * current_path_key;
   hash_type            * runpath_map;
+  bool                   pre_clear_runpath;
   char                 * jobname_fmt;               /* Format string with one '%d' for the jobname - can be NULL in which case the eclbase name will be used. */
   char                 * enspath;
   char                 * rftpath;
@@ -117,6 +118,9 @@ void model_config_set_jobname_fmt( model_config_type * model_config , const char
   model_config->jobname_fmt = util_realloc_string_copy( model_config->jobname_fmt , jobname_fmt );
 }
 
+bool model_config_get_pre_clear_runpath(const model_config_type * model_config) {
+  return model_config->pre_clear_runpath;
+}
 
 path_fmt_type * model_config_get_runpath_fmt(const model_config_type * model_config) {
   return model_config->current_runpath;
@@ -331,6 +335,7 @@ model_config_type * model_config_alloc() {
   model_config->gen_kw_export_file_name   = NULL;
   model_config->refcase                   = NULL;
 
+  model_config->pre_clear_runpath = DEFAULT_PRE_CLEAR_RUNPATH;
   model_config_set_enspath( model_config        , DEFAULT_ENSPATH );
   model_config_set_rftpath( model_config        , DEFAULT_RFTPATH );
   model_config_set_dbase_type( model_config     , DEFAULT_DBASE_TYPE );
@@ -431,6 +436,12 @@ void model_config_init(model_config_type * model_config ,
     model_config_add_runpath( model_config , DEFAULT_RUNPATH_KEY , config_content_get_value(config , RUNPATH_KEY) );
     model_config_select_runpath( model_config , DEFAULT_RUNPATH_KEY );
   }
+
+  if (config_content_has_item(config, PRE_CLEAR_RUNPATH_KEY))
+    model_config->pre_clear_runpath = config_content_get_value_as_bool(
+                                                         config,
+                                                         PRE_CLEAR_RUNPATH_KEY
+                                                         );
 
   {
     history_source_type source_type = DEFAULT_HISTORY_SOURCE;

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -33,6 +33,7 @@
 #include <ert/enkf/ecl_config.h>
 #include <ert/enkf/ensemble_config.h>
 #include <ert/enkf/model_config.h>
+#include <ert/enkf/log_config.h>
 
 struct res_config_struct {
 
@@ -50,6 +51,7 @@ struct res_config_struct {
   ecl_config_type        * ecl_config;
   ensemble_config_type   * ensemble_config;
   model_config_type      * model_config;
+  log_config_type        * log_config;
 
 };
 
@@ -71,6 +73,7 @@ static res_config_type * res_config_alloc_empty() {
   res_config->ecl_config        = NULL;
   res_config->ensemble_config   = NULL;
   res_config->model_config      = NULL;
+  res_config->log_config        = NULL;
 
   return res_config;
 }
@@ -118,6 +121,8 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                         ecl_config_get_refcase(res_config->ecl_config)
                                    );
 
+  res_config->log_config      = log_config_alloc_load(res_config->user_config_file);
+
   return res_config;
 }
 
@@ -136,6 +141,7 @@ void res_config_free(res_config_type * res_config) {
   ecl_config_free(res_config->ecl_config);
   ensemble_config_free(res_config->ensemble_config);
   model_config_free(res_config->model_config);
+  log_config_free(res_config->log_config);
 
   free(res_config->user_config_file);
   free(res_config->working_dir);
@@ -206,6 +212,12 @@ model_config_type * res_config_get_model_config(
                     const res_config_type * res_config
                   ) {
   return res_config->model_config;
+}
+
+const log_config_type * res_config_get_log_config(
+                    const res_config_type * res_config
+                  ) {
+  return res_config->log_config;
 }
 
 static char * res_config_alloc_working_directory(const char * user_config_file) {

--- a/python/python/res/enkf/CMakeLists.txt
+++ b/python/python/res/enkf/CMakeLists.txt
@@ -45,6 +45,7 @@ set(PYTHON_SOURCES
     summary_key_set.py
     forward_load_context.py
     es_update.py
+    log_config.py
 )
 
 add_python_package("python.res.enkf" ${PYTHON_INSTALL_PREFIX}/res/enkf "${PYTHON_SOURCES}" True)

--- a/python/python/res/enkf/__init__.py
+++ b/python/python/res/enkf/__init__.py
@@ -85,6 +85,7 @@ from .runpath_list import RunpathList, RunpathNode
 from .hook_workflow import HookWorkflow
 from .hook_manager import HookManager
 from .rng_config import RNGConfig
+from .log_config import LogConfig
 from .res_config import ResConfig
 
 from .es_update import ESUpdate

--- a/python/python/res/enkf/log_config.py
+++ b/python/python/res/enkf/log_config.py
@@ -1,0 +1,61 @@
+#  Copyright (C) 2017  Statoil ASA, Norway.
+#
+#  The file 'log_config.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+from os.path import isfile
+
+from cwrap import BaseCClass
+
+from ecl.util.enums import MessageLevelEnum
+
+from res.enkf import EnkfPrototype
+
+class LogConfig(BaseCClass):
+
+    TYPE_NAME = "log_config"
+
+    _alloc     = EnkfPrototype("void* log_config_alloc_load(char*)", bind=False)
+    _free      = EnkfPrototype("void log_config_free(log_config)")
+
+    _log_file  = EnkfPrototype("char* log_config_get_log_file(log_config)")
+    _log_level = EnkfPrototype("message_level_enum log_config_get_log_level(log_config)")
+
+    def __init__(self, user_config_file):
+        if user_config_file is not None and not isfile(user_config_file):
+            raise IOError('No such configuration file "%s".' % user_config_file)
+
+        c_ptr = self._alloc(user_config_file)
+        if c_ptr:
+            super(LogConfig, self).__init__(c_ptr)
+        else:
+            raise ValueError(
+                    'Failed to construct LogConfig instance from config file %s.'
+                    % user_config_file
+                    )
+
+    def __repr__(self):
+        return "LogConfig(log_file=%s, log_level=%r)" % (
+                self.log_file, self.log_level)
+
+    def free(self):
+        self._free()
+
+    @property
+    def log_file(self):
+        return self._log_file()
+
+    @property
+    def log_level(self):
+        return self._log_level()

--- a/python/python/res/enkf/res_config.py
+++ b/python/python/res/enkf/res_config.py
@@ -45,6 +45,7 @@ class ResConfig(BaseCClass):
     _ert_workflow_list = EnkfPrototype("ert_workflow_list_ref res_config_get_workflow_list(res_config)")
     _rng_config        = EnkfPrototype("rng_config_ref res_config_get_rng_config(res_config)")
     _ert_templates     = EnkfPrototype("ert_templates_ref res_config_get_templates(res_config)")
+    _log_config        = EnkfPrototype("log_config_ref res_config_get_log_config(res_config)")
 
     def __init__(self, user_config_file):
         if user_config_file is not None and not isfile(user_config_file):
@@ -55,7 +56,7 @@ class ResConfig(BaseCClass):
             super(ResConfig, self).__init__(c_ptr)
         else:
             raise ValueError(
-                    'Failed to construct EnkfConfig instance from config file %s.'
+                    'Failed to construct ResConfig instance from config file %s.'
                     % user_config_file
                     )
 
@@ -117,3 +118,7 @@ class ResConfig(BaseCClass):
     @property
     def ert_templates(self):
         return self._ert_templates()
+
+    @property
+    def log_config(self):
+        return self._log_config()

--- a/python/tests/res/enkf/CMakeLists.txt
+++ b/python/tests/res/enkf/CMakeLists.txt
@@ -39,6 +39,7 @@ set(TEST_SOURCES
     test_queue_config.py
     test_site_config.py
     test_res_config.py
+    test_log_config.py
 )
 
 add_python_package("python.tests.res.enkf" ${PYTHON_INSTALL_PREFIX}/tests/res/enkf "${TEST_SOURCES}" False)
@@ -69,6 +70,7 @@ addPythonTest(tests.res.enkf.test_hook_workflow.HookWorkFlowTest)
 addPythonTest(tests.res.enkf.test_runpath_list.RunpathListTest)
 addPythonTest(tests.res.enkf.test_field_config.FieldConfigTest)
 addPythonTest(tests.res.enkf.test_queue_config.QueueConfigTest)
+addPythonTest(tests.res.enkf.test_log_config.LogConfigTest)
 
 if (STATOIL_TESTDATA_ROOT)
   addPythonTest(tests.res.enkf.test_enkf.EnKFTest LABELS StatoilData)

--- a/python/tests/res/enkf/test_log_config.py
+++ b/python/tests/res/enkf/test_log_config.py
@@ -1,0 +1,98 @@
+#  Copyright (C) 2017  Statoil ASA, Norway.
+#
+#  The file 'test_res_config.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+import os, itertools
+
+from ecl.test import ExtendedTestCase, TestAreaContext
+from ecl.util.enums import MessageLevelEnum
+
+from res.enkf import LogConfig, ResConfig
+
+class LogConfigTest(ExtendedTestCase):
+
+    def setUp(self):
+        self.case_directory = self.createTestPath("local/simple_config/")
+        self.config_file = "simple_config/minimum_config"
+
+        self.log_files = [
+                            (None, "simple_config/log"),
+                            ("file_loglog", "simple_config/file_loglog"),
+                            ("this/is/../my/log/file.loglog", "simple_config/this/my/log/file.loglog")
+                         ]
+
+        self.log_levels = [(None, MessageLevelEnum.LOG_ERROR)]
+        for message_level in MessageLevelEnum.enums():
+            # Add new log level
+            self.log_levels.append((message_level.name.split("_")[1], message_level))
+
+            # Add old log level
+            self.log_levels.append((str(message_level.value), message_level))
+
+    def assert_log_config_load(
+            self,
+            log_file, exp_log_file,
+            log_level, exp_log_level,
+            write_abs_path=False
+            ):
+
+
+        with TestAreaContext("log_config_test") as work_area:
+            work_area.copy_directory(self.case_directory)
+
+            # Append config file
+            with open(self.config_file, 'a') as cf:
+                if log_file:
+                    if write_abs_path:
+                        log_file = os.path.join(
+                                os.path.abspath(os.path.split(self.config_file)[0]),
+                                log_file
+                                )
+
+                    cf.write("\nLOG_FILE %s\n" % log_file)
+
+                if log_level:
+                    cf.write("\nLOG_LEVEL %s\n" % log_level)
+
+            log_config = LogConfig(self.config_file)
+
+            self.assertTrue(os.path.isabs(log_config.log_file))
+
+            self.assertEqual(
+                    os.path.normpath(log_config.log_file),
+                    os.path.normpath(os.path.abspath(exp_log_file))
+                    )
+
+            self.assertEqual(
+                    log_config.log_level,
+                    exp_log_level
+                    )
+
+
+    def test_log_config(self):
+        test_cases = itertools.product(self.log_files, self. log_levels)
+
+        for log_file_data, log_level_data in test_cases:
+            self.assert_log_config_load(
+                    log_file_data[0], log_file_data[1],
+                    log_level_data[0], log_level_data[1]
+                    )
+
+            if log_file_data[0]:
+                self.assert_log_config_load(
+                        log_file_data[0], log_file_data[1],
+                        log_level_data[0], log_level_data[1],
+                        write_abs_path=True
+                        )

--- a/python/tests/res/enkf/test_res_config.py
+++ b/python/tests/res/enkf/test_res_config.py
@@ -19,7 +19,7 @@ from datetime import date
 
 from ecl.test import ExtendedTestCase, TestAreaContext
 from ecl.util import CTime
-from ecl.util.enums import RngAlgTypeEnum
+from ecl.util.enums import RngAlgTypeEnum, MessageLevelEnum
 
 from res.sched import HistorySourceEnum
 
@@ -89,7 +89,7 @@ config_data = {
         "LOAD_WORKFLOW_JOB" : {
                                   "UBER_PRINT"  : "../bin/workflows/workflowjobs/bin/uber_print.py"
                               },
-        "LOG_LEVEL"         : 3,
+        "LOG_LEVEL"         : MessageLevelEnum.LOG_INFO,
         "RNG_ALG_TYPE"      : RngAlgTypeEnum.MZRAN,
         "STORE_SEED"        : "../input/rng/SEED",
         "LOAD_SEED"         : "../input/rng/SEED",
@@ -404,6 +404,18 @@ class ResConfigTest(ExtendedTestCase):
                     working_dir
                     )
 
+    def assert_log_config(self, log_config, config_data, working_dir):
+        self.assert_same_config_file(
+                config_data["LOG_FILE"],
+                log_config.log_file,
+                working_dir
+                )
+
+        self.assertEqual(
+                config_data["LOG_LEVEL"],
+                log_config.log_level
+                )
+
 
     def test_extensive_config(self):
         self.set_up_snake_oil_structure()
@@ -439,10 +451,10 @@ class ResConfigTest(ExtendedTestCase):
             self.assert_ert_workflow_list(res_config.ert_workflow_list, config_data, work_dir)
             self.assert_rng_config(res_config.rng_config, config_data, work_dir)
             self.assert_ert_templates(res_config.ert_templates, config_data, work_dir)
+            self.assert_log_config(res_config.log_config, config_data, work_dir)
+
 
             # TODO: Not tested
             # - NUM_REALIZATIONS
             # - MIN_REALIZATIONS
-            # - LOG_FILE
-            # - LOG_LEVEL
             # - OBS_CONFIG


### PR DESCRIPTION
**Task**
_The keywords PRE_CLEAR_RUNPATH and DELETE_RUNPATH are loaded directly by enkf_main. This needs to be fixed in order to programatically instantiate an instance of enkf_main._


**Approach**
_Move the two keywords into model_config._


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps