### PR TITLE
Runpath to model config

### DIFF
--- a/libenkf/include/ert/enkf/model_config.h
+++ b/libenkf/include/ert/enkf/model_config.h
@@ -68,6 +68,7 @@ extern "C" {
   void                   model_config_init(model_config_type * model_config , const config_content_type * , int ens_size , const ext_joblist_type * , int , const sched_file_type * , const ecl_sum_type * refcase);
   void                   model_config_free(model_config_type *);
   bool                   model_config_runpath_requires_iter( const model_config_type * model_config );
+  bool                   model_config_get_pre_clear_runpath(const model_config_type * model_config);
   path_fmt_type        * model_config_get_runpath_fmt(const model_config_type * );
   history_type         * model_config_get_history(const model_config_type * );
   forward_model_type   * model_config_get_forward_model( const model_config_type * );

--- a/libenkf/include/ert/enkf/model_config.h
+++ b/libenkf/include/ert/enkf/model_config.h
@@ -70,6 +70,7 @@ extern "C" {
   bool                   model_config_runpath_requires_iter( const model_config_type * model_config );
   bool                   model_config_get_pre_clear_runpath(const model_config_type * model_config);
   path_fmt_type        * model_config_get_runpath_fmt(const model_config_type * );
+  int                    model_config_iget_keep_runpath(const model_config_type * model_config, const size_t iens);
   history_type         * model_config_get_history(const model_config_type * );
   forward_model_type   * model_config_get_forward_model( const model_config_type * );
   bool                   model_config_internalize_state( const model_config_type *, int );

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -153,8 +153,6 @@ struct enkf_main_struct {
   rng_type               * rng;
   ranking_table_type     * ranking_table;
 
-  int_vector_type        * keep_runpath;       /* HACK: This is only used in the initialization period - afterwards the data is held by the enkf_state object. */
-
   char                   * user_config_file;
   char                   * rft_config_file;       /* File giving the configuration to the RFTwells*/
   enkf_obs_type          * obs;
@@ -333,8 +331,6 @@ void enkf_main_free(enkf_main_type * enkf_main){
   res_log_close();
 
   local_config_free( enkf_main->local_config );
-
-  int_vector_free( enkf_main->keep_runpath );
 
   util_safe_free( enkf_main->user_config_file );
   util_safe_free( enkf_main->rft_config_file );
@@ -1913,31 +1909,6 @@ bool enkf_main_get_verbose( const enkf_main_type * enkf_main ) {
   return enkf_main->verbose;
 }
 
-/**
-   Observe that this function parses and TEMPORARILY stores the keep_runpath
-   information ion the enkf_main object. This is subsequently passed on the
-   enkf_state members, and the functions enkf_main_iget_keep_runpath() and
-   enkf_main_iset_keep_runpath() act on the enkf_state objects, and not on the
-   internal keep_runpath field of the enkf_main object (what a fxxxing mess).
-*/
-
-
-void enkf_main_parse_keep_runpath(enkf_main_type * enkf_main , const char * delete_runpath_string , int ens_size ) {
-
-  int i;
-  for (i = 0; i < ens_size; i++)
-    int_vector_iset( enkf_main->keep_runpath , i , DEFAULT_KEEP);
-
-  {
-    int_vector_type * active_list = string_util_alloc_active_list(delete_runpath_string);
-
-    for (i = 0; i < int_vector_size( active_list ); i++)
-      int_vector_iset( enkf_main->keep_runpath , int_vector_iget( active_list , i ) , EXPLICIT_DELETE);
-
-    int_vector_free( active_list );
-  }
-}
-
 
 
 /**
@@ -1968,7 +1939,6 @@ static enkf_main_type * enkf_main_alloc_empty( ) {
   enkf_main->local_config       = NULL;
   enkf_main->rng                = NULL;
   enkf_main->ens_size           = 0;
-  enkf_main->keep_runpath       = int_vector_alloc( 0 , DEFAULT_KEEP );
   enkf_main->res_config         = NULL;
   enkf_main->ranking_table      = ranking_table_alloc( 0 );
   enkf_main->obs                = NULL;
@@ -2100,32 +2070,6 @@ static void enkf_main_init_log(const enkf_main_type * enkf_main) {
 }
 
 
-/**
-   By default the simulation directories are left intact when
-   the simulations re complete, but using the keyword
-   DELETE_RUNPATH you can request (some of) the directories to
-   be wiped after the simulations are complete.
-*/
-static void enkf_main_init_delete_runpath(
-                enkf_main_type * enkf_main,
-                const config_content_type * content) {
-
-  char * delete_runpath_string = NULL;
-  int ens_size = config_content_get_value_as_int(content, NUM_REALIZATIONS_KEY);
-
-  if (config_content_has_item(content, DELETE_RUNPATH_KEY))
-    delete_runpath_string = config_content_alloc_joined_string(
-                                                          content,
-                                                          DELETE_RUNPATH_KEY,
-                                                          ""
-                                                          );
-
-  enkf_main_parse_keep_runpath(enkf_main, delete_runpath_string, ens_size);
-
-  util_safe_free(delete_runpath_string);
-}
-
-
 static void enkf_main_init_rft_config(
                 enkf_main_type * enkf_main,
                 const config_content_type * content) {
@@ -2160,8 +2104,6 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
 
   config_parser_type * config = config_alloc();
   config_content_type * content = model_config_alloc_content(enkf_main->user_config_file, config);
-
-  enkf_main_init_delete_runpath(enkf_main, content);
 
   enkf_main_init_rft_config(enkf_main, content);
 

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -154,7 +154,6 @@ struct enkf_main_struct {
   ranking_table_type     * ranking_table;
 
   int_vector_type        * keep_runpath;       /* HACK: This is only used in the initialization period - afterwards the data is held by the enkf_state object. */
-  bool                     pre_clear_runpath;  /* HACK: This is only used in the initialization period - afterwards the data is held by the enkf_state object. */
 
   char                   * user_config_file;
   char                   * rft_config_file;       /* File giving the configuration to the RFTwells*/
@@ -2126,18 +2125,6 @@ static void enkf_main_init_delete_runpath(
   util_safe_free(delete_runpath_string);
 }
 
-static void enkf_main_init_pre_clear_runpath(
-                enkf_main_type * enkf_main,
-                const config_content_type * content) {
-
-  enkf_main->pre_clear_runpath = DEFAULT_PRE_CLEAR_RUNPATH;
-  if (config_content_has_item(content, PRE_CLEAR_RUNPATH_KEY))
-    enkf_main->pre_clear_runpath = config_content_get_value_as_bool(
-                                                         content,
-                                                         PRE_CLEAR_RUNPATH_KEY
-                                                         );
-}
-
 
 static void enkf_main_init_rft_config(
                 enkf_main_type * enkf_main,
@@ -2175,8 +2162,6 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
   config_content_type * content = model_config_alloc_content(enkf_main->user_config_file, config);
 
   enkf_main_init_delete_runpath(enkf_main, content);
-
-  enkf_main_init_pre_clear_runpath(enkf_main, content);
 
   enkf_main_init_rft_config(enkf_main, content);
 

--- a/libenkf/src/enkf_main_ensemble.c
+++ b/libenkf/src/enkf_main_ensemble.c
@@ -64,7 +64,7 @@ void enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size ) 
       enkf_main->ensemble[iens] = enkf_state_alloc(iens,
                                                    enkf_main->rng,
                                                    model_config_iget_casename(enkf_main_get_model_config(enkf_main), iens),
-                                                   enkf_main->pre_clear_runpath,
+                                                   model_config_get_pre_clear_runpath(enkf_main_get_model_config(enkf_main)),
                                                    int_vector_safe_iget(enkf_main->keep_runpath, iens),
                                                    enkf_main_get_model_config(enkf_main),
                                                    enkf_main_get_ensemble_config(enkf_main),

--- a/libenkf/src/enkf_main_ensemble.c
+++ b/libenkf/src/enkf_main_ensemble.c
@@ -57,16 +57,18 @@ void enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size ) 
     /*1: Grow the ensemble pointer. */
     enkf_main->ensemble = util_realloc(enkf_main->ensemble , new_ens_size * sizeof * enkf_main->ensemble );
 
+
     /*2: Allocate the new ensemble members. */
+    model_config_type * model_config = enkf_main_get_model_config(enkf_main);
     for (iens = enkf_main->ens_size; iens < new_ens_size; iens++)
 
       /* Observe that due to the initialization of the rng - this function is currently NOT thread safe. */
       enkf_main->ensemble[iens] = enkf_state_alloc(iens,
                                                    enkf_main->rng,
-                                                   model_config_iget_casename(enkf_main_get_model_config(enkf_main), iens),
-                                                   model_config_get_pre_clear_runpath(enkf_main_get_model_config(enkf_main)),
-                                                   int_vector_safe_iget(enkf_main->keep_runpath, iens),
-                                                   enkf_main_get_model_config(enkf_main),
+                                                   model_config_iget_casename(model_config, iens),
+                                                   model_config_get_pre_clear_runpath(model_config),
+                                                   model_config_iget_keep_runpath(model_config, iens),
+                                                   model_config,
                                                    enkf_main_get_ensemble_config(enkf_main),
                                                    enkf_main_get_site_config(enkf_main),
                                                    enkf_main_get_ecl_config(enkf_main),

--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -143,6 +143,9 @@ int model_config_iget_keep_runpath(const model_config_type * model_config, const
   return int_vector_safe_iget(model_config->keep_runpath, iens);
 }
 
+const int_vector_type * model_config_get_keep_runpath(const model_config_type * model_config) {
+  return model_config->keep_runpath;
+}
 
 const char * model_config_get_case_table_file( const model_config_type * model_config ) {
   return model_config->case_table_file;

--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -24,6 +24,7 @@
 
 #include <ert/util/type_macros.h>
 #include <ert/util/util.h>
+#include <ert/util/string_util.h>
 #include <ert/util/path_fmt.h>
 #include <ert/util/hash.h>
 #include <ert/util/menu.h>
@@ -93,6 +94,7 @@ struct model_config_struct {
   char                 * current_path_key;
   hash_type            * runpath_map;
   bool                   pre_clear_runpath;
+  int_vector_type      * keep_runpath;
   char                 * jobname_fmt;               /* Format string with one '%d' for the jobname - can be NULL in which case the eclbase name will be used. */
   char                 * enspath;
   char                 * rftpath;
@@ -135,6 +137,10 @@ bool model_config_runpath_requires_iter( const model_config_type * model_config 
     return true;
   else
     return false;
+}
+
+int model_config_iget_keep_runpath(const model_config_type * model_config, const size_t iens) {
+  return int_vector_safe_iget(model_config->keep_runpath, iens);
 }
 
 
@@ -334,6 +340,7 @@ model_config_type * model_config_alloc() {
   model_config->runpath_map               = hash_alloc();
   model_config->gen_kw_export_file_name   = NULL;
   model_config->refcase                   = NULL;
+  model_config->keep_runpath              = int_vector_alloc(0, DEFAULT_KEEP);
 
   model_config->pre_clear_runpath = DEFAULT_PRE_CLEAR_RUNPATH;
   model_config_set_enspath( model_config        , DEFAULT_ENSPATH );
@@ -412,6 +419,47 @@ static bool model_config_select_any_history( model_config_type * model_config , 
 }
 
 
+static void model_config_parse_keep_runpath(
+        model_config_type * model_config,
+        const char * delete_runpath_string
+        ) {
+
+  int_vector_type * active_list = string_util_alloc_active_list(delete_runpath_string);
+
+  for (int i = 0; i < int_vector_size(active_list); i++)
+    int_vector_iset(model_config->keep_runpath, int_vector_iget(active_list, i), EXPLICIT_DELETE);
+
+  int_vector_free(active_list);
+}
+
+
+/**
+   By default the simulation directories are left intact when
+   the simulations re complete, but using the keyword
+   DELETE_RUNPATH you can request (some of) the directories to
+   be wiped after the simulations are complete.
+*/
+static void model_config_init_delete_runpath(
+                model_config_type * model_config,
+                const config_content_type * config
+                ) {
+
+  int ens_size = config_content_get_value_as_int(config, NUM_REALIZATIONS_KEY);
+  for (int i = 0; i < ens_size; i++)
+    int_vector_iset(model_config->keep_runpath, i, DEFAULT_KEEP);
+
+  if (config_content_has_item(config, DELETE_RUNPATH_KEY)) {
+    char * delete_runpath_string = config_content_alloc_joined_string(
+                                                        config,
+                                                        DELETE_RUNPATH_KEY,
+                                                        ""
+                                                        );
+
+    model_config_parse_keep_runpath(model_config, delete_runpath_string);
+
+    util_safe_free(delete_runpath_string);
+  }
+}
 
 
 void model_config_init(model_config_type * model_config ,
@@ -442,6 +490,8 @@ void model_config_init(model_config_type * model_config ,
                                                          config,
                                                          PRE_CLEAR_RUNPATH_KEY
                                                          );
+
+  model_config_init_delete_runpath(model_config, config);
 
   {
     history_source_type source_type = DEFAULT_HISTORY_SOURCE;
@@ -548,6 +598,7 @@ void model_config_free(model_config_type * model_config) {
     time_map_free( model_config->external_time_map );
 
 
+  int_vector_free(model_config->keep_runpath);
   bool_vector_free(model_config->internalize_state);
   bool_vector_free(model_config->__load_eclipse_restart);
   hash_free(model_config->runpath_map);

--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -92,6 +92,7 @@ struct model_config_struct {
   path_fmt_type        * current_runpath;           /* path_fmt instance for runpath - runtime the call gets arguments: (iens, report_step1 , report_step2) - i.e. at least one %d must be present.*/
   char                 * current_path_key;
   hash_type            * runpath_map;
+  bool                   pre_clear_runpath;
   char                 * jobname_fmt;               /* Format string with one '%d' for the jobname - can be NULL in which case the eclbase name will be used. */
   char                 * enspath;
   char                 * rftpath;
@@ -117,6 +118,9 @@ void model_config_set_jobname_fmt( model_config_type * model_config , const char
   model_config->jobname_fmt = util_realloc_string_copy( model_config->jobname_fmt , jobname_fmt );
 }
 
+bool model_config_get_pre_clear_runpath(const model_config_type * model_config) {
+  return model_config->pre_clear_runpath;
+}
 
 path_fmt_type * model_config_get_runpath_fmt(const model_config_type * model_config) {
   return model_config->current_runpath;
@@ -331,6 +335,7 @@ model_config_type * model_config_alloc() {
   model_config->gen_kw_export_file_name   = NULL;
   model_config->refcase                   = NULL;
 
+  model_config->pre_clear_runpath = DEFAULT_PRE_CLEAR_RUNPATH;
   model_config_set_enspath( model_config        , DEFAULT_ENSPATH );
   model_config_set_rftpath( model_config        , DEFAULT_RFTPATH );
   model_config_set_dbase_type( model_config     , DEFAULT_DBASE_TYPE );
@@ -431,6 +436,12 @@ void model_config_init(model_config_type * model_config ,
     model_config_add_runpath( model_config , DEFAULT_RUNPATH_KEY , config_content_get_value(config , RUNPATH_KEY) );
     model_config_select_runpath( model_config , DEFAULT_RUNPATH_KEY );
   }
+
+  if (config_content_has_item(config, PRE_CLEAR_RUNPATH_KEY))
+    model_config->pre_clear_runpath = config_content_get_value_as_bool(
+                                                         config,
+                                                         PRE_CLEAR_RUNPATH_KEY
+                                                         );
 
   {
     history_source_type source_type = DEFAULT_HISTORY_SOURCE;

--- a/python/python/res/enkf/enums/CMakeLists.txt
+++ b/python/python/res/enkf/enums/CMakeLists.txt
@@ -13,6 +13,7 @@ set(PYTHON_SOURCES
     gen_data_file_type_enum.py
     active_mode_enum.py
     hook_runtime_enum.py
+    keep_runpath_enum.py
 )
 
 add_python_package("python.res.enkf.enums"  ${PYTHON_INSTALL_PREFIX}/res/enkf/enums "${PYTHON_SOURCES}" True)

--- a/python/python/res/enkf/enums/__init__.py
+++ b/python/python/res/enkf/enums/__init__.py
@@ -11,6 +11,7 @@ from .enkf_fs_type_enum import EnKFFSType
 from .gen_data_file_type_enum import GenDataFileType
 from .active_mode_enum import ActiveMode
 from .hook_runtime_enum import HookRuntime
+from .keep_runpath_enum import KeepRunpath
 
 __all__ = ["EnkfFieldFileFormatEnum",
            "LoadFailTypeEnum",
@@ -24,4 +25,5 @@ __all__ = ["EnkfFieldFileFormatEnum",
            "EnKFFSType",
            "GenDataFileType",
            "ActiveMode",
-           "HookRuntime"]
+           "HookRuntime",
+           "KeepRunpath"]

--- a/python/python/res/enkf/enums/keep_runpath_enum.py
+++ b/python/python/res/enkf/enums/keep_runpath_enum.py
@@ -1,0 +1,29 @@
+#  Copyright (C) 2017  Statoil ASA, Norway.
+#
+#  The file 'keep_runpath_enum.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+from cwrap import BaseCEnum
+
+class KeepRunpath(BaseCEnum):
+    TYPE_NAME = "keep_runpath_enum"
+
+    DEFAULT_KEEP    = None
+    EXPLICIT_DELETE = None
+    EXPLICIT_KEEP   = None
+
+
+KeepRunpath.addEnum("DEFAULT_KEEP",    0)
+KeepRunpath.addEnum("EXPLICIT_DELETE", 1)
+KeepRunpath.addEnum("EXPLICIT_KEEP",   2)

--- a/python/python/res/enkf/model_config.py
+++ b/python/python/res/enkf/model_config.py
@@ -19,6 +19,7 @@ from res.enkf import EnkfPrototype
 from res.sched import HistorySourceEnum, SchedFile
 from res.job_queue import ForwardModel
 from ecl.util import PathFormat
+from res.enkf.enums import KeepRunpath
 
 
 class ModelConfig(BaseCClass):
@@ -42,6 +43,8 @@ class ModelConfig(BaseCClass):
     _runpath_requires_iterations = EnkfPrototype("bool  model_config_runpath_requires_iter(model_config)")
     _get_jobname_fmt             = EnkfPrototype("char* model_config_get_jobname_fmt(model_config)")
     _get_runpath_fmt             = EnkfPrototype("path_fmt_ref model_config_get_runpath_fmt(model_config)")
+    _get_pre_clear_runpath       = EnkfPrototype("bool model_config_get_pre_clear_runpath(model_config)")
+    _get_keep_runpath            = EnkfPrototype("int_vector_ref model_config_get_keep_runpath(model_config)")
 
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
@@ -118,3 +121,21 @@ class ModelConfig(BaseCClass):
     def getRunpathFormat(self):
         """ @rtype: PathFormat """
         return self._get_runpath_fmt()
+
+    @property
+    def pre_clear_runpath(self):
+        return self._get_pre_clear_runpath()
+
+    @property
+    def keep_runpath(self):
+        def int2enum(value):
+            for enum in KeepRunpath.enums():
+                if value == enum.value:
+                    return enum
+
+            raise KeyError(
+                    "Unexpected value %d, expected value in %r" %
+                    (value, [e.value() for e in KeepRunpath.enums()])
+                    )
+
+        return map(int2enum, list(self._get_keep_runpath()))

--- a/python/tests/res/enkf/CMakeLists.txt
+++ b/python/tests/res/enkf/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TEST_SOURCES
     test_site_config.py
     test_res_config.py
     test_log_config.py
+    test_model_config.py
 )
 
 add_python_package("python.tests.res.enkf" ${PYTHON_INSTALL_PREFIX}/tests/res/enkf "${TEST_SOURCES}" False)
@@ -71,6 +72,7 @@ addPythonTest(tests.res.enkf.test_runpath_list.RunpathListTest)
 addPythonTest(tests.res.enkf.test_field_config.FieldConfigTest)
 addPythonTest(tests.res.enkf.test_queue_config.QueueConfigTest)
 addPythonTest(tests.res.enkf.test_log_config.LogConfigTest)
+addPythonTest(tests.res.enkf.test_model_config.ModelConfigTest)
 
 if (STATOIL_TESTDATA_ROOT)
   addPythonTest(tests.res.enkf.test_enkf.EnKFTest LABELS StatoilData)

--- a/python/tests/res/enkf/test_model_config.py
+++ b/python/tests/res/enkf/test_model_config.py
@@ -1,0 +1,117 @@
+#  Copyright (C) 2017  Statoil ASA, Norway.
+#
+#  The file 'test_model_config.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+import os
+
+from ecl.test import ExtendedTestCase, TestAreaContext
+
+from res.enkf.enums import KeepRunpath
+from res.enkf import ModelConfig, ResConfig
+
+class ModelConfigTest(ExtendedTestCase):
+
+
+    def setUp(self):
+        self.case_directory = self.createTestPath("local/simple_config/")
+        self.config_file = "simple_config/minimum_config"
+
+
+    def test_enum(self):
+        self.assertEnumIsFullyDefined(
+                KeepRunpath,
+                "keep_runpath_type",
+                "libenkf/include/ert/enkf/enkf_types.h",
+                verbose=True
+                )
+
+
+    def assert_pre_clear_runpath(self, write_pcr, exp_pcr):
+        area_name = "model_config_pre_clear_runpath_%s" % write_pcr
+        with TestAreaContext(area_name) as work_area:
+            work_area.copy_directory(self.case_directory)
+
+            # Append config file
+            if write_pcr:
+                with open(self.config_file, 'a') as cf:
+                    cf.write("\nPRE_CLEAR_RUNPATH %s\n" % write_pcr)
+
+            res_config = ResConfig(self.config_file)
+            model_config = res_config.model_config
+            self.assertEqual(model_config.pre_clear_runpath, exp_pcr)
+
+
+    def test_pre_clear_runpath(self):
+        test_cases = [(None, False), ("FALSE", False), ("TRUE", True)]
+
+        for (write_pcr, exp_pcr) in test_cases:
+            self.assert_pre_clear_runpath(write_pcr, exp_pcr)
+
+
+    def assert_delete_runpath(self, delete_runpath):
+        with TestAreaContext("model_config_delete") as work_area:
+            work_area.copy_directory(self.case_directory)
+
+            # Increase the number of realizations
+            with open(self.config_file, 'w') as cf:
+                cf.writelines(map(
+                    lambda line: line+os.linesep,
+                    [
+                    "JOBNAME  Job%d",
+                    "RUNPATH /tmp/simulations/run%d",
+                    "NUM_REALIZATIONS 100",
+                    "JOB_SCRIPT script.sh"
+                    ]))
+
+            # Append config file
+            if delete_runpath:
+                output_ranges = [
+                                    str(interval)
+                                    if isinstance(interval, int) else
+                                    " - ".join(map(str, interval))
+                                    for interval in delete_runpath
+                                 ]
+
+                with open(self.config_file, 'a') as cf:
+                    cf.write(
+                            "\nDELETE_RUNPATH %s\n" %
+                            ", ".join(output_ranges)
+                            )
+
+            exp_keep_runpath = [KeepRunpath.DEFAULT_KEEP]*100
+            for interval in delete_runpath:
+                if isinstance(interval, int):
+                   interval = [interval] * 2
+
+                for i in range(interval[0], interval[1]+1):
+                    exp_keep_runpath[i] = KeepRunpath.EXPLICIT_DELETE
+
+            res_config = ResConfig(self.config_file)
+            self.assertEqual(
+                    exp_keep_runpath,
+                    res_config.model_config.keep_runpath
+                    )
+
+    def test_delete_runpath(self):
+        test_cases = [
+                        [],
+                        [1,5,[8,10]],
+                        [2,3,4,5],
+                        [[1,10], [40,99]],
+                        [[0, 99]]
+                     ]
+
+        for delete_runpath in test_cases:
+            self.assert_delete_runpath(delete_runpath)


### PR DESCRIPTION
**Task**
_The keywords PRE_CLEAR_RUNPATH and DELETE_RUNPATH are loaded directly by enkf_main. This needs to be fixed in order to programatically instantiate an instance of enkf_main._


**Approach**
_Move the two keywords into model_config._


**Pre un-WIP checklist**
- [x] Statoil tests pass locally