### PR TITLE
Enkf main no longer initializes from file

### DIFF
--- a/docs/course/ex1/sol1.py
+++ b/docs/course/ex1/sol1.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 import sys
 import time 
-from ert.enkf import EnKFMain
+from ert.enkf import EnKFMain, ResConfig
 from ert.enkf.enums import ErtImplType
 
 
 # This will instantiate the EnkFMain object and create a handle to
 # "everything" ert related for this instance.
-ert = EnKFMain( sys.argv[1] )
+res_config = ResConfig( sys.argv[1] )
+ert = EnKFMain( res_config )
 
 
 # Ask the EnKFMain instance how many realisations it has. Observe that

--- a/docs/course/ex3/sol3.py
+++ b/docs/course/ex3/sol3.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 import sys
 import time 
-from ert.enkf import EnKFMain
+from ert.enkf import EnKFMain, ResConfig
 
 
 # This will instantiate the EnkFMain object and create a handle to
 # "everything" ert related for this instance.
-ert = EnKFMain( sys.argv[1] )
+res_config = ResConfig( sys.argv[1] )
+ert = EnKFMain( res_config )
 site_config = ert.siteConfig( )
 
 jobs = site_config.get_installed_jobs( )

--- a/docs/course/ex4/sol4.py
+++ b/docs/course/ex4/sol4.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 import sys
 import time 
-from ert.enkf import EnKFMain, RunArg, NodeId
+from ert.enkf import EnKFMain, RunArg, NodeId, ResConfig
 from ert.enkf.data import EnkfNode
 from ert.job_queue import JobQueueManager
 
-ert = EnKFMain( sys.argv[1] )
+res_config = ResConfig( sys.argv[1] )
+ert = EnKFMain( res_config )
 fs_manager = ert.getEnkfFsManager( )
 fs = fs_manager.getCurrentFileSystem( )
 

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -71,7 +71,6 @@ extern "C" {
   typedef struct enkf_main_struct enkf_main_type;
   ui_return_type *              enkf_main_set_eclbase( enkf_main_type * enkf_main , const char * eclbase_fmt);
   ui_return_type *              enkf_main_set_data_file( enkf_main_type * enkf_main , const char * data_file );
-  void                          enkf_main_set_user_config_file( enkf_main_type * enkf_main , const char * user_config_file );
   const char                  * enkf_main_get_user_config_file( const enkf_main_type * enkf_main );
   void                          enkf_main_set_rft_config_file( enkf_main_type * enkf_main , const char * rft_config_file );
   const char                  * enkf_main_get_rft_config_file( const enkf_main_type * enkf_main );

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -118,7 +118,7 @@ extern "C" {
   void                          enkf_main_set_state_run_path(const enkf_main_type * , int );
   void                          enkf_main_set_state_eclbase(const enkf_main_type * , int );
   void                          enkf_main_interactive_set_runpath__(void * );
-  enkf_main_type              * enkf_main_alloc(const char *, const res_config_type *, bool, bool);
+  enkf_main_type              * enkf_main_alloc(const res_config_type *, bool, bool);
   void                          enkf_main_create_new_config( const char * config_file , const char * storage_path , const char * dbase_type , int num_realizations);
 
 

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -2087,7 +2087,7 @@ static void enkf_main_add_ensemble_members(enkf_main_type * enkf_main) {
    is mainly to be able to test that the site config file is valid.
 */
 
-enkf_main_type * enkf_main_alloc(const char * model_config, const res_config_type * res_config, bool strict , bool verbose) {
+enkf_main_type * enkf_main_alloc(const res_config_type * res_config, bool strict , bool verbose) {
   enkf_main_type * enkf_main = enkf_main_alloc_empty();
   enkf_main->res_config = res_config;
 

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -2064,20 +2064,6 @@ static void enkf_main_add_ensemble_members(enkf_main_type * enkf_main) {
   enkf_main_resize_ensemble(enkf_main, num_realizations);
 }
 
-static void enkf_main_bootstrap_model(enkf_main_type * enkf_main, bool strict, bool verbose) {
-  if (!enkf_main->user_config_file)
-    return;
-
-  config_parser_type * config = config_alloc();
-  config_content_type * content = model_config_alloc_content(enkf_main->user_config_file, config);
-
-  enkf_main_user_select_initial_fs( enkf_main );
-
-  enkf_main_init_obs(enkf_main);
-
-  config_content_free(content);
-  config_free(config);
-}
 
 /**
    This function boots everything needed for running a EnKF
@@ -2125,20 +2111,18 @@ enkf_main_type * enkf_main_alloc(const char * model_config, const res_config_typ
   enkf_main->res_config = res_config;
 
   enkf_main_rng_init( enkf_main );
-
   enkf_main_set_verbose(enkf_main, verbose);
-
   enkf_main_init_log(enkf_main);
 
   char * user_config_file = enkf_main_alloc_model_config_filename(model_config);
   if(user_config_file) {
     enkf_main_set_user_config_file(enkf_main, user_config_file);
-    enkf_main_bootstrap_model(enkf_main, strict, verbose);
   }
   free(user_config_file);
 
+  enkf_main_user_select_initial_fs( enkf_main );
+  enkf_main_init_obs(enkf_main);
   enkf_main_add_ensemble_members(enkf_main);
-
   enkf_main_init_jobname(enkf_main);
 
   return enkf_main;

--- a/libenkf/src/ert_test_context.c
+++ b/libenkf/src/ert_test_context.c
@@ -64,7 +64,7 @@ static ert_test_context_type * ert_test_context_alloc__( const char * test_name 
     {
       char * config_file = util_split_alloc_filename( model_config );
       test_context->res_config = res_config_alloc_load(config_file);
-      test_context->enkf_main = enkf_main_alloc(config_file, test_context->res_config, true, false);
+      test_context->enkf_main = enkf_main_alloc(test_context->res_config, true, false);
       free( config_file );
     }
     test_context->rng = rng_alloc( MZRAN , INIT_DEV_URANDOM );

--- a/libenkf/tests/enkf_forward_init_FIELD.c
+++ b/libenkf/tests/enkf_forward_init_FIELD.c
@@ -60,7 +60,7 @@ int main(int argc , char ** argv) {
 
     util_clear_directory( "Storage" , true , true );
     res_config_type * res_config = res_config_alloc_load(config_file);
-    enkf_main = enkf_main_alloc(config_file, res_config, strict, true);
+    enkf_main = enkf_main_alloc(res_config, strict, true);
     {
       ensemble_config_type * ens_config = enkf_main_get_ensemble_config( enkf_main );
       enkf_config_node_type * field_config_node = ensemble_config_get_node( ens_config , "PORO" );

--- a/libenkf/tests/enkf_forward_init_GEN_KW.c
+++ b/libenkf/tests/enkf_forward_init_GEN_KW.c
@@ -59,7 +59,7 @@ int main(int argc , char ** argv) {
 
     util_clear_directory( "Storage" , true , true );
     res_config_type * res_config = res_config_alloc_load(config_file);
-    enkf_main = enkf_main_alloc(config_file, res_config, strict, true);
+    enkf_main = enkf_main_alloc(res_config, strict, true);
     {
       const enkf_config_node_type * gen_kw_config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ) , "MULTFLT" );
       enkf_node_type * gen_kw_node = enkf_node_alloc( gen_kw_config_node );

--- a/libenkf/tests/enkf_forward_init_GEN_PARAM.c
+++ b/libenkf/tests/enkf_forward_init_GEN_PARAM.c
@@ -60,7 +60,7 @@ int main(int argc , char ** argv) {
 
     util_clear_directory( "Storage" , true , true );
     res_config_type * res_config = res_config_alloc_load(config_file);
-    enkf_main = enkf_main_alloc(config_file, res_config, strict, true);
+    enkf_main = enkf_main_alloc(res_config, strict, true);
     {
       const enkf_config_node_type * config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ) , "PARAM" );
       enkf_node_type * gen_param_node = enkf_node_alloc( config_node );

--- a/libenkf/tests/enkf_forward_init_SURFACE.c
+++ b/libenkf/tests/enkf_forward_init_SURFACE.c
@@ -63,7 +63,7 @@ int main(int argc , char ** argv) {
 
     util_clear_directory( "Storage" , true , true );
     res_config_type * res_config = res_config_alloc_load(config_file);
-    enkf_main = enkf_main_alloc(config_file, res_config, strict, true);
+    enkf_main = enkf_main_alloc(res_config, strict, true);
     ensemble_config_type * ens_config = enkf_main_get_ensemble_config( enkf_main );
     {
       const enkf_config_node_type * surface_config_node = ensemble_config_get_node( ens_config , "SURFACE");

--- a/libenkf/tests/enkf_forward_init_transform.c
+++ b/libenkf/tests/enkf_forward_init_transform.c
@@ -78,7 +78,7 @@ int main(int argc , char ** argv) {
 
   bool strict = true;
   res_config_type * res_config = res_config_alloc_load(config_file);
-  enkf_main_type * enkf_main = enkf_main_alloc(config_file, res_config, strict, true);
+  enkf_main_type * enkf_main = enkf_main_alloc(res_config, strict, true);
   ensemble_config_type * ens_config = enkf_main_get_ensemble_config( enkf_main );
   enkf_fs_type * init_fs = enkf_main_get_fs(enkf_main);
   run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( init_fs , 0 ,0 , "simulations/run0");

--- a/libenkf/tests/enkf_main.c
+++ b/libenkf/tests/enkf_main.c
@@ -35,7 +35,7 @@ void test_case_initialized(const char * config_path, const char * config_file) {
   test_work_area_copy_directory_content(work_area, config_path);
   {
     res_config_type * res_config = res_config_alloc_load(config_file);
-    enkf_main_type * enkf_main = enkf_main_alloc(config_file, res_config, true, true);
+    enkf_main_type * enkf_main = enkf_main_alloc(res_config, true, true);
     model_config_type * model_config = enkf_main_get_model_config(enkf_main);
     const char * new_case = "fs/case";
     char * mount_point = util_alloc_sprintf("%s/%s" , model_config_get_enspath(model_config) , new_case);
@@ -57,7 +57,7 @@ void test_create(const char * config_path, const char * config_file) {
   test_work_area_copy_directory_content(work_area, config_path);
 
   res_config_type * res_config = res_config_alloc_load(config_file);
-  enkf_main_type * enkf_main = enkf_main_alloc(config_file, res_config, true, true);
+  enkf_main_type * enkf_main = enkf_main_alloc(res_config, true, true);
   test_assert_true( enkf_main_is_instance( enkf_main ) );
 
   enkf_main_free( enkf_main );

--- a/libenkf/tests/enkf_main_fs.c
+++ b/libenkf/tests/enkf_main_fs.c
@@ -41,7 +41,7 @@ int main(int argc, char ** argv) {
   test_work_area_copy_parent_content( work_area , config_file );
   {
     res_config_type * res_config = res_config_alloc_load(model_config);
-    enkf_main_type * enkf_main = enkf_main_alloc(model_config, res_config, false, false);
+    enkf_main_type * enkf_main = enkf_main_alloc(res_config, false, false);
 
     enkf_main_select_fs( enkf_main , "enkf");
     test_assert_true( enkf_main_case_is_current( enkf_main , "enkf"));

--- a/libenkf/tests/enkf_main_fs_current_file_test.c
+++ b/libenkf/tests/enkf_main_fs_current_file_test.c
@@ -30,7 +30,7 @@ void test_current_file_not_present_symlink_present(const char * model_config) {
     test_assert_true(util_file_exists("Storage/enkf"));
     util_make_slink("enkf", "Storage/current" ); 
     res_config_type * res_config = res_config_alloc_load(model_config);
-    enkf_main_type * enkf_main = enkf_main_alloc(model_config, res_config, false, false);
+    enkf_main_type * enkf_main = enkf_main_alloc(res_config, false, false);
     test_assert_true( enkf_main_case_is_current( enkf_main , "enkf"));
     test_assert_false(util_file_exists("Storage/current"));
     test_assert_true(util_file_exists("Storage/current_case"));
@@ -44,7 +44,7 @@ void test_current_file_not_present_symlink_present(const char * model_config) {
 void test_current_file_present(const char * model_config) {
     test_assert_true(util_file_exists("Storage/current_case"));
     res_config_type * res_config = res_config_alloc_load(model_config);
-    enkf_main_type * enkf_main = enkf_main_alloc(model_config, res_config, false, false);
+    enkf_main_type * enkf_main = enkf_main_alloc(res_config, false, false);
     test_assert_true( enkf_main_case_is_current( enkf_main , "enkf"));
     test_assert_false(util_file_exists("Storage/current"));
     char * current_case = enkf_main_read_alloc_current_case_name(enkf_main);
@@ -57,7 +57,7 @@ void test_current_file_present(const char * model_config) {
 
 void test_change_case(const char * model_config) {
     res_config_type * res_config = res_config_alloc_load(model_config);
-    enkf_main_type * enkf_main = enkf_main_alloc(model_config, res_config, false, false);
+    enkf_main_type * enkf_main = enkf_main_alloc(res_config, false, false);
     enkf_main_select_fs( enkf_main , "default");
     test_assert_true( enkf_main_case_is_current( enkf_main , "default"));
     test_assert_false( enkf_main_case_is_current(enkf_main , "enkf"));

--- a/libenkf/tests/enkf_plot_data_fs.c
+++ b/libenkf/tests/enkf_plot_data_fs.c
@@ -114,7 +114,7 @@ int main(int argc, char ** argv) {
     test_work_area_copy_parent_content( work_area , config_file );
     {
       res_config_type * res_config = res_config_alloc_load(model_config);
-      enkf_main_type * enkf_main = enkf_main_alloc(model_config, res_config, false, false);
+      enkf_main_type * enkf_main = enkf_main_alloc(res_config, false, false);
 
       test_load_summary(enkf_main , "WWCT:OP_3");
       test_load_GEN_KW( enkf_main , "MULTFLT" , "F3");

--- a/libenkf/tests/enkf_rng.c
+++ b/libenkf/tests/enkf_rng.c
@@ -38,7 +38,7 @@ int main(int argc , char ** argv) {
     test_work_area_copy_directory_content(work_area, config_path);
     {
       res_config_type * res_config = res_config_alloc_load(NULL);
-      enkf_main_type * enkf_main = enkf_main_alloc(NULL, res_config, true, true);
+      enkf_main_type * enkf_main = enkf_main_alloc(res_config, true, true);
       enkf_main_resize_ensemble( enkf_main , 10 );
       {
         enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
@@ -50,7 +50,7 @@ int main(int argc , char ** argv) {
     
     {
       res_config_type * res_config = res_config_alloc_load(NULL);
-      enkf_main_type * enkf_main = enkf_main_alloc(NULL, res_config, true, true);
+      enkf_main_type * enkf_main = enkf_main_alloc(res_config, true, true);
       enkf_main_resize_ensemble( enkf_main , 10 );
       {
         enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
@@ -72,7 +72,7 @@ int main(int argc , char ** argv) {
     const char * seed_file = "seed";
     {
       res_config_type * res_config = res_config_alloc_load(config_file);
-      enkf_main_type * enkf_main = enkf_main_alloc(config_file, res_config, true, true);
+      enkf_main_type * enkf_main = enkf_main_alloc(res_config, true, true);
       {
         rng_config_type * rng_config = enkf_main_get_rng_config( enkf_main );
         rng_config_set_seed_store_file( rng_config , seed_file );
@@ -90,7 +90,7 @@ int main(int argc , char ** argv) {
     
     {
       res_config_type * res_config = res_config_alloc_load(config_file);
-      enkf_main_type * enkf_main = enkf_main_alloc(config_file, res_config, true, true);
+      enkf_main_type * enkf_main = enkf_main_alloc(res_config, true, true);
       {
         rng_config_type * rng_config = enkf_main_get_rng_config( enkf_main );
         rng_config_set_seed_load_file( rng_config , seed_file );
@@ -115,7 +115,7 @@ int main(int argc , char ** argv) {
     test_work_area_copy_directory_content( work_area , config_path );
     {
       res_config_type * res_config = res_config_alloc_load(config_file);
-      enkf_main_type * enkf_main = enkf_main_alloc(config_file, res_config, true, true);
+      enkf_main_type * enkf_main = enkf_main_alloc(res_config, true, true);
       enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
       rand1 = enkf_state_get_random( state );
       enkf_main_free( enkf_main );
@@ -124,7 +124,7 @@ int main(int argc , char ** argv) {
 
     {
       res_config_type * res_config = res_config_alloc_load(config_file);
-      enkf_main_type * enkf_main = enkf_main_alloc(config_file, res_config, true, true);
+      enkf_main_type * enkf_main = enkf_main_alloc(res_config, true, true);
       enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
       rand2 = enkf_state_get_random( state );
       enkf_main_free( enkf_main );
@@ -134,7 +134,7 @@ int main(int argc , char ** argv) {
     
     {
       res_config_type * res_config = res_config_alloc_load(config_file);
-      enkf_main_type * enkf_main = enkf_main_alloc(config_file, res_config, true, true);
+      enkf_main_type * enkf_main = enkf_main_alloc(res_config, true, true);
       enkf_state_type * state = enkf_main_iget_state( enkf_main , 9 );
       rand2 = enkf_state_get_random( state );
       enkf_main_free( enkf_main );

--- a/libenkf/tests/enkf_state_manual_load_test.c
+++ b/libenkf/tests/enkf_state_manual_load_test.c
@@ -67,7 +67,7 @@ int main(int argc , char ** argv) {
   {
     bool strict = true;
     res_config_type * res_config = res_config_alloc_load(config_file);
-    enkf_main_type * enkf_main = enkf_main_alloc(config_file, res_config, strict, true);
+    enkf_main_type * enkf_main = enkf_main_alloc(res_config, strict, true);
 
     test_assert_int_equal( 0 , test_load_manually_to_new_case(enkf_main));
 

--- a/libenkf/tests/enkf_state_report_step_compatible.c
+++ b/libenkf/tests/enkf_state_report_step_compatible.c
@@ -61,7 +61,7 @@ int main(int argc , char ** argv) {
   
   bool strict = true;
   res_config_type * res_config = res_config_alloc_load(config_file);
-  enkf_main_type * enkf_main = enkf_main_alloc(config_file, res_config, strict, true);
+  enkf_main_type * enkf_main = enkf_main_alloc(res_config, strict, true);
   
   test_assert_bool_equal(check_compatible , check_ecl_sum_compatible(enkf_main));
   

--- a/libenkf/tests/enkf_state_skip_summary_load_test.c
+++ b/libenkf/tests/enkf_state_skip_summary_load_test.c
@@ -63,7 +63,7 @@ int main(int argc , char ** argv) {
   
   bool strict = true;
   res_config_type * res_config = res_config_alloc_load(config_file);
-  enkf_main_type * enkf_main = enkf_main_alloc(config_file, res_config, strict, true);
+  enkf_main_type * enkf_main = enkf_main_alloc(res_config, strict, true);
   
   test_assert_true( check_ecl_sum_loaded(enkf_main) );
   

--- a/python/python/res/enkf/enkf_main.py
+++ b/python/python/res/enkf/enkf_main.py
@@ -32,7 +32,7 @@ from res.enkf.key_manager import KeyManager
 
 class EnKFMain(BaseCClass):
     TYPE_NAME = "enkf_main"
-    _alloc = EnkfPrototype("void* enkf_main_alloc(char*, res_config, bool, bool)", bind = False)
+    _alloc = EnkfPrototype("void* enkf_main_alloc(res_config, bool, bool)", bind = False)
     _create_new_config = EnkfPrototype("void enkf_main_create_new_config(char* , char*, char* , int)", bind = False)
 
     _free = EnkfPrototype("void enkf_main_free(enkf_main)")
@@ -73,9 +73,16 @@ class EnKFMain(BaseCClass):
     _get_res_config = EnkfPrototype("res_config_ref enkf_main_get_res_config(enkf_main)")
 
 
-    def __init__(self, model_config, res_config=None, strict=True, verbose=True):
+    def __init__(self, model_config=None, res_config=None, strict=True, verbose=True):
         if model_config is not None and not isfile(model_config):
             raise IOError('No such configuration file "%s".' % model_config)
+
+        if model_config is not None and res_config is not None:
+            raise ValueError(
+                        "Expected either model_config or res_config to be None"
+                        )
+
+        # TODO: Deprecation warning it model_config is not None
 
         if res_config is None:
             res_config = ResConfig(model_config)
@@ -84,7 +91,7 @@ class EnKFMain(BaseCClass):
         if res_config is None or not isinstance(res_config, ResConfig):
             raise TypeError("Failed to construct EnKFMain instance due to invalid res_config.")
 
-        c_ptr = self._alloc(model_config, res_config, strict, verbose)
+        c_ptr = self._alloc(res_config, strict, verbose)
         if c_ptr:
             super(EnKFMain, self).__init__(c_ptr)
         else:

--- a/python/tests/res/enkf/test_enkf.py
+++ b/python/tests/res/enkf/test_enkf.py
@@ -40,7 +40,8 @@ class EnKFTest(ExtendedTestCase):
     def test_repr( self ):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
             work_area.copy_directory(self.case_directory)
-            main = EnKFMain("simple_config/minimum_config")
+            res_config = ResConfig("simple_config/minimum_config")
+            main = EnKFMain(res_config)
             pfx = 'EnKFMain(ensemble_size'
             self.assertEqual(pfx, repr(main)[:len(pfx)])
             main.free()
@@ -48,7 +49,8 @@ class EnKFTest(ExtendedTestCase):
     def test_bootstrap( self ):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
             work_area.copy_directory(self.case_directory)
-            main = EnKFMain("simple_config/minimum_config")
+            res_config = ResConfig("simple_config/minimum_config")
+            main = EnKFMain(res_config)
             self.assertTrue(main, "Load failed")
             main.free()
 
@@ -56,7 +58,7 @@ class EnKFTest(ExtendedTestCase):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
             work_area.copy_directory(self.case_directory)
             res_config = ResConfig("simple_config/minimum_config")
-            main = EnKFMain(res_config=res_config)
+            main = EnKFMain(res_config)
 
             self.assertTrue(main, "Load failed")
 
@@ -77,7 +79,8 @@ class EnKFTest(ExtendedTestCase):
     def test_default_res_config(self):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
             work_area.copy_directory(self.case_directory)
-            main = EnKFMain("simple_config/minimum_config")
+            res_config = ResConfig("simple_config/minimum_config")
+            main = EnKFMain(res_config)
 
             self.assertIsNotNone(main.resConfig)
             self.assertIsNotNone(main.siteConfig)
@@ -87,7 +90,7 @@ class EnKFTest(ExtendedTestCase):
         with TestAreaContext("enkf_test") as work_area:
             with self.assertRaises(TypeError):
                 work_area.copy_directory(self.case_directory)
-                main = EnKFMain(res_config=self)
+                main = EnKFMain(res_config="This is not a ResConfig instance")
 
 
 
@@ -109,7 +112,8 @@ class EnKFTest(ExtendedTestCase):
         with TestAreaContext("enkf_test") as work_area:
             work_area.copy_directory(self.case_directory)
 
-            main = EnKFMain("simple_config/minimum_config")
+            res_config = ResConfig("simple_config/minimum_config")
+            main = EnKFMain(res_config)
 
             count = 10
             summary_key = "test_key"
@@ -160,7 +164,8 @@ class EnKFTest(ExtendedTestCase):
         with TestAreaContext("enkf_test") as work_area:
             work_area.copy_directory(self.case_directory)
 
-            main = EnKFMain("simple_config/minimum_config")
+            res_config = ResConfig("simple_config/minimum_config")
+            main = EnKFMain(res_config)
 
             self.assertIsInstance(main.ensembleConfig(), EnsembleConfig)
             self.assertIsInstance(main.analysisConfig(), AnalysisConfig)
@@ -188,14 +193,16 @@ class EnKFTest(ExtendedTestCase):
         
         with TestAreaContext("python/ens_condif/create_config" , store_area = True) as ta:
             EnKFMain.createNewConfig(config_file, "storage" , dbase_type, num_realizations)
-            main = EnKFMain(config_file)
+            res_config = ResConfig(config_file)
+            main = EnKFMain(res_config)
             self.assertEqual(main.getEnsembleSize(), num_realizations)
 
 
     def test_run_context(self):
         with TestAreaContext("enkf_test") as work_area:
             work_area.copy_directory(self.case_directory)
-            main = EnKFMain("simple_config/minimum_config")
+            res_config = ResConfig("simple_config/minimum_config")
+            main = EnKFMain(res_config)
             fs_manager = main.getEnkfFsManager()
             fs = fs_manager.getCurrentFileSystem( )
             iactive = BoolVector(initial_size = 10 , default_value = True)

--- a/python/tests/res/enkf/test_enkf.py
+++ b/python/tests/res/enkf/test_enkf.py
@@ -56,10 +56,7 @@ class EnKFTest(ExtendedTestCase):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
             work_area.copy_directory(self.case_directory)
             res_config = ResConfig("simple_config/minimum_config")
-            main = EnKFMain(
-                    "simple_config/minimum_config",
-                    res_config=res_config
-                    )
+            main = EnKFMain(res_config=res_config)
 
             self.assertTrue(main, "Load failed")
 
@@ -90,7 +87,7 @@ class EnKFTest(ExtendedTestCase):
         with TestAreaContext("enkf_test") as work_area:
             with self.assertRaises(TypeError):
                 work_area.copy_directory(self.case_directory)
-                main = EnKFMain("simple_config/minimum_config", res_config=self)
+                main = EnKFMain(res_config=self)
 
 
 

--- a/python/tests/res/enkf/test_enkf_library.py
+++ b/python/tests/res/enkf/test_enkf_library.py
@@ -5,7 +5,7 @@ from ecl.ecl import EclSum
 from res.enkf import AnalysisConfig, EclConfig, GenKwConfig, EnkfConfigNode, SiteConfig, ObsVector
 from res.enkf import GenDataConfig, FieldConfig, EnkfFs, EnkfObs, EnKFState, EnsembleConfig
 from res.enkf import ErtTemplate, ErtTemplates, LocalConfig, ModelConfig
-from res.enkf.enkf_main import EnKFMain
+from res.enkf import EnKFMain, ResConfig
 
 from res.enkf.util import TimeMap
 
@@ -27,7 +27,8 @@ class EnKFLibraryTest(ExtendedTestCase):
         with TestAreaContext("enkf_library_test") as work_area:
             work_area.copy_directory(self.case_directory)
 
-            main = EnKFMain("simple_config/minimum_config")
+            res_config = ResConfig("simple_config/minimum_config")
+            main = EnKFMain(res_config)
 
             self.assertIsInstance(main.analysisConfig(), AnalysisConfig)
             self.assertIsInstance(main.eclConfig(), EclConfig)
@@ -47,7 +48,8 @@ class EnKFLibraryTest(ExtendedTestCase):
         with TestAreaContext("enkf_library_test") as work_area:
             work_area.copy_directory(self.case_directory)
 
-            main = EnKFMain("simple_config/minimum_config")
+            res_config = ResConfig("simple_config/minimum_config")
+            main = EnKFMain(res_config)
             state = main.getRealisation( 0 )
             
             with self.assertRaises(TypeError):

--- a/python/tests/res/enkf/test_summary_key_set.py
+++ b/python/tests/res/enkf/test_summary_key_set.py
@@ -5,7 +5,7 @@ from res.test.ert_test_context import ErtTestContext
 
 from res.enkf import SummaryKeySet
 from res.enkf.enkf_fs import EnkfFs
-from res.enkf.enkf_main import EnKFMain
+from res.enkf import EnKFMain, ResConfig
 
 
 class SummaryKeySetTest(ExtendedTestCase):
@@ -83,7 +83,8 @@ class SummaryKeySetTest(ExtendedTestCase):
             summary_key_set.addSummaryKey("WOPR")
             fs.umount()
 
-            ert = EnKFMain("config")
+            res_config = ResConfig("config")
+            ert = EnKFMain(res_config)
             fs = ert.getEnkfFsManager().getCurrentFileSystem()
             summary_key_set = fs.getSummaryKeySet()
             self.assertTrue("FOPT" in summary_key_set)

--- a/python/tests/res/server/test_rpc_service.py
+++ b/python/tests/res/server/test_rpc_service.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import time
+import warnings
 from threading import Thread
 
 from ecl import Version
@@ -25,13 +26,55 @@ class RPCServiceTest(ExtendedTestCase):
     def setUp(self):
         self.config = self.createTestPath("local/snake_oil_no_data/snake_oil.ert")
 
+
+    def test_deprecated_server_creation(self):
+        with ErtTestContext("ert/server/rpc/server", self.config) as test_context:
+            ert = test_context.getErt()
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                server = ErtRPCServer(ert.getUserConfigFile())
+                self.assertTrue(len(w) > 0)
+                self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+            self.assertIsNotNone(server.port)
+
+            expected_config_file = os.path.join(
+                                            test_context.getCwd(),
+                                            os.path.basename(self.config)
+                                            )
+            self.assertEqual(expected_config_file, server._config_file)
+
+            thread = Thread(name="ErtRPCServerTest")
+            thread.run = server.start
+            thread.start()
+
+            server.stop()
+
+    def test_invalid_server_creation(self):
+        with ErtTestContext("ert/server/rpc/server", self.config) as test_context:
+
+            # No such file
+            with self.assertRaises(IOError):
+                server = ErtRPCServer("this/is/not/a/file")
+
+            # No configuration
+            with self.assertRaises(ValueError):
+                server = ErtRPCServer(None)
+
+            # Wrong enkf_main type
+            with self.assertRaises(TypeError):
+                enkf_main = test_context.getErt()
+                server = ErtRPCServer(enkf_main=enkf_main.resConfig())
+
+
     def test_server_creation(self):
         with ErtTestContext("ert/server/rpc/server", self.config) as test_context:
             ert = test_context.getErt()
             server = ErtRPCServer(ert)
 
             self.assertIsNotNone(server.port)
-            self.assertEqual(ert, server._config)
+            self.assertEqual(ert, server._enkf_main)
 
             expected_config_file = os.path.join(
                                             test_context.getCwd(),

--- a/python/tests/res/server/test_rpc_service.py
+++ b/python/tests/res/server/test_rpc_service.py
@@ -32,7 +32,12 @@ class RPCServiceTest(ExtendedTestCase):
 
             self.assertIsNotNone(server.port)
             self.assertEqual(ert, server._config)
-            self.assertEqual(os.path.basename(self.config), server._config_file)
+
+            expected_config_file = os.path.join(
+                                            test_context.getCwd(),
+                                            os.path.basename(self.config)
+                                            )
+            self.assertEqual(expected_config_file, server._config_file)
 
             thread = Thread(name="ErtRPCServerTest")
             thread.run = server.start


### PR DESCRIPTION
**Task**
_Remove the last part of enkf_main's initialization that depends on the configuration file provided by the user._


**Approach**
_enkf_main_alloc no longer takes the filename of the configuration file as an argument._


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/ert#47