### PR TITLE
Let model_config hold OBS_CONFIG keyword

### DIFF
--- a/libenkf/include/ert/enkf/model_config.h
+++ b/libenkf/include/ert/enkf/model_config.h
@@ -66,6 +66,7 @@ extern "C" {
   int                    model_config_get_last_history_restart(const model_config_type * );
   time_map_type        * model_config_get_external_time_map( const model_config_type * config);
   int                    model_config_get_num_realizations(const model_config_type * model_config);
+  const char           * model_config_get_obs_config_file(const model_config_type * model_config);
   void                   model_config_init(model_config_type * model_config , const config_content_type * , int ens_size , const ext_joblist_type * , int , const sched_file_type * , const ecl_sum_type * refcase);
   void                   model_config_free(model_config_type *);
   bool                   model_config_runpath_requires_iter( const model_config_type * model_config );

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -2128,20 +2128,14 @@ static void enkf_main_init_pre_clear_runpath(
 }
 
 
-static void enkf_main_init_obs(
-                enkf_main_type * enkf_main,
-                const config_content_type * content) {
 
+static void enkf_main_init_obs(enkf_main_type * enkf_main) {
   enkf_main_alloc_obs(enkf_main);
-  if (config_content_has_item(content, OBS_CONFIG_KEY)) {
-    const char * obs_config_file = config_content_iget(
-                                                    content,
-                                                    OBS_CONFIG_KEY,
-                                                    0, 0
-                                                    );
 
+  const model_config_type * model_config = enkf_main_get_model_config(enkf_main);
+  const char * obs_config_file = model_config_get_obs_config_file(model_config);
+  if (obs_config_file)
     enkf_main_load_obs(enkf_main, obs_config_file, true);
-  }
 }
 
 static void enkf_main_add_ensemble_members(enkf_main_type * enkf_main) {
@@ -2163,7 +2157,7 @@ static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, b
 
   enkf_main_user_select_initial_fs( enkf_main );
 
-  enkf_main_init_obs(enkf_main, content);
+  enkf_main_init_obs(enkf_main);
 
   config_content_free(content);
   config_free(config);

--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -102,6 +102,7 @@ struct model_config_struct {
                                                         to the ecl_sum instance owned and held by the ecl_config object. */
   char                 * gen_kw_export_file_name;
   int                    num_realizations;
+  char                 * obs_config_file;
 
   /** The results are always loaded. */
   bool_vector_type    * internalize_state;          /* Should the (full) state be internalized (at this report_step). */
@@ -118,6 +119,9 @@ void model_config_set_jobname_fmt( model_config_type * model_config , const char
   model_config->jobname_fmt = util_realloc_string_copy( model_config->jobname_fmt , jobname_fmt );
 }
 
+const char * model_config_get_obs_config_file(const model_config_type * model_config) {
+  return model_config->obs_config_file;
+}
 
 path_fmt_type * model_config_get_runpath_fmt(const model_config_type * model_config) {
   return model_config->current_runpath;
@@ -332,6 +336,7 @@ model_config_type * model_config_alloc() {
   model_config->gen_kw_export_file_name   = NULL;
   model_config->refcase                   = NULL;
   model_config->num_realizations          = 0;
+  model_config->obs_config_file           = NULL;
 
   model_config_set_enspath( model_config        , DEFAULT_ENSPATH );
   model_config_set_rftpath( model_config        , DEFAULT_RFTPATH );
@@ -511,6 +516,15 @@ void model_config_init(model_config_type * model_config ,
 
     model_config_set_gen_kw_export_file(model_config, export_file_name);
    }
+
+  if (config_content_has_item(config, OBS_CONFIG_KEY)) {
+    const char * obs_config_file = config_content_get_value_as_abspath(
+                                                    config,
+                                                    OBS_CONFIG_KEY
+                                                    );
+
+    model_config->obs_config_file = util_alloc_string_copy(obs_config_file);
+  }
 }
 
 
@@ -530,6 +544,7 @@ void model_config_free(model_config_type * model_config) {
   util_safe_free( model_config->case_table_file );
   util_safe_free( model_config->current_path_key);
   util_safe_free( model_config->gen_kw_export_file_name);
+  util_safe_free( model_config->obs_config_file );
 
   if (model_config->history)
     history_free(model_config->history);

--- a/python/python/res/enkf/model_config.py
+++ b/python/python/res/enkf/model_config.py
@@ -43,6 +43,7 @@ class ModelConfig(BaseCClass):
     _get_jobname_fmt             = EnkfPrototype("char* model_config_get_jobname_fmt(model_config)")
     _get_runpath_fmt             = EnkfPrototype("path_fmt_ref model_config_get_runpath_fmt(model_config)")
     _get_num_realizations        = EnkfPrototype("int model_config_get_num_realizations(model_config)")
+    _get_obs_config_file         = EnkfPrototype("char* model_config_get_obs_config_file(model_config)")
 
     def __init__(self):
         raise NotImplementedError("Class can not be instantiated directly!")
@@ -111,6 +112,10 @@ class ModelConfig(BaseCClass):
     def getJobnameFormat(self):
         """ @rtype: str """
         return self._get_jobname_fmt()
+
+    @property
+    def obs_config_file(self):
+        return self._get_obs_config_file()
 
     def getEnspath(self):
         """ @rtype: str """

--- a/python/tests/res/enkf/test_res_config.py
+++ b/python/tests/res/enkf/test_res_config.py
@@ -180,7 +180,7 @@ class ResConfigTest(ExtendedTestCase):
                     )
 
 
-    def assert_model_config(self, model_config, config_data):
+    def assert_model_config(self, model_config, config_data, working_dir):
         self.assertEqual(
                 config_data["RUNPATH"],
                 model_config.getRunpathAsString()
@@ -209,6 +209,12 @@ class ResConfigTest(ExtendedTestCase):
         self.assertEqual(
                 config_data["NUM_REALIZATIONS"],
                 model_config.num_realizations
+                )
+
+        self.assert_same_config_file(
+                config_data["OBS_CONFIG"],
+                model_config.obs_config_file,
+                working_dir
                 )
 
 
@@ -445,7 +451,7 @@ class ResConfigTest(ExtendedTestCase):
                                              path
                                              )
 
-            self.assert_model_config(res_config.model_config, config_data)
+            self.assert_model_config(res_config.model_config, config_data, work_dir)
             self.assert_analysis_config(res_config.analysis_config, config_data)
             self.assert_site_config(res_config.site_config, config_data, work_dir)
             self.assert_ecl_config(res_config.ecl_config, config_data, work_dir)
@@ -460,4 +466,3 @@ class ResConfigTest(ExtendedTestCase):
 
             # TODO: Not tested
             # - MIN_REALIZATIONS
-            # - OBS_CONFIG


### PR DESCRIPTION
**Task**
_The OBS_CONFIG keyword is loaded directly be enkf_main. Someone else should be responsible for this._


**Approach**
_Move logic to model_config._


**Pre un-WIP checklist**
- [x] Statoil tests pass locally