### PR TITLE
Retain backwards compatibility of completeStatus

### DIFF
--- a/bin/job_dispatch.py
+++ b/bin/job_dispatch.py
@@ -393,7 +393,7 @@ def main(argv):
         for job in job_manager:
             job_manager.startStatus( job )
             (OK , exit_status, error_msg) = run_one( job_manager , job)
-            job_manager.completeStatus(job, exit_status , error_msg )
+            job_manager.completeStatus(exit_status, error_msg, job=job)
             if not OK:
                 job_manager.exit( job, exit_status , error_msg )
 

--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -228,7 +228,7 @@ class JobManager(object):
         self.postMessage(job=job, extra_fields={"status": "startStatus"})
 
 
-    def completeStatus(self, job, exit_status, error_msg):
+    def completeStatus(self, exit_status, error_msg, job=None):
         now = time.localtime()
         extra_fields = {"finished": True,
                         "exit_status": exit_status,


### PR DESCRIPTION
**Task**

When the parameters to `completeStatus` changed, this did not take into account already use of older versions of `job_dispatch`.

`completeStatus` had signature `(exit_status, error_msg)`, but was made into a signature of `(job, exit_status, error_msg)`.

This PR changes the latter to `(exit_status, error_msg, job=None)` so that we retain backwards compatibility of older versions of `job_dispatch`.

```
Above error log NOT submitted.Traceback (most recent call last):
  File "/project/res/x86_64_RH_6/share/ert/release/2.1.8/bin/job_dispatch.py", line 463, in <module>
    main( sys.argv )
  File "/project/res/x86_64_RH_6/share/ert/release/2.1.8/bin/job_dispatch.py", line 378, in main
    job_manager.completeStatus( exit_status , error_msg )
TypeError: completeStatus() takes exactly 4 arguments (3 given)
 ```

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps
