### PR TITLE
Move files from libecl to libres

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,18 @@ set(INSTALL_GROUP ""
         CACHE STRING "Group to install as - blank to install as current group")
 set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
-
 #-----------------------------------------------------------------
+
+find_package(Threads)
+if (CMAKE_USE_PTHREADS_INIT)
+    set(HAVE_PTHREAD TRUE)
+endif ()
+
+# feature tests
+include(CheckFunctionExists)
+check_function_exists( regexec ERT_HAVE_REGEXP )
+#-----------------------------------------------------------------
+
 add_subdirectory(libres_util)
 add_subdirectory(libconfig)
 add_subdirectory(libsched)

--- a/applications/block_fs/bcp.c
+++ b/applications/block_fs/bcp.c
@@ -1,0 +1,85 @@
+/*
+   Copyright (C) 2011  Statoil ASA, Norway. 
+    
+   The file 'bcp.c' is part of ERT - Ensemble based Reservoir Tool. 
+    
+   ERT is free software: you can redistribute it and/or modify 
+   it under the terms of the GNU General Public License as published by 
+   the Free Software Foundation, either version 3 of the License, or 
+   (at your option) any later version. 
+    
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+   FITNESS FOR A PARTICULAR PURPOSE.   
+    
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+   for more details. 
+*/
+
+#include <util.h>
+#include <block_fs.h>
+#include <vector.h>
+#include <signal.h>
+#include <msg.h>
+
+
+static void install_SIGNALS(void) {
+  signal(SIGSEGV , util_abort_signal);    /* Segmentation violation, i.e. overwriting memory ... */
+  signal(SIGINT  , util_abort_signal);    /* Control C */
+  signal(SIGTERM , util_abort_signal);    /* If killing the program with SIGTERM (the default kill signal) you will get a backtrace. Killing with SIGKILL (-9) will not give a backtrace.*/
+}
+
+
+static void usage() {
+  printf("Usage: \n\n");
+  printf("bcp src.mnt   target.mnt  file \n");
+  exit(1);
+}
+
+
+
+int main(int argc , char ** argv) {
+  install_SIGNALS();
+  if (argc < 4)
+    usage();
+  {
+    const char * src_mount      = argv[1];
+    const char * target_mount   = argv[2];
+    if (block_fs_is_mount(src_mount)) {
+      const char * pattern  = NULL;
+      int iarg;
+      
+      for (iarg = 3; iarg < argc; iarg++) {
+        if (argv[iarg][0] == '-') {
+          /** OK - this is an option .. */
+        }
+        else pattern = argv[iarg];
+      }
+      
+      {
+        block_fs_type * src_fs    = block_fs_mount(src_mount , 1 , 0 , 1 , 0 , false , true );
+        block_fs_type * target_fs = block_fs_mount(target_mount , 1 , 0 , 1 , 0 , false , false );
+        vector_type   * files     = block_fs_alloc_filelist( src_fs , pattern , NO_SORT , false );
+        buffer_type   * buffer    = buffer_alloc( 1024 );
+        {
+          int i;
+          msg_type   * msg      = msg_alloc("Copying :" , false);
+          msg_show( msg );
+          for (i=0; i < vector_get_size( files ); i++) {
+            const user_file_node_type * node = vector_iget_const( files , i );
+            const char * filename       = user_file_node_get_filename( node );
+            msg_update( msg , filename ); 
+            block_fs_fread_realloc_buffer( src_fs , filename , buffer );
+            block_fs_fwrite_buffer( target_fs , filename , buffer );
+          }
+          msg_free( msg , true );
+        }
+        buffer_free( buffer );
+        vector_free( files );
+        block_fs_close( target_fs , true);
+        block_fs_close( src_fs    , false );
+      }
+    } else 
+      fprintf(stderr,"The files:%s/%s does not seem to be a block_fs mount files.\n" , src_mount , target_mount);
+  }
+}

--- a/applications/block_fs/bfs_extract.c
+++ b/applications/block_fs/bfs_extract.c
@@ -1,0 +1,100 @@
+/*
+   Copyright (C) 2011  Statoil ASA, Norway. 
+    
+   The file 'bfs_extract.c' is part of ERT - Ensemble based Reservoir Tool. 
+    
+   ERT is free software: you can redistribute it and/or modify 
+   it under the terms of the GNU General Public License as published by 
+   the Free Software Foundation, either version 3 of the License, or 
+   (at your option) any later version. 
+    
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+   FITNESS FOR A PARTICULAR PURPOSE.   
+    
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+   for more details. 
+*/
+
+#include <util.h>
+#include <block_fs.h>
+#include <vector.h>
+#include <signal.h>
+#include <msg.h>
+
+/*****************************************************************/
+/* 
+   This program is used to extract individual files from a block_fs
+   file.
+*/
+   
+
+
+
+void install_SIGNALS(void) {
+  signal(SIGSEGV , util_abort_signal);    /* Segmentation violation, i.e. overwriting memory ... */
+  signal(SIGINT  , util_abort_signal);    /* Control C */
+  signal(SIGTERM , util_abort_signal);    /* If killing the enkf program with SIGTERM (the default kill signal) you will get a backtrace. Killing with SIGKILL (-9) will not give a backtrace.*/
+}
+
+
+static void usage() {
+  fprintf(stderr,"\nThis program is used to extract individual files from a block_fs\n");
+  fprintf(stderr,"file. The arguments to the program are:\n");
+  fprintf(stderr,"\n");
+  fprintf(stderr,"  1. The block_fs mount file.\n");
+  fprintf(stderr,"  2. The name of directory (need not exist) where the extracted files will be put.\n");
+  fprintf(stderr,"  3. A list of files to extract - this can contain wildcards, but they MUST be \n");
+  fprintf(stderr,"     quoted to avoid expansion by the shell.\n");
+  fprintf(stderr,"\n");
+  fprintf(stderr,"Example:\n\n");
+  fprintf(stderr,"  bash%% bfs_extract  block_fs_file.mnt  DOGFolder \'DOG*\'\n\n");
+  fprintf(stderr,"This will extract all files starting with \'DOG\' to folder \'DOGFolder\'.\n\n");
+  exit(1);
+}
+
+
+int main(int argc , char ** argv) {
+  install_SIGNALS();
+  if (argc < 3)
+    usage();
+  {
+    
+    const char * mount_file      = argv[1];
+    if (block_fs_is_mount(mount_file)) {
+      const char * target_path     = argv[2];
+      int iarg;
+      if (!util_is_directory( target_path )) {
+        if (util_file_exists( target_path ))
+          util_exit("The target:%s already exists - but it is not a directory.\n");
+        else
+          util_make_path( target_path );
+      }
+      {
+        block_fs_type * block_fs = block_fs_mount(mount_file , 1 , 0 , 1 , 0 , false , true );
+        buffer_type * buffer = buffer_alloc(1024);
+        msg_type * msg = msg_alloc("Extracting: " , false);
+        msg_show( msg );
+
+        for (iarg = 3; iarg < argc; iarg++) {
+          vector_type   * files  = block_fs_alloc_filelist( block_fs , argv[iarg] , NO_SORT , false );
+          {
+            int i;
+            for (i=0; i < vector_get_size( files ); i++) {
+              const user_file_node_type * node = vector_iget_const( files , i );
+              const char * filename    = user_file_node_get_filename( node );
+              const char * target_file = util_alloc_filename( target_path , filename , NULL );
+              msg_update( msg , filename );
+              block_fs_fread_realloc_buffer( block_fs , filename , buffer );
+              buffer_store( buffer , target_file );
+            }
+          }
+          vector_free( files );
+        }
+        block_fs_close( block_fs , false );
+        msg_free( msg , true );
+      }
+    } else 
+      fprintf(stderr,"The file:%s does not seem to be a block_fs mount file.\n" , mount_file);
+  }
+}

--- a/applications/block_fs/block_fs_test.c
+++ b/applications/block_fs/block_fs_test.c
@@ -1,0 +1,221 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <util.h>
+#include <block_fs.h>
+#include <hash.h>
+
+
+typedef enum {
+  WRITE_FILE  = 1,
+  DELETE_FILE = 2,
+  CHECK       = 3,
+  ROTATE      = 4
+} test_action_enum;
+
+#define WRITE_FILE_STRING  "WRITE_FILE"
+#define DELETE_FILE_STRING "DELETE_FILE"
+#define CHECK_STRING       "CHECK"
+#define ROATATE_STRING     "ROTATE"
+
+
+typedef struct {
+  test_action_enum   action;
+  char             * filename;
+  int                length;
+} action_node_type;
+
+
+action_node_type * action_node_alloc_new() {
+  action_node_type * node = util_malloc( sizeof * node );
+  node->filename = NULL;
+  return node;
+}
+
+void action_node_free(action_node_type * node) {
+  util_safe_free( node->filename );
+  free( node );
+}
+
+void action_node_update(action_node_type * node, test_action_enum action , char * filename) {
+  util_safe_free( node->filename );
+  node->filename = filename;  /* Node takes ownership of filename. */
+  node->action   = action;
+}
+
+
+void apply_delete_file( const action_node_type * node , block_fs_type * fs , const char * file_path) {
+  if (block_fs_has_file( fs , node->filename)) {
+    char * filename = util_alloc_filename( file_path , node->filename , NULL );
+    block_fs_unlink_file( fs , node->filename );
+    unlink( filename );
+    free( filename );
+  }
+}
+
+void apply_check( block_fs_type * fs , const char * file_path ) {
+  char * buffer1 = NULL;
+  char * buffer2 = NULL;
+
+  int current_size = 0;
+  vector_type   * files = block_fs_alloc_filelist( fs , NULL  , NO_SORT , false );
+  int i;
+  for (i=0; i < vector_get_size( files ); i++) {
+    const user_file_node_type * node = vector_iget_const( files , i );
+    int size = user_file_node_get_data_size( node );
+    if (size > current_size) {
+      current_size = size;
+      buffer1 = util_realloc( buffer1 , current_size );
+      buffer2 = util_realloc( buffer2 , current_size );
+    }
+    block_fs_fread_file( fs , user_file_node_get_filename( node ) , buffer1 );
+    {
+      char * filename = util_alloc_filename( file_path , user_file_node_get_filename( node ) , NULL);
+      FILE * stream   = util_fopen( filename , "r");
+      util_fread( buffer2 , 1 , size , stream , __func__);
+      fclose( stream );
+      free( filename );
+    }
+    if (memcmp( buffer1 , buffer2 , size ) != 0)
+      fprintf(stderr,"Fatal error ..\n");
+  }
+  vector_free( files );
+  free( buffer1 );
+  free( buffer2 );
+  printf("CHeck OK \n");
+}
+
+
+void apply_write_file( const action_node_type * node , block_fs_type * fs , const char * file_path) {
+  const int short_min = 128;
+  const int short_max = 256;
+  const int long_min  = 4096;
+  const int long_max  = 32000;
+  const double p_short = 0.75;
+  int length;
+
+  
+  {
+    int min,max;
+    double R = rand() * 1.0 / RAND_MAX;
+    if (R < p_short) {
+      min = short_min;
+      max = short_max;
+    } else {
+      min = long_min;
+      max = long_max;
+    }
+    length = min + (rand() % (max - min + 1));
+  }
+  {
+    char * buffer = util_malloc( length * sizeof * buffer );
+    int i;
+    for (i=0; i < length; i++)
+      buffer[i] = rand() % 256;
+    block_fs_fwrite_file( fs , node->filename , buffer , length);
+    {
+      char * filename = util_alloc_filename(  file_path , node->filename , NULL );
+      FILE * stream = util_fopen( filename , "w");
+      util_fwrite( buffer , 1 , length , stream , __func__ );
+      fclose( stream );
+      free(filename);
+    }
+    free( buffer );
+  }
+}
+
+
+
+void apply( const action_node_type ** action_list , int action_length, block_fs_type * fs , const char * file_path) {
+  int i;
+  for (i=0; i < action_length; i++) {
+    const action_node_type * node = action_list[i];
+    switch( node->action) {
+    case WRITE_FILE:
+      apply_write_file( node , fs , file_path );
+      break;
+    case DELETE_FILE:
+      apply_delete_file( node , fs , file_path );
+      break;
+    case CHECK:
+      apply_check( fs , file_path );
+      break;
+    case ROTATE:
+      block_fs_rotate( fs , 0.00 );
+      break;
+    default:
+      util_abort("Unrecognized enum value:%d \n", node->action );
+    }
+  }
+}
+
+
+int main(int argc, char ** argv) {
+  
+  const char * test_path  = "/tmp/block_fs"; 
+  const char * file_fmt   = "file_%04d";
+  char * file_path        = util_alloc_filename( test_path , "files" , NULL );
+  char * test_mnt         = util_alloc_filename( test_path , "FORECAST" , "mnt");
+  char * test_log         = util_alloc_filename( test_path , "test" , "log");
+
+  const int    test_run   =    10;
+  const int    block_size =  1000;
+  const int    max_files  =  1000;
+  
+  const int fs_block_size  = 32;
+  const int cache_size     = 2048;
+  const float frag_limit   = 0.25;
+  const int fsync_interval = 100;
+  const bool preload       = false;
+  int run = 0;
+
+  block_fs_type * block_fs = block_fs_mount( test_mnt , fs_block_size , cache_size , frag_limit , fsync_interval , preload , false );
+  
+  action_node_type ** action_list = util_malloc( block_size * sizeof * action_list );
+  {
+    int i;
+    for (i=0; i < block_size; i++) {
+      action_list[i] = action_node_alloc_new(  );
+    }
+  }
+
+  while ( run < test_run) {
+    int action_nr = 0;
+
+    run++;
+    while (action_nr < (block_size - 2)) {
+      char * filename = NULL;
+      int R = rand() % 3;
+      if (R == 0) {
+        /* Delete file */
+        filename = util_alloc_sprintf( file_fmt , rand() % max_files );
+        action_node_update( action_list[ action_nr ] , DELETE_FILE  , filename );
+      } else {
+        /* Create file */
+        filename = util_alloc_sprintf( file_fmt , rand() % max_files );
+        action_node_update( action_list[ action_nr ] , WRITE_FILE  , filename );
+      }
+
+      action_nr++;
+    }
+    action_node_update( action_list[ block_size - 2] , ROTATE  , NULL);
+    action_node_update( action_list[ block_size - 1] , CHECK   , NULL);
+    
+    apply( (const action_node_type **) action_list , block_size , block_fs , file_path );
+    //fprintf_log( log_stream , action_list , block_size );
+    printf("*"); fflush( stdout );
+  }
+  
+  {
+    int i;
+    for (i=0; i < block_size; i++) 
+      action_node_free( action_list[i] );
+    
+  }
+  free( action_list );
+  block_fs_close( block_fs , true);
+  
+  free( file_path );
+  free( test_mnt );
+  free( test_log );
+}

--- a/applications/block_fs/bls.c
+++ b/applications/block_fs/bls.c
@@ -1,0 +1,77 @@
+/*
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'bls.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <signal.h>
+
+#include <ert/util/util.h>
+#include <ert/util/block_fs.h>
+#include <ert/util/vector.h>
+
+
+void install_SIGNALS(void) {
+  signal(SIGSEGV , util_abort_signal);    /* Segmentation violation, i.e. overwriting memory ... */
+  signal(SIGINT  , util_abort_signal);    /* Control C */
+  signal(SIGTERM , util_abort_signal);    /* If killing the enkf program with SIGTERM (the default kill signal) you will get a backtrace. Killing with SIGKILL (-9) will not give a backtrace.*/
+}
+
+
+static int usage( void ) {
+  fprintf(stderr,"\n");
+  fprintf(stderr,"Usage:\n\n");
+  fprintf(stderr,"   bash%% bls BLOCK_FILE.mnt <pattern>\n\n");
+  fprintf(stderr,"Will list all elements in BLOCK_FILE matching pattern - remember to quote wildcards.\n");
+  exit(1);
+}
+
+
+int main(int argc , char ** argv) {
+  install_SIGNALS();
+  if (argc == 1)
+    usage();
+  {
+    const char * mount_file      = argv[1];
+    if (block_fs_is_mount(mount_file)) {
+      block_fs_sort_type sort_mode = OFFSET_SORT;
+      const char * pattern         = NULL;
+      int iarg;
+
+      for (iarg = 2; iarg < argc; iarg++) {
+        if (argv[iarg][0] == '-') {
+          /** OK - this is an option .. */
+        }
+        else
+          pattern = argv[iarg];
+      }
+
+      {
+        block_fs_type * block_fs = block_fs_mount(mount_file , 1 , 0 , 1 , 0 , false , true , false);
+        vector_type   * files    = block_fs_alloc_filelist( block_fs , pattern , sort_mode , false );
+        {
+          int i;
+          for (i=0; i < vector_get_size( files ); i++) {
+            const user_file_node_type * node = vector_iget_const( files , i );
+            printf("%-40s   %10d %ld    \n",user_file_node_get_filename( node ), user_file_node_get_data_size( node ) , user_file_node_get_node_offset( node ));
+          }
+        }
+        vector_free( files );
+        block_fs_close( block_fs , false );
+      }
+    } else
+      fprintf(stderr,"The file:%s does not seem to be a block_fs mount file.\n" , mount_file);
+  }
+}

--- a/applications/block_fs/brm.c
+++ b/applications/block_fs/brm.c
@@ -1,0 +1,73 @@
+/*
+   Copyright (C) 2011  Statoil ASA, Norway. 
+    
+   The file 'brm.c' is part of ERT - Ensemble based Reservoir Tool. 
+    
+   ERT is free software: you can redistribute it and/or modify 
+   it under the terms of the GNU General Public License as published by 
+   the Free Software Foundation, either version 3 of the License, or 
+   (at your option) any later version. 
+    
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+   FITNESS FOR A PARTICULAR PURPOSE.   
+    
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+   for more details. 
+*/
+
+#include <util.h>
+#include <block_fs.h>
+#include <vector.h>
+#include <signal.h>
+#include <msg.h>
+
+
+void install_SIGNALS(void) {
+  signal(SIGSEGV , util_abort_signal);    /* Segmentation violation, i.e. overwriting memory ... */
+  signal(SIGINT  , util_abort_signal);    /* Control C */
+  signal(SIGTERM , util_abort_signal);    /* If killing the enkf program with SIGTERM (the default kill signal) you will get a backtrace. Killing with SIGKILL (-9) will not give a backtrace.*/
+}
+
+
+int main(int argc , char ** argv) {
+  install_SIGNALS();
+  const char * mount_file      = argv[1];
+  if (block_fs_is_mount(mount_file)) {
+    block_fs_sort_type sort_mode = OFFSET_SORT;
+    const char * pattern         = NULL;
+    int iarg;
+
+    for (iarg = 2; iarg < argc; iarg++) {
+      if (argv[iarg][0] == '-') {
+        /** OK - this is an option .. */
+      }
+      else pattern = argv[iarg];
+    }
+    
+    {
+      block_fs_type * block_fs = block_fs_mount(mount_file , 1 , 0 , 1 , 0 , false , false );
+      vector_type   * files    = block_fs_alloc_filelist( block_fs , pattern , sort_mode , false );
+      {
+        int i;
+        msg_type * msg = msg_alloc("Deleting file: " , false);
+        msg_show( msg );
+        //for (i=0; i < vector_get_size( files ); i++) {
+        //  const user_file_node_type * node = vector_iget_const( files , i );
+        //  printf("%-40s   %10d %ld    \n",user_file_node_get_filename( node ), user_file_node_get_data_size( node ) , user_file_node_get_node_offset( node ));
+        //}
+
+        for (i=0; i < vector_get_size( files ); i++) {
+          const user_file_node_type * node = vector_iget_const( files , i );
+          msg_update( msg , user_file_node_get_filename( node ) );
+          block_fs_unlink_file( block_fs , user_file_node_get_filename( node ));
+        }
+        msg_free( msg , true );
+        printf("Final fragmentation: %5.2f \n", block_fs_get_fragmentation( block_fs ));
+      }
+      vector_free( files );
+      block_fs_close( block_fs , false );
+    }
+  } else 
+    fprintf(stderr,"The file:%s does not seem to be a block_fs mount file.\n" , mount_file);
+}

--- a/applications/block_fs/brot.c
+++ b/applications/block_fs/brot.c
@@ -1,0 +1,41 @@
+/*
+   Copyright (C) 2011  Statoil ASA, Norway. 
+    
+   The file 'brot.c' is part of ERT - Ensemble based Reservoir Tool. 
+    
+   ERT is free software: you can redistribute it and/or modify 
+   it under the terms of the GNU General Public License as published by 
+   the Free Software Foundation, either version 3 of the License, or 
+   (at your option) any later version. 
+    
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+   FITNESS FOR A PARTICULAR PURPOSE.   
+    
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+   for more details. 
+*/
+
+#include <util.h>
+#include <block_fs.h>
+#include <vector.h>
+#include <signal.h>
+#include <msg.h>
+
+
+void install_SIGNALS(void) {
+  signal(SIGSEGV , util_abort_signal);    /* Segmentation violation, i.e. overwriting memory ... */
+  signal(SIGINT  , util_abort_signal);    /* Control C */
+  signal(SIGTERM , util_abort_signal);    /* If killing the enkf program with SIGTERM (the default kill signal) you will get a backtrace. Killing with SIGKILL (-9) will not give a backtrace.*/
+}
+
+
+int main(int argc , char ** argv) {
+  install_SIGNALS();
+  const char * mount_file = argv[1];
+  if (block_fs_is_mount(mount_file)) {
+    block_fs_type * block_fs = block_fs_mount(mount_file , 1 , 0 , 1 , 0 , false , false );
+    block_fs_rotate( block_fs , 0.00 ); 
+    block_fs_close( block_fs , false );
+  }
+}

--- a/libconfig/CMakeLists.txt
+++ b/libconfig/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(config src/config_parser.c
                    src/conf_util.c
 )
 
-target_link_libraries(config PUBLIC ecl)
+target_link_libraries(config PUBLIC ecl res_util)
 target_include_directories(config
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
            $<INSTALL_INTERFACE:include>

--- a/libconfig/include/ert/config/config_content.h
+++ b/libconfig/include/ert/config/config_content.h
@@ -26,7 +26,7 @@ extern "C" {
 
 #include <ert/util/type_macros.h>
 #include <ert/util/stringlist.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_content_item.h>
 #include <ert/config/config_schema_item.h>

--- a/libconfig/include/ert/config/config_parser.h
+++ b/libconfig/include/ert/config/config_parser.h
@@ -28,8 +28,8 @@ extern "C" {
 #include <stdbool.h>
 
 #include <ert/util/stringlist.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/hash.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_schema_item.h>
 #include <ert/config/config_content_item.h>

--- a/libconfig/src/config_content.c
+++ b/libconfig/src/config_content.c
@@ -21,7 +21,7 @@
 #include <ert/util/hash.h>
 #include <ert/util/set.h>
 #include <ert/util/vector.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_root_path.h>
 #include <ert/config/config_path_elm.h>

--- a/libconfig/src/config_parser.c
+++ b/libconfig/src/config_parser.c
@@ -27,9 +27,9 @@
 #include <ert/util/parser.h>
 #include <ert/util/hash.h>
 #include <ert/util/stringlist.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/vector.h>
 #include <ert/util/path_stack.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_parser.h>
 #include <ert/config/config_error.h>

--- a/libconfig/src/config_schema_item.c
+++ b/libconfig/src/config_schema_item.c
@@ -27,8 +27,8 @@
 #include <ert/util/hash.h>
 #include <ert/util/stringlist.h>
 #include <ert/util/set.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/vector.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_error.h>
 #include <ert/config/config_schema_item.h>

--- a/libconfig/tests/config_define.c
+++ b/libconfig/tests/config_define.c
@@ -21,12 +21,13 @@
 
 #include <ert/util/test_util.h>
 #include <ert/util/util.h>
-#include <ert/util/subst_list.h>
 
 #include <ert/config/config_parser.h>
 #include <ert/config/config_content_node.h>
 #include <ert/config/config_schema_item.h>
 #include <ert/config/config_path_elm.h>
+
+#include <ert/res_util/subst_list.h>
 
 void test_define(config_parser_type * config , const char * config_file) {
   hash_type * pre_defined_kw_map = hash_alloc();

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -27,13 +27,13 @@ extern "C" {
 #include <ert/util/util.h>
 #include <ert/util/stringlist.h>
 #include <ert/util/set.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/bool_vector.h>
 #include <ert/util/int_vector.h>
 #include <ert/util/matrix.h>
 #include <ert/util/path_fmt.h>
 #include <ert/util/ui_return.h>
 #include <ert/util/log.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/sched/sched_file.h>
 

--- a/libenkf/include/ert/enkf/enkf_state.h
+++ b/libenkf/include/ert/enkf/enkf_state.h
@@ -25,11 +25,10 @@ extern "C" {
 #include <stdbool.h>
 
 #include <ert/util/hash.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/rng.h>
 #include <ert/util/stringlist.h>
 #include <ert/util/matrix.h>
-
+#include <ert/res_util/subst_list.h>
 
 #include <ert/sched/sched_file.h>
 

--- a/libenkf/include/ert/enkf/ert_run_context.h
+++ b/libenkf/include/ert/enkf/ert_run_context.h
@@ -25,7 +25,7 @@ extern "C" {
 #include <ert/util/type_macros.h>
 #include <ert/util/bool_vector.h>
 #include <ert/util/path_fmt.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/enkf_types.h>
 #include <ert/enkf/run_arg.h>

--- a/libenkf/include/ert/enkf/ert_template.h
+++ b/libenkf/include/ert/enkf/ert_template.h
@@ -23,8 +23,8 @@
 extern "C" {
 #endif
 
-#include <ert/util/subst_list.h>
 #include <ert/util/stringlist.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_parser.h>
 #include <ert/config/config_content.h>

--- a/libenkf/include/ert/enkf/ert_workflow_list.h
+++ b/libenkf/include/ert/enkf/ert_workflow_list.h
@@ -24,8 +24,8 @@
 extern "C" {
 #endif
 
-#include <ert/util/subst_list.h>
 #include <ert/util/type_macros.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_parser.h>
 #include <ert/config/config_content.h>

--- a/libenkf/include/ert/enkf/gen_kw.h
+++ b/libenkf/include/ert/enkf/gen_kw.h
@@ -22,8 +22,8 @@
 extern "C" {
 #endif
 
-#include <ert/util/subst_list.h>
 #include <ert/util/double_vector.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/gen_kw_config.h>
 #include <ert/enkf/enkf_util.h>

--- a/libenkf/include/ert/enkf/member_config.h
+++ b/libenkf/include/ert/enkf/member_config.h
@@ -26,7 +26,7 @@ extern "C" {
 #include <stdbool.h>
 #include <time.h>
 
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/sched/sched_file.h>
 

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -19,8 +19,8 @@
 #ifndef ERT_RES_CONFIG_H
 #define ERT_RES_CONFIG_H
 
-#include <ert/util/subst_list.h>
 #include <ert/util/subst_func.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_settings.h>
 

--- a/libenkf/include/ert/enkf/run_arg.h
+++ b/libenkf/include/ert/enkf/run_arg.h
@@ -23,8 +23,8 @@ extern "C" {
 #endif
 
 #include <ert/util/path_fmt.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/type_macros.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/enkf_types.h>
 #include <ert/enkf/enkf_fs.h>

--- a/libenkf/src/block_fs_driver.c
+++ b/libenkf/src/block_fs_driver.c
@@ -22,10 +22,10 @@
 
 #include <ert/util/util.h>
 #include <ert/util/path_fmt.h>
-#include <ert/util/block_fs.h>
 #include <ert/util/buffer.h>
 #include <ert/util/timer.h>
 #include <ert/util/thread_pool.h>
+#include <ert/res_util/block_fs.h>
 
 #include <ert/enkf/fs_types.h>
 #include <ert/enkf/fs_driver.h>

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -31,7 +31,6 @@
 
 #define HAVE_THREAD_POOL 1
 #include <ert/util/matrix.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/rng.h>
 #include <ert/util/subst_func.h>
 #include <ert/util/int_vector.h>
@@ -47,6 +46,7 @@
 #include <ert/util/node_ctype.h>
 #include <ert/util/string_util.h>
 #include <ert/util/type_vector_functions.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_parser.h>
 #include <ert/config/config_schema_item.h>

--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -33,10 +33,10 @@
 #include <ert/util/arg_pack.h>
 #include <ert/util/stringlist.h>
 #include <ert/util/node_ctype.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/timer.h>
 #include <ert/util/time_t_vector.h>
 #include <ert/util/rng.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/ecl/fortio.h>
 #include <ert/ecl/ecl_kw.h>

--- a/libenkf/src/ert_run_context.c
+++ b/libenkf/src/ert_run_context.c
@@ -22,10 +22,10 @@
 #include <ert/util/type_macros.h>
 #include <ert/util/vector.h>
 #include <ert/util/path_fmt.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/int_vector.h>
 #include <ert/util/stringlist.h>
 #include <ert/util/type_vector_functions.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/enkf_types.h>
 #include <ert/enkf/run_arg.h>

--- a/libenkf/src/ert_template.c
+++ b/libenkf/src/ert_template.c
@@ -18,10 +18,10 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-#include <ert/util/template.h>
 #include <ert/util/hash.h>
 #include <ert/util/util.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/template.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/ert_template.h>
 #include <ert/enkf/config_keys.h>

--- a/libenkf/src/ert_workflow_list.c
+++ b/libenkf/src/ert_workflow_list.c
@@ -28,8 +28,8 @@
 #include <ert/util/ert_version.h>
 #include <ert/util/stringlist.h>
 #include <ert/util/util.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/type_macros.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_parser.h>
 #include <ert/config/config_error.h>

--- a/libenkf/src/gen_kw.c
+++ b/libenkf/src/gen_kw.c
@@ -25,7 +25,7 @@
 #include <ert/util/buffer.h>
 #include <ert/util/matrix.h>
 #include <ert/util/rng.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/ecl/fortio.h>
 

--- a/libenkf/src/hook_manager.c
+++ b/libenkf/src/hook_manager.c
@@ -20,8 +20,8 @@
 #include <string.h>
 
 #include <ert/util/util.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/vector.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_parser.h>
 

--- a/libenkf/src/hook_workflow.c
+++ b/libenkf/src/hook_workflow.c
@@ -20,8 +20,8 @@
 #include <string.h>
 
 #include <ert/util/util.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/type_macros.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_parser.h>
 

--- a/libenkf/src/member_config.c
+++ b/libenkf/src/member_config.c
@@ -22,7 +22,7 @@
 
 #include <ert/util/util.h>
 #include <ert/util/path_fmt.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/ecl_config.h>
 #include <ert/enkf/member_config.h>

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -16,8 +16,8 @@
    for more details.
 */
 
-#include <ert/util/subst_list.h>
 #include <ert/util/subst_func.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_settings.h>
 

--- a/libenkf/src/run_arg.c
+++ b/libenkf/src/run_arg.c
@@ -18,8 +18,8 @@
 
 
 #include <ert/util/path_fmt.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/type_macros.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/enkf_types.h>
 #include <ert/enkf/run_arg.h>

--- a/libenkf/src/subst_config.c
+++ b/libenkf/src/subst_config.c
@@ -17,8 +17,8 @@
 */
 
 #include <ert/util/rng.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/subst_func.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/enkf_defaults.h>
 #include <ert/enkf/config_keys.h>

--- a/libenkf/tests/enkf_ert_run_context.c
+++ b/libenkf/tests/enkf_ert_run_context.c
@@ -19,7 +19,7 @@
 
 #include <ert/util/test_util.h>
 #include <ert/util/path_fmt.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/ert_run_context.h>
 #include <ert/enkf/run_arg.h>

--- a/libenkf/tests/enkf_export_inactive_cells.c
+++ b/libenkf/tests/enkf_export_inactive_cells.c
@@ -23,7 +23,7 @@
 #include <ert/util/test_util.h>
 #include <ert/enkf/ert_test_context.h>
 #include <ert/util/util.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/ecl/ecl_kw_magic.h>
 #include <ert/ecl/ecl_kw.h>

--- a/libenkf/tests/enkf_forward_init_FIELD.c
+++ b/libenkf/tests/enkf_forward_init_FIELD.c
@@ -27,7 +27,7 @@
 #include <ert/util/arg_pack.h>
 #include <ert/util/rng.h>
 #include <ert/util/mzran.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/enkf_main.h>
 

--- a/libenkf/tests/enkf_forward_init_GEN_PARAM.c
+++ b/libenkf/tests/enkf_forward_init_GEN_PARAM.c
@@ -27,7 +27,7 @@
 #include <ert/util/util.h>
 #include <ert/util/thread_pool.h>
 #include <ert/util/arg_pack.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/enkf_main.h>
 #include <ert/enkf/run_arg.h>

--- a/libenkf/tests/enkf_forward_init_SURFACE.c
+++ b/libenkf/tests/enkf_forward_init_SURFACE.c
@@ -27,7 +27,7 @@
 #include <ert/util/arg_pack.h>
 #include <ert/util/rng.h>
 #include <ert/util/mzran.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/enkf_main.h>
 #include <ert/enkf/run_arg.h>

--- a/libenkf/tests/enkf_forward_init_transform.c
+++ b/libenkf/tests/enkf_forward_init_transform.c
@@ -23,7 +23,7 @@
 #include <ert/util/test_util.h>
 #include <ert/util/test_work_area.h>
 #include <ert/util/util.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/ecl/ecl_kw_magic.h>
 

--- a/libenkf/tests/enkf_hook_manager_test.c
+++ b/libenkf/tests/enkf_hook_manager_test.c
@@ -18,7 +18,7 @@
 #include <ert/util/util.h>
 #include <ert/util/test_util.h>
 #include <ert/enkf/hook_manager.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 int main(int argc, char ** argv) {
 

--- a/libenkf/tests/enkf_run_arg.c
+++ b/libenkf/tests/enkf_run_arg.c
@@ -19,8 +19,8 @@
 
 #include <ert/util/test_util.h>
 #include <ert/util/path_fmt.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/test_work_area.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/enkf/ert_run_context.h>
 #include <ert/enkf/run_arg.h>

--- a/libjob_queue/include/ert/job_queue/ext_job.h
+++ b/libjob_queue/include/ert/job_queue/ext_job.h
@@ -24,8 +24,8 @@ extern "C" {
 #include <stdio.h>
 
 #include <ert/util/hash.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/stringlist.h>
+#include <ert/res_util/subst_list.h>
 
 typedef struct ext_job_struct ext_job_type;
 

--- a/libjob_queue/include/ert/job_queue/ext_joblist.h
+++ b/libjob_queue/include/ert/job_queue/ext_joblist.h
@@ -25,7 +25,7 @@ extern "C" {
 
 #include <ert/util/hash.h>
 #include <ert/util/stringlist.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/job_queue/ext_job.h>
 

--- a/libjob_queue/include/ert/job_queue/forward_model.h
+++ b/libjob_queue/include/ert/job_queue/forward_model.h
@@ -25,7 +25,7 @@ extern "C" {
 #include <stdbool.h>
 
 #include <ert/util/stringlist.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/job_queue/ext_joblist.h>
 

--- a/libjob_queue/include/ert/job_queue/workflow.h
+++ b/libjob_queue/include/ert/job_queue/workflow.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
   
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_error.h>
 

--- a/libjob_queue/src/ext_job.c
+++ b/libjob_queue/src/ext_job.c
@@ -27,8 +27,8 @@
 #include <ert/util/util.h>
 #include <ert/util/hash.h>
 #include <ert/util/stringlist.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/parser.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_parser.h>
 #include <ert/config/config_content.h>

--- a/libjob_queue/src/ext_joblist.c
+++ b/libjob_queue/src/ext_joblist.c
@@ -27,7 +27,7 @@
 #include <ert/util/util.h>
 #include <ert/util/hash.h>
 #include <ert/util/stringlist.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/job_queue/ext_job.h>
 #include <ert/job_queue/ext_joblist.h>

--- a/libjob_queue/src/forward_model.c
+++ b/libjob_queue/src/forward_model.c
@@ -23,9 +23,9 @@
 #include <unistd.h>
 
 #include <ert/util/util.h>
-#include <ert/util/subst_list.h>
 #include <ert/util/vector.h>
 #include <ert/util/parser.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/job_queue/ext_job.h>
 #include <ert/job_queue/ext_joblist.h>

--- a/libjob_queue/src/workflow.c
+++ b/libjob_queue/src/workflow.c
@@ -26,7 +26,7 @@
 #include <ert/util/stringlist.h>
 #include <ert/util/arg_pack.h>
 #include <ert/util/vector.h>
-#include <ert/util/subst_list.h>
+#include <ert/res_util/subst_list.h>
 
 #include <ert/config/config_parser.h>
 

--- a/libres_util/CMakeLists.txt
+++ b/libres_util/CMakeLists.txt
@@ -1,6 +1,19 @@
 project(res_util C)
 
-add_library( res_util src/res_log.c )
+if (ERT_HAVE_REGEXP)
+ list(APPEND opt_srcs src/template_loop.c)
+endif ()
+
+if (HAVE_PTHREAD)
+    list(APPEND opt_srcs src/block_fs.c)
+endif ()
+
+add_library( res_util src/res_log.c
+                      src/subst_list.c
+                      src/template.c
+                      src/template_loop.c
+                      src/block_fs.c
+                      ${opt_srcs})
 
 
 target_link_libraries( res_util PUBLIC ecl )
@@ -24,3 +37,11 @@ if (NOT BUILD_TESTS)
 endif()
 
 #Tests go below
+add_executable(ert_util_subst_list tests/ert_util_subst_list.c)
+target_link_libraries(ert_util_subst_list res_util)
+add_test(NAME ert_util_subst_list COMMAND ert_util_subst_list)
+
+add_executable(ert_util_block_fs tests/ert_util_block_fs.c)
+target_link_libraries(ert_util_block_fs res_util)
+add_test(NAME ert_util_block_fs COMMAND ert_util_block_fs)
+

--- a/libres_util/include/ert/res_util/block_fs.h
+++ b/libres_util/include/ert/res_util/block_fs.h
@@ -1,0 +1,76 @@
+/*
+   Copyright (C) 2011  Statoil ASA, Norway. 
+    
+   The file 'block_fs.h' is part of ERT - Ensemble based Reservoir Tool. 
+    
+   ERT is free software: you can redistribute it and/or modify 
+   it under the terms of the GNU General Public License as published by 
+   the Free Software Foundation, either version 3 of the License, or 
+   (at your option) any later version. 
+    
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+   FITNESS FOR A PARTICULAR PURPOSE.   
+    
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+   for more details. 
+*/
+
+#ifndef ERT_BLOCK_FS
+#define ERT_BLOCK_FS
+#include <ert/util/buffer.h>
+#include <ert/util/vector.h>
+#include <ert/util/type_macros.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  typedef struct block_fs_struct  block_fs_type;
+  typedef struct user_file_node_struct user_file_node_type;
+  
+  typedef enum {
+    NO_SORT     = 0,
+    STRING_SORT = 1,
+    OFFSET_SORT = 2
+  } block_fs_sort_type;
+  
+  size_t          block_fs_get_cache_usage( const block_fs_type * block_fs );
+  double          block_fs_get_fragmentation( const block_fs_type * block_fs );
+  bool            block_fs_rotate( block_fs_type * block_fs , double fragmentation_limit);
+  void            block_fs_fsync( block_fs_type * block_fs );
+  bool            block_fs_is_mount( const char * mount_file );
+  bool            block_fs_is_readonly( const block_fs_type * block_fs);
+  block_fs_type * block_fs_mount( const char * mount_file , 
+                                  int block_size , 
+                                  int max_cache_size , 
+                                  float fragmentation_limit , 
+                                  int fsync_interval , 
+                                  bool preload , 
+                                  bool read_only, 
+                                  bool use_lockfile);
+  void            block_fs_close( block_fs_type * block_fs , bool unlink_empty);
+  void            block_fs_fwrite_file(block_fs_type * block_fs , const char * filename , const void * ptr , size_t byte_size);
+  void            block_fs_fwrite_buffer(block_fs_type * block_fs , const char * filename , const buffer_type * buffer);
+  void            block_fs_fread_file( block_fs_type * block_fs , const char * filename , void * ptr);
+  int             block_fs_get_filesize( block_fs_type * block_fs , const char * filename);
+  void            block_fs_fread_realloc_buffer( block_fs_type * block_fs , const char * filename , buffer_type * buffer);
+  void            block_fs_sync( block_fs_type * block_fs );
+  void            block_fs_unlink_file( block_fs_type * block_fs , const char * filename);
+  bool            block_fs_has_file( block_fs_type * block_fs , const char * filename);
+  vector_type   * block_fs_alloc_filelist( block_fs_type * block_fs  , const char * pattern , block_fs_sort_type sort_mode , bool include_free_nodes );
+  void            block_fs_defrag( block_fs_type * block_fs );
+  
+  long int        user_file_node_get_node_offset( const user_file_node_type * user_file_node );
+  long int        user_file_node_get_data_offset( const user_file_node_type * user_file_node );
+  int             user_file_node_get_node_size( const user_file_node_type * user_file_node );
+  int             user_file_node_get_data_size( const user_file_node_type * user_file_node );
+  bool            user_file_node_in_use( const user_file_node_type * user_file_node );
+  const char *    user_file_node_get_filename( const user_file_node_type * user_file_node );
+
+UTIL_IS_INSTANCE_HEADER( block_fs );
+UTIL_SAFE_CAST_HEADER( block_fs );
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/libres_util/include/ert/res_util/subst_list.h
+++ b/libres_util/include/ert/res_util/subst_list.h
@@ -1,0 +1,70 @@
+/*
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'subst_list.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#ifndef ERT_SUBST_H
+#define ERT_SUBST_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stdio.h>
+#include <stdbool.h>
+
+#include <ert/util/type_macros.h>
+#include <ert/util/subst_func.h>
+
+  typedef struct          subst_list_struct subst_list_type;
+  bool                    subst_list_update_buffer( const subst_list_type * subst_list , buffer_type * buffer );
+  void                    subst_list_insert_func(subst_list_type * subst_list , const char * func_name , const char * local_func_name);
+  void                    subst_list_fprintf(const subst_list_type * , FILE * stream);
+  void                    subst_list_set_parent( subst_list_type * subst_list , const subst_list_type * parent);
+  const subst_list_type * subst_list_get_parent( const subst_list_type * subst_list );
+  subst_list_type       * subst_list_alloc( const void * input_arg );
+  subst_list_type       * subst_list_alloc_deep_copy(const subst_list_type * );
+  void                    subst_list_free(subst_list_type *);
+  void                    subst_list_clear( subst_list_type * subst_list );
+  void                    subst_list_append_copy(subst_list_type *  , const char * , const char * , const char * doc_string);
+  void                    subst_list_append_ref(subst_list_type *  , const char * , const char * , const char * doc_string);
+  void                    subst_list_append_owned_ref(subst_list_type *  , const char * , const char * , const char * doc_string);
+  void                    subst_list_prepend_copy(subst_list_type *  , const char * , const char * , const char * doc_string);
+  void                    subst_list_prepend_ref(subst_list_type *  , const char * , const char * , const char * doc_string);
+  void                    subst_list_prepend_owned_ref(subst_list_type *  , const char * , const char * , const char * doc_string);
+
+  bool                    subst_list_filter_file(const subst_list_type * , const char * , const  char * );
+  bool                    subst_list_update_file(const subst_list_type * , const char * );
+  bool                    subst_list_update_string(const subst_list_type * , char ** );
+  char                  * subst_list_alloc_filtered_string(const subst_list_type * , const char * );
+  void                    subst_list_filtered_fprintf(const subst_list_type * , const char *  , FILE * );
+  int                     subst_list_get_size( const subst_list_type *);
+  const char            * subst_list_get_value( const subst_list_type * subst_list , const char * key);
+  const char            * subst_list_iget_value( const subst_list_type * subst_list , int index);
+  const char            * subst_list_iget_key( const subst_list_type * subst_list , int index);
+  const char            * subst_list_iget_doc_string( const subst_list_type * subst_list , int index);
+  const char            * subst_list_get_doc_string( const subst_list_type * subst_list , const char * key);
+  bool                    subst_list_has_key( const subst_list_type * subst_list , const char * key);
+  char                  * subst_list_alloc_string_representation( const subst_list_type * subst_list );
+  int                     subst_list_add_from_string( subst_list_type * subst_list , const char * arg_string, bool append);
+
+  UTIL_IS_INSTANCE_HEADER( subst_list );
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+
+

--- a/libres_util/include/ert/res_util/template.h
+++ b/libres_util/include/ert/res_util/template.h
@@ -1,0 +1,48 @@
+/*
+   Copyright (C) 2011  Statoil ASA, Norway. 
+    
+   The file 'template.h' is part of ERT - Ensemble based Reservoir Tool. 
+    
+   ERT is free software: you can redistribute it and/or modify 
+   it under the terms of the GNU General Public License as published by 
+   the Free Software Foundation, either version 3 of the License, or 
+   (at your option) any later version. 
+    
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+   FITNESS FOR A PARTICULAR PURPOSE.   
+    
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+   for more details. 
+*/
+
+#ifndef ERT_UTIL_TEMPLATE_H
+#define ERT_UTIL_TEMPLATE_H
+#ifdef __cplusplus 
+extern "C" {
+#endif
+
+
+#include <stdbool.h>
+
+#include <ert/res_util/subst_list.h>
+
+typedef struct template_struct template_type;
+
+
+template_type * template_alloc( const char * template_file , bool internalize_template, subst_list_type * parent_subst);
+void            template_free( template_type * template );
+void            template_instantiate( const template_type * template , const char * __target_file , const subst_list_type * arg_list , bool override_symlink);
+void            template_add_arg( template_type * template , const char * key , const char * value );
+
+void            template_clear_args( template_type * template );
+int             template_add_args_from_string( template_type * template , const char * arg_string);
+char          * template_get_args_as_string( template_type * template );
+void            template_set_template_file( template_type * template , const char * template_file);
+const char    * template_get_template_file( const template_type * template );
+
+
+#endif
+#ifdef __cplusplus 
+}
+#endif

--- a/libres_util/include/ert/res_util/template_type.h
+++ b/libres_util/include/ert/res_util/template_type.h
@@ -1,0 +1,34 @@
+#ifndef ERT_TEMPLATE_TYPE_H
+#define ERT_TEMPLATE_TYPE_H
+
+#include <ert/util/ert_api_config.h>
+
+#include <ert/res_util/subst_list.h>
+
+#ifdef ERT_HAVE_REGEXP
+#include <regex.h>
+#endif //ERT_HAVE_REGEXP
+
+#define TEMPLATE_TYPE_ID 7781045
+
+struct template_struct {
+  UTIL_TYPE_ID_DECLARATION;
+  char            * template_file;           /* The template file - if internalize_template == false this filename can contain keys which will be replaced at instantiation time. */
+  char            * template_buffer;         /* The content of the template buffer; only has valid content if internalize_template == true. */
+  bool              internalize_template;    /* Should the template be loadad and internalized at template_alloc(). */
+  subst_list_type * arg_list;                /* Key-value mapping established at alloc time. */
+  char            * arg_string;              /* A string representation of the arguments - ONLY used for a _get_ function. */ 
+  #ifdef ERT_HAVE_REGEXP
+  regex_t start_regexp;
+  regex_t end_regexp;
+  #endif
+};
+
+#ifdef ERT_HAVE_REGEXP
+typedef struct loop_struct loop_type;
+void template_init_loop_regexp( struct template_struct* );
+int template_eval_loop( const struct template_struct* , buffer_type * buffer , int global_offset , struct loop_struct * );
+void template_eval_loops( const struct template_struct* template , buffer_type * buffer );
+#endif //ERT_HAVE_REGEXP
+
+#endif //ERT_TEMPLATE_TYPE_H

--- a/libres_util/src/block_fs.c
+++ b/libres_util/src/block_fs.c
@@ -1,0 +1,1814 @@
+/*
+   Copyright (C) 2011  Statoil ASA, Norway. 
+    
+   The file 'block_fs.c' is part of ERT - Ensemble based Reservoir Tool. 
+    
+   ERT is free software: you can redistribute it and/or modify 
+   it under the terms of the GNU General Public License as published by 
+   the Free Software Foundation, either version 3 of the License, or 
+   (at your option) any later version. 
+    
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+   FITNESS FOR A PARTICULAR PURPOSE.    
+    
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+   for more details. 
+*/
+
+#define  _GNU_SOURCE   /* Must define this to get access to pthread_rwlock_t */
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <time.h>
+#include <fnmatch.h>
+
+#include <ert/util/hash.h>
+#include <ert/util/util.h>
+#include <ert/util/vector.h>
+#include <ert/util/buffer.h>
+#include <ert/util/long_vector.h>
+#include <ert/res_util/block_fs.h>
+
+
+#define MOUNT_MAP_MAGIC_INT  8861290
+#define BLOCK_FS_TYPE_ID     7100652
+#define INDEX_MAGIC_INT      1213775
+#define INDEX_FORMAT_VERSION       1
+
+// #define ENABLE_CACHE
+
+
+/*
+  During mounting a significant part of the time is spent on filling
+  up the index hash table. By default a hash table is created with a
+  quite small size, and when initializing a large block_fs structure
+  it must be resized many times. By setting a default size with the
+  DEFAULT_INDEX_SIZE variable the hash table will immediately be
+  resized, avoiding some of the automatic calls to hash_resize. 
+
+  When the file system is loaded from an index a good size estimate
+  can be inferred directly from the index.  
+*/
+
+#define DEFAULT_INDEX_SIZE 2048
+
+
+
+/**
+   These should be bitwise "smart" - so it is possible
+   to go on a wild chase through a binary stream and look for them.
+*/
+
+#define NODE_IN_USE_BYTE  85                /* Binary(85)  =  01010101 */
+#define NODE_FREE_BYTE   170                /* Binary(170) =  10101010 */   
+#define WRITE_START__    77162
+
+static const int NODE_END_TAG            = 16711935;       /* Binary      =  00000000111111110000000011111111 */
+static const int NODE_WRITE_ACTIVE_START = WRITE_START__;
+static const int NODE_WRITE_ACTIVE_END   = 776512;
+
+
+typedef enum {
+  NODE_IN_USE       =  1431655765,    /* NODE_IN_USE_BYTE * ( 1 + 256 + 256**2 + 256**3) => Binary 01010101010101010101010101010101 */
+  NODE_FREE         = -1431655766,    /* NODE_FREE_BYTE   * ( 1 + 256 + 256**2 + 256**3) => Binary 10101010101010101010101010101010 */
+  NODE_WRITE_ACTIVE =  WRITE_START__, /* This */
+  NODE_INVALID      = 13              /* This should __never__ be written to disk */
+} node_status_type;
+
+
+/**
+   The free_node_struct is used to implement a doubly linked list of
+   free nodes; i.e. holes in the file which are available for other use. 
+*/
+typedef struct file_node_struct file_node_type;
+typedef struct free_node_struct free_node_type;
+
+struct free_node_struct {
+  free_node_type * next;
+  free_node_type * prev;
+  file_node_type * file_node;
+};
+
+
+
+/*
+  Datastructure representing one 'block' in the datafile. The block
+  can either refer to a file (status == NODE_IN_USE) or to an empty
+  slot in the datafile (status == NODE_FREE).
+*/
+
+struct file_node_struct{
+  long int           node_offset;   /* The offset into the data_file of this node. NEVER Changed. */
+  int                data_offset;   /* The offset from the node start to the start of actual data - i.e. data starts at absolute position: node_offset + data_offset. */
+  int                node_size;     /* The size in bytes of this node - must be >= data_size. NEVER Changed. */
+  int                data_size;     /* The size of the data stored in this node - in addition the node might need to store header information. */
+  node_status_type   status;        /* This should be: NODE_IN_USE | NODE_FREE; in addition the disk can have NODE_WRITE_ACTIVE for incomplete writes. */
+
+#ifdef ENABLE_CACHE
+  char             * cache;
+  int                cache_size;
+#endif
+};
+
+
+/**
+   data_size   : manipulated in block_fs_fwrite__() and block_fs_insert_free_node().
+   status      : manipulated in block_fs_fwrite__() and block_fs_unlink_file__();
+   data_offset : manipulated in block_fs_fwrite__() and block_fs_insert_free_node().
+*/
+
+
+
+
+
+
+struct block_fs_struct {
+  UTIL_TYPE_ID_DECLARATION;
+  char           * mount_file;    /* The full path to a file with some mount information - input to the mount routine. */
+  char           * path;          
+  char           * base_name;
+  
+  int              version;       /* A version number which is incremented each time the filesystem is defragmented - not implemented yet. */
+  
+  char           * data_file;
+  char           * lock_file;
+  char           * index_file;
+  
+  int              data_fd;
+  FILE           * data_stream;
+
+  long int         data_file_size;  /* The total number of bytes in the data_file. */
+  long int         free_size;       /* Size of 'holes' in the data file. */ 
+  int              block_size;      /* The size of blocks in bytes. */
+  int              lock_fd;         /* The file descriptor for the lock_file. Set to -1 if we do not have write access. */
+  
+  pthread_mutex_t  io_lock;         /* Lock held during fread of the data file. */
+  pthread_rwlock_t rw_lock;         /* Read-write lock during all access to the fs. */
+  
+  int              num_free_nodes;   
+  hash_type      * index;           /* THE HASH table of all the nodes/files which have been stored. */
+  free_node_type * free_nodes;
+  vector_type    * file_nodes;      /* This vector owns all the file_node instances - the index and free_nodes structures
+                                       only contain pointers to the objects stored in this vector. */
+  int              write_count;     /* This just counts the number of writes since the file system was mounted. */
+  int              max_cache_size;
+  size_t           total_cache_size;
+  size_t           max_total_cache_size;
+  float            fragmentation_limit;  /* If fragmentation (amount of wasted space) is above this limit - do a rotate.
+                                            fragmentation_limit == 1.0 : Never rotate.
+                                            fragmentation_limit == 0.0 : Rotate when one byte is wasted. */
+  bool             data_owner;
+  int              fsync_interval;  /* 0: never  n: every nth iteration. */
+};
+
+/*****************************************************************/
+
+static void block_fs_rotate__( block_fs_type * block_fs );
+
+UTIL_SAFE_CAST_FUNCTION( block_fs , BLOCK_FS_TYPE_ID )
+
+
+static inline void fseek__(FILE * stream , long int arg , int whence) {
+  if (fseek(stream , arg , whence) != 0) {
+    fprintf(stderr,"** Warning - seek:%ld failed %s(%d) \n",arg,strerror(errno) , errno);
+    util_abort("%S - aborting\n",__func__);
+  }
+}
+
+static inline void block_fs_fseek(block_fs_type * block_fs , long offset) {
+  fseek__( block_fs->data_stream , offset , SEEK_SET );
+}
+
+
+/*****************************************************************/
+/* file_node functions */
+
+
+
+
+/**
+   Observe that the two input arguments to this function should NEVER
+   change. They represent offset and size in the underlying data file,
+   and that is for ever fixed.  
+*/
+
+
+static file_node_type * file_node_alloc( node_status_type status , long int offset , int node_size) {
+  file_node_type * file_node = util_malloc( sizeof * file_node );
+  
+  file_node->node_offset = offset;    /* These should NEVER change. */
+  file_node->node_size   = node_size; /* -------------------------  */
+
+  file_node->data_size   = 0;
+  file_node->data_offset = 0;
+  file_node->status      = status; 
+  
+#ifdef ENABLE_CACHE
+  file_node->cache      = NULL;
+  file_node->cache_size = 0;
+#endif
+
+  return file_node;
+}
+
+
+/**
+   This function is called from the functions exporting file_node
+   instances; the file_node instance will then have a correct filename
+   field immediately afterwards, but the normal block_fs functions
+   (read/write/unlink) do NOT update this field, so it can quickly go
+   out of sync.
+*/
+
+
+     
+
+
+
+#ifdef ENABLE_CACHE
+static void file_node_read_from_cache( const file_node_type * file_node , void * ptr , size_t read_bytes) {
+  memcpy(ptr , file_node->cache , read_bytes);
+  /*
+    Could check: (ext_offset + file_node->cache_size <= read_bytes) - else
+    we are reading beyond the end of the cache.
+  */
+}
+
+
+static void file_node_buffer_read_from_cache( const file_node_type * file_node , buffer_type * buffer ) {
+  buffer_fwrite( buffer , file_node->cache , 1 , file_node->cache_size );
+}
+
+
+static void file_node_update_cache( file_node_type * file_node , int data_size , const void * data) {
+  if (data_size != file_node->cache_size) {
+    file_node->cache = util_realloc_copy( file_node->cache , data , data_size );
+    file_node->cache_size = data_size;
+  } else 
+    memcpy( file_node->cache , data , data_size);
+}
+
+
+static void file_node_clear_cache( file_node_type * file_node ) {
+  if (file_node->cache != NULL) {
+    file_node->cache_size = 0;
+    free(file_node->cache);
+    file_node->cache = NULL;
+  }
+}
+#endif
+
+
+static void file_node_free( file_node_type * file_node ) {
+  free( file_node );
+#ifdef ENABLE_CACHE
+  util_safe_free( file_node->cache );
+#endif
+}
+
+
+static void file_node_free__( void * file_node ) {
+  file_node_free( (file_node_type *) file_node );
+}
+
+
+
+static bool file_node_verify_end_tag( const file_node_type * file_node , FILE * stream ) {
+  int end_tag;
+  fseek__( stream , file_node->node_offset + file_node->node_size - sizeof NODE_END_TAG , SEEK_SET);      
+  if (fread( &end_tag , sizeof end_tag , 1 , stream) == 1) {
+    if (end_tag == NODE_END_TAG) 
+      return true; /* All hunkadory. */
+    else
+      return false;
+  } else 
+    return false;
+}
+
+
+
+static file_node_type * file_node_fread_alloc( FILE * stream , char ** key) {
+  file_node_type * file_node = NULL;
+  node_status_type status;
+  long int node_offset = ftell( stream );
+  if (fread( &status , sizeof status , 1 , stream) == 1) {
+    if ((status == NODE_IN_USE) || (status == NODE_FREE)) {
+      int node_size;
+      if (status == NODE_IN_USE) 
+        *key = util_fread_realloc_string( *key , stream );
+      else {
+        util_safe_free( *key );  /* Explicitly set to NULL for free nodes. */
+        *key = NULL;
+      }
+      
+      node_size = util_fread_int( stream );
+      if (node_size <= 0)
+        status = NODE_INVALID;
+      /*
+        A case has occured with an invalid node with size 0. That
+        resulted in a deadlock, because the reader never got beyond
+        the broken node. We therefor explicitly check for this
+        condition.
+      */
+      
+      file_node = file_node_alloc( status , node_offset , node_size );
+      if (status == NODE_IN_USE) {
+        file_node->data_size = util_fread_int( stream );
+        file_node->data_offset    = ftell( stream ) - file_node->node_offset;
+      }
+    } else {
+      /* 
+         We did not recognize the status identifier; the node will
+         eventually be marked as free. 
+      */
+      if (status != NODE_WRITE_ACTIVE)
+        status = NODE_INVALID;
+      file_node = file_node_alloc( status , node_offset , 0 );
+    }
+  }
+  return file_node;
+}
+
+
+/**
+   Internal index layout:
+
+   |<InUse: Bool><Key: String><node_size: Int><data_size: Int>|
+   |<InUse: Bool><node_size: Int><data_size: Int>|
+             
+  /|\                                                        
+   |                                                         
+   |<-------------------------------------------------------->|                                                         
+                                                   |           
+node_offset                                      offset
+
+  The node_offset and offset values are not stored on disk, but rather
+  implicitly read with ftell() calls.
+*/
+
+/**
+   This function will write the node information to file, this
+   includes the NODE_END_TAG identifier which shoule be written to the
+   end of the node.
+*/
+
+static void file_node_fwrite( const file_node_type * file_node , const char * key , FILE * stream ) {
+  if (file_node->node_size == 0)
+    util_abort("%s: trying to write node with z<ero size \n",__func__);
+  {
+    fseek__( stream , file_node->node_offset , SEEK_SET);
+    util_fwrite_int( file_node->status , stream );
+    if (file_node->status == NODE_IN_USE)
+      util_fwrite_string( key , stream );
+    util_fwrite_int( file_node->node_size , stream );
+    util_fwrite_int( file_node->data_size , stream );
+    fseek__( stream , file_node->node_offset + file_node->node_size - sizeof NODE_END_TAG , SEEK_SET);
+    util_fwrite_int( NODE_END_TAG , stream );
+  }
+}
+
+
+/**
+   This marks the start and end of the node with the integer tags:
+   NODE_WRITE_ACTIVE_START and NODE_WRITE_ACTIVE_END, signalling this
+   section in the data file is 'work in progress', and should be
+   discarded if the application aborts during the write.
+
+   When the write is complete file_node_fwrite() should be called,
+   which will replace the NODE_WRITE_ACTIVE_START and
+   NODE_WRITE_ACTIVE_END tags with NODE_IN_USE and NODE_END_TAG
+   identifiers.
+*/
+
+   
+static void file_node_init_fwrite( const file_node_type * file_node , FILE * stream) {
+  fseek__( stream , file_node->node_offset , SEEK_SET );
+  util_fwrite_int( NODE_WRITE_ACTIVE_START , stream );
+  fseek__( stream , file_node->node_offset + file_node->node_size - sizeof NODE_END_TAG , SEEK_SET);
+  util_fwrite_int( NODE_WRITE_ACTIVE_END   , stream );
+}
+
+
+/**
+   Observe that header in this context include the size of the tail
+   marker NODE_END_TAG.
+*/
+   
+static int file_node_header_size( const char * filename ) {
+  file_node_type * file_node;
+  return sizeof ( file_node->status    ) + 
+         sizeof ( file_node->node_size ) + 
+         sizeof ( file_node->data_size ) + 
+         sizeof ( NODE_END_TAG )         + sizeof(int) /* embedded by the util_fwrite_string routine */ + strlen(filename) + 1 /* \0 */;
+}
+
+
+static void file_node_set_data_offset( file_node_type * file_node, const char * filename ) {
+  file_node->data_offset = file_node_header_size( filename ) - sizeof( NODE_END_TAG );
+}
+
+
+
+static void file_node_dump_index( const file_node_type * file_node , FILE * index_stream) {
+  util_fwrite_int( file_node->status , index_stream );
+  util_fwrite_long( file_node->node_offset , index_stream );
+  util_fwrite_int( file_node->node_size   , index_stream );
+  util_fwrite_int( file_node->data_offset , index_stream );
+  util_fwrite_int( file_node->data_size   , index_stream );
+}
+
+
+
+/*
+static file_node_type * file_node_index_fread_alloc( FILE * stream ) {
+  node_status_type status = util_fread_int( stream );
+  long int node_offset    = util_fread_long( stream );
+  int node_size           = util_fread_int( stream );
+  {
+    file_node_type * file_node = file_node_alloc( status , node_offset , node_size );
+    file_node->data_offset = util_fread_int( stream );
+    file_node->data_size   = util_fread_int( stream );
+    
+    return file_node;
+  }
+}
+*/
+
+static file_node_type * file_node_index_buffer_fread_alloc( buffer_type * buffer) {
+  node_status_type status = buffer_fread_int( buffer );
+  long int node_offset    = buffer_fread_long( buffer );
+  int node_size           = buffer_fread_int( buffer );
+  {
+    file_node_type * file_node = file_node_alloc( status , node_offset , node_size );
+
+    file_node->data_offset = buffer_fread_int( buffer );
+    file_node->data_size   = buffer_fread_int( buffer );
+    
+    return file_node;
+  }
+}
+
+/* file_node functions - end. */
+/*****************************************************************/
+
+static free_node_type * free_node_alloc( file_node_type * file_node ) {
+  free_node_type * free_node = util_malloc( sizeof * free_node );
+
+  free_node->file_node = file_node;
+  free_node->next = NULL;
+  free_node->prev = NULL;
+
+  return free_node;
+}
+
+
+static void free_node_free( free_node_type * free_node ) {
+  free( free_node );
+}
+
+static void free_node_free_list( free_node_type * head ) {
+  free_node_type * current = head;
+  free_node_type * next;
+  while (current != NULL) {
+    next = current->next;
+    free_node_free( current );
+    current = next;
+  }
+}
+
+
+
+/*****************************************************************/
+static inline void block_fs_aquire_wlock( block_fs_type * block_fs ) {
+  if (block_fs->data_owner)
+    pthread_rwlock_wrlock( &block_fs->rw_lock );
+  else
+    util_abort("%s: tried to write to read only filesystem mounted at: %s \n",__func__ , block_fs->mount_file );
+}
+
+
+static inline void block_fs_release_rwlock( block_fs_type * block_fs ) {
+  pthread_rwlock_unlock( &block_fs->rw_lock );
+}
+
+
+static inline void block_fs_aquire_rlock( block_fs_type * block_fs ) {
+  pthread_rwlock_rdlock( &block_fs->rw_lock );
+  /*
+    We just assume that the user does NOT write to the filesystem
+    with another instance; in that case we will go out of sync;
+    and things will probably fail badly.
+  */
+}
+
+
+
+static void block_fs_insert_index_node( block_fs_type * block_fs , const char * filename , const file_node_type * file_node) {
+  hash_insert_ref( block_fs->index , filename , file_node);
+}
+
+
+/**
+   Looks through the list of free nodes - looking for a node with
+   offset 'node_offset'. If no such node can be found, NULL will be
+   returned.
+*/
+
+static file_node_type * block_fs_lookup_free_node( const block_fs_type * block_fs , long int node_offset) {
+  free_node_type * current = block_fs->free_nodes;
+  while (current != NULL && (current->file_node->node_offset != node_offset)) 
+    current = current->next;
+  
+  if (current == NULL)
+    return NULL;
+  else
+    return current->file_node;
+}
+
+
+
+
+
+
+
+
+
+/**
+   Inserts a file_node instance in the linked list of free nodes. The
+   list is sorted in order of increasing node size.
+*/
+
+static void block_fs_insert_free_node( block_fs_type * block_fs , file_node_type * file_node ) {
+  free_node_type * new = free_node_alloc( file_node );
+  
+  /* Special case: starting with a empty list. */
+  if (block_fs->free_nodes == NULL) {
+    new->next = NULL;
+    new->prev = NULL;
+    block_fs->free_nodes = new;
+  } else {
+    free_node_type * current = block_fs->free_nodes;
+    free_node_type * prev    = NULL;
+    
+    while ( current != NULL && (current->file_node->node_size < file_node->node_size)) {
+      prev = current;
+      current = current->next;
+    }
+    
+    if (current == NULL) {
+      /* 
+         The new node should be added at the end of the list - i.e. it
+         will not have a next node.
+      */
+      new->next = NULL;
+      new->prev = prev;
+      prev->next = new;
+    } else {
+      /*
+        The new node should be placed BEFORE the current node.
+      */
+      if (prev == NULL) {
+        /* The new node should become the new list head. */
+        block_fs->free_nodes = new;
+        new->prev = NULL;
+      } else {
+        prev->next = new;
+        new->prev  = prev;
+      }
+      current->prev = new;
+      new->next  = current;
+    }
+    if (new != NULL)     if (new->next == new) util_abort("%s: broken LIST1 \n",__func__);
+    if (prev != NULL)    if (prev->next == prev) util_abort("%s: broken LIST2 \n",__func__);
+    if (current != NULL) if (current->next == current) util_abort("%s: Broken LIST3 \n",__func__);
+  }
+  block_fs->num_free_nodes++;
+  block_fs->free_size += new->file_node->node_size;
+}
+
+
+/**
+   Installing the new node AND updating file tail. 
+*/
+
+static void block_fs_install_node(block_fs_type * block_fs , file_node_type * node) {
+  block_fs->data_file_size = util_size_t_max( block_fs->data_file_size , node->node_offset + node->node_size);  /* Updating the total size of the file - i.e the next available offset. */
+  vector_append_owned_ref( block_fs->file_nodes , node , file_node_free__ );
+}
+
+
+static void block_fs_set_filenames( block_fs_type * block_fs ) {
+  char * data_ext  = util_alloc_sprintf("data_%d" , block_fs->version );
+  char * lock_ext  = util_alloc_sprintf("lock_%d" , block_fs->version );
+  const char * index_ext = "index";
+
+  util_safe_free( block_fs->data_file );
+  util_safe_free( block_fs->lock_file );
+  util_safe_free( block_fs->index_file );
+  
+  block_fs->data_file  = util_alloc_filename( block_fs->path , block_fs->base_name , data_ext);
+  block_fs->lock_file  = util_alloc_filename( block_fs->path , block_fs->base_name , lock_ext);
+  block_fs->index_file = util_alloc_filename( block_fs->path , block_fs->base_name , index_ext);
+
+  free( data_ext );
+  free( lock_ext );
+}
+
+
+
+/**
+   This function is called both when allocating a new block_fs
+   instance, and when an existing block_fs instance is 'rotated'.
+*/
+
+
+static void block_fs_reinit( block_fs_type * block_fs ) {
+  block_fs->index               = hash_alloc_unlocked();
+  block_fs->file_nodes          = vector_alloc_new();
+  block_fs->free_nodes          = NULL;
+  block_fs->num_free_nodes      = 0;
+  block_fs->write_count         = 0;
+  block_fs->data_file_size      = 0;
+  block_fs->free_size           = 0; 
+  block_fs->total_cache_size    = 0;
+  block_fs_set_filenames( block_fs );
+}
+
+
+
+
+static block_fs_type * block_fs_alloc_empty( const char * mount_file ,
+                                             int block_size ,
+                                             int max_cache_size,
+                                             float fragmentation_limit,
+                                             int fsync_interval ,
+                                             bool read_only,
+                                             bool use_lockfile) {
+  block_fs_type * block_fs      = util_malloc( sizeof * block_fs );
+  UTIL_TYPE_ID_INIT(block_fs , BLOCK_FS_TYPE_ID);
+  
+  block_fs->mount_file           = util_alloc_string_copy( mount_file );
+  block_fs->fsync_interval       = fsync_interval;
+  block_fs->block_size           = block_size;
+  block_fs->max_cache_size       = max_cache_size;
+  block_fs->total_cache_size     = 0;
+  block_fs->max_total_cache_size = 512 * 1024 * 1024;  /* 512 MB */
+  
+  block_fs->fragmentation_limit = fragmentation_limit;   
+  util_alloc_file_components( mount_file , &block_fs->path , &block_fs->base_name, NULL );
+  pthread_mutex_init( &block_fs->io_lock  , NULL);
+  pthread_rwlock_init( &block_fs->rw_lock , NULL);
+  {
+    FILE * stream            = util_fopen( mount_file , "r");
+    int id                   = util_fread_int( stream );
+    block_fs->version        = util_fread_int( stream );
+    fclose( stream );
+    
+    if (id != MOUNT_MAP_MAGIC_INT) 
+      util_abort("%s: The file:%s does not seem to be a valid block_fs mount map \n",__func__ , mount_file);
+  }
+  block_fs->data_file   = NULL;
+  block_fs->lock_file   = NULL;
+  block_fs->index_file  = NULL;
+  block_fs_reinit( block_fs );
+
+
+  {
+    bool lock_aquired = true;
+
+    if (use_lockfile) {
+      lock_aquired = util_try_lockf( block_fs->lock_file , S_IWUSR + S_IWGRP , &block_fs->lock_fd);
+    
+      if (!lock_aquired) 
+        fprintf(stderr," Another program has already opened filesystem read-write - this instance will be UNSYNCRONIZED read-only. Cross your fingers ....\n");
+    }
+
+    if (lock_aquired && (read_only == false))
+      block_fs->data_owner = true; 
+    else
+      block_fs->data_owner = false;
+
+  }
+  return block_fs;
+}
+  
+
+UTIL_IS_INSTANCE_FUNCTION(block_fs , BLOCK_FS_TYPE_ID);
+
+
+static void block_fs_fwrite_mount_info__( const char * mount_file , int version) {
+  FILE * stream = util_fopen( mount_file , "w");
+  util_fwrite_int( MOUNT_MAP_MAGIC_INT , stream );
+  util_fwrite_int( version , stream );
+  fclose( stream );
+ }
+
+
+/**
+   Will seek the datafile to the end of the current file_node. So that the next read will be "guaranteed" to
+   start at a new node.
+*/
+static void block_fs_fseek_node_end(block_fs_type * block_fs , const file_node_type * file_node) {
+  block_fs_fseek( block_fs , file_node->node_offset + file_node->node_size);
+}
+
+static void block_fs_fseek_node_data(block_fs_type * block_fs , const file_node_type * file_node) {
+  block_fs_fseek( block_fs , file_node->node_offset + file_node->data_offset );
+}
+
+
+
+
+/**
+   This function will read through the datafile seeking for one of the
+   identifiers: NODE_IN_USE | NODE_FREE. If one of the valid status
+   identifiers is found the stream is repositioned at the beginning of
+   the valid node, so the calling scope can continue with a
+   
+      file_node = file_node_date_fread_alloc()
+
+   call. If no valid status ID is found whatsover the data_stream
+   indicator is left at the end of the file; and the calling scope
+   will finish from there.
+*/
+static bool block_fs_fseek_valid_node( block_fs_type * block_fs ) {
+  unsigned char byte;
+  int  status;
+  while (true) {
+    if (fread(&byte , sizeof byte ,1 , block_fs->data_stream) == 1) {
+      if (byte == NODE_IN_USE_BYTE || byte == NODE_FREE_BYTE) {
+        long int pos = ftell( block_fs->data_stream );
+        /* 
+           OK - we found one interesting byte; let us try to read the
+           whole integer and see if we have hit any of the valid status identifiers.
+        */
+        fseek__( block_fs->data_stream , -1 , SEEK_CUR);
+        if (fread(&status , sizeof status , 1 , block_fs->data_stream) == 1) {
+          if (status == NODE_IN_USE || status == NODE_FREE_BYTE) {
+            /* 
+               OK - we have found a valid identifier. We reposition to
+               the start of this valid status id and return true.
+            */
+            fseek__( block_fs->data_stream , -sizeof status , SEEK_CUR);
+            return true;
+          } else 
+            /* 
+               OK - this was not a valid id; we go back and continue 
+               reading single bytes.
+            */
+            block_fs_fseek( block_fs , pos );
+        } else
+          break; /* EOF */
+      }
+    } else
+      break; /* EOF */
+  }
+  fseek__( block_fs->data_stream , 0 , SEEK_END);
+  return false;
+}
+
+
+
+
+
+/**
+   The read-only open mode is only for the mount section, where the
+   data file is read in to load/verify the index.
+
+   If the read_only open fails - the data_stream is set to NULL. If
+   the open succeeds the calling scope should close the stream before
+   calling this function again, with read_only == false.
+*/
+
+static void block_fs_open_data( block_fs_type * block_fs , bool read_write) {
+  if (read_write) {
+    /* Normal read-write open.- */
+    if (util_file_exists( block_fs->data_file ))
+      block_fs->data_stream = util_fopen( block_fs->data_file , "r+");
+    else
+      block_fs->data_stream = util_fopen( block_fs->data_file , "w+");
+  } else {
+    /* read-only open. */
+    if (util_file_exists( block_fs->data_file ))
+      block_fs->data_stream = util_fopen( block_fs->data_file , "r");
+    else
+      block_fs->data_stream = NULL;
+    /* 
+       If we ever try to dereference this pointer it will break
+       hard; but it should be stopped in hash_get() calls before the
+       data_stream is dereferenced anyway?
+    */
+  }
+  if (block_fs->data_stream == NULL)
+    block_fs->data_fd = -1;
+  else
+    block_fs->data_fd = fileno( block_fs->data_stream );
+}
+
+#ifdef ENABLE_CACHE
+
+static void block_fs_clear_cache_node( block_fs_type * block_fs , file_node_type * node ) {
+  if (node->cache_size > 0) {
+    block_fs->total_cache_size -= node->cache_size;
+    file_node_clear_cache( node );
+  }
+}
+
+static void block_fs_update_cache_node( block_fs_type * block_fs, file_node_type * node, int data_size, const void * data) {
+  int delta_size = data_size - node->cache_size;
+  if (delta_size < 0) {
+    file_node_update_cache( node , data_size , data );
+    block_fs->total_cache_size += delta_size;
+  } else {
+    if (((block_fs->total_cache_size + delta_size) <= block_fs->max_total_cache_size) &&   /* Check total cache usage */
+        (data_size <= block_fs->max_cache_size)) {                                         /* Chech cache size of this node */
+      block_fs->total_cache_size += delta_size;
+      file_node_update_cache( node , data_size , data );
+    } else
+      block_fs_clear_cache_node( block_fs , node );
+  }
+}
+
+/**
+   This function will load all the small (i.e. with size less than the
+   maximum cache size) nodes, and fill the cache.
+*/
+
+static void block_fs_preload( block_fs_type * block_fs ) {
+  if ((block_fs->max_cache_size > 0) && (block_fs->data_stream != NULL) && (block_fs->max_total_cache_size > 0)) {
+    void * buffer = util_malloc( block_fs->max_cache_size );
+    hash_iter_type * index_iter = hash_iter_alloc( block_fs->index );
+    
+    while (!hash_iter_is_complete( index_iter )) {
+      file_node_type * node = hash_iter_get_next_value( index_iter );
+      if ((node->data_size < block_fs->max_cache_size) &&                                         /* Check the size of this node */ 
+          (block_fs->total_cache_size + node->data_size < block_fs->max_total_cache_size)) {      /* Check the total cache size */
+        block_fs_fseek_node_data(block_fs , node);
+        util_fread( buffer , 1 , node->data_size , block_fs->data_stream , __func__);
+        block_fs_update_cache_node( block_fs , node , node->data_size , buffer );
+      }
+    }
+    
+    hash_iter_free( index_iter );
+    free( buffer );
+  }
+}
+#else
+static void block_fs_clear_cache_node( block_fs_type * block_fs , file_node_type * node ) { return; }
+static void block_fs_update_cache_node( block_fs_type * block_fs, file_node_type * node, int data_size, const void * data) { return ;}
+static void block_fs_preload( block_fs_type * block_fs ) { return; }
+#endif
+
+
+
+/**
+   This function will 'fix' the nodes with offset in offset_list.  The
+   fixing in this case means the following:
+
+     1. The node is updated in place on the file to become a free node.
+     2. The node is added to the block_fs instance as a free node, which can
+        be recycled at a later stage.
+   
+   If the instance is not data owner (i.e. read-only) the function
+   will return immediately.
+*/
+
+
+static void block_fs_fix_nodes( block_fs_type * block_fs , long_vector_type * offset_list ) {
+  if (block_fs->data_owner) { 
+    fsync( block_fs->data_fd );
+    {
+      char * key = NULL;
+      for (int inode = 0; inode < long_vector_size( offset_list ); inode++) {
+        bool new_node = false;
+        long int node_offset = long_vector_iget( offset_list , inode );
+        file_node_type * file_node;
+        block_fs_fseek(block_fs , node_offset);
+        file_node = file_node_fread_alloc( block_fs->data_stream , &key );
+        
+        if ((file_node->status == NODE_INVALID) || (file_node->status == NODE_WRITE_ACTIVE)) {
+          /* This node is really quite broken. */
+          long int node_end;
+          block_fs_fseek_valid_node( block_fs );
+          node_end             = ftell( block_fs->data_stream );
+          file_node->node_size = node_end - node_offset;
+        } 
+        
+        file_node->status      = NODE_FREE;
+        file_node->data_size   = 0;
+        file_node->data_offset = 0;
+        if (block_fs_lookup_free_node( block_fs , node_offset) == NULL) {
+          /* The node is already on the free list - we just change some metadata. */
+          new_node = true;
+          block_fs_install_node( block_fs , file_node );
+          block_fs_insert_free_node( block_fs , file_node );
+        }
+        
+        block_fs_fseek(block_fs , node_offset);
+        file_node_fwrite( file_node , NULL , block_fs->data_stream );
+        if (!new_node)
+          file_node_free( file_node );
+      }
+      util_safe_free( key );
+    }
+    fsync( block_fs->data_fd );
+  }
+}
+
+
+
+static void block_fs_build_index( block_fs_type * block_fs , long_vector_type * error_offset ) {
+  char * filename = NULL;
+  file_node_type * file_node;
+  
+  hash_resize( block_fs->index , DEFAULT_INDEX_SIZE );
+  block_fs_fseek( block_fs , 0);
+  do {
+    file_node = file_node_fread_alloc( block_fs->data_stream , &filename );
+    if (file_node != NULL) {
+      if ((file_node->status == NODE_INVALID) || (file_node->status == NODE_WRITE_ACTIVE)) {
+        /* Oh fuck */
+        if (file_node->status == NODE_INVALID) 
+          fprintf(stderr,"** Warning:: invalid node found at offset:%ld in datafile:%s - data will be lost, node_size:%d\n", file_node->node_offset , block_fs->data_file , file_node->node_size);
+        else
+          fprintf(stderr,"** Warning:: file system was prematurely shut down while writing node in %s/%ld - will be discarded.\n",block_fs->data_file , file_node->node_offset);
+        
+        long_vector_append( error_offset , file_node->node_offset );
+        file_node_free( file_node );
+        block_fs_fseek_valid_node( block_fs );
+      } else {
+        if (file_node_verify_end_tag(file_node, block_fs->data_stream)) {
+          block_fs_fseek_node_end(block_fs , file_node);
+          block_fs_install_node( block_fs , file_node );
+          switch(file_node->status) {
+          case(NODE_IN_USE):
+            block_fs_insert_index_node(block_fs , filename , file_node);
+            break;
+          case(NODE_FREE):
+            block_fs_insert_free_node( block_fs , file_node );
+            break;
+          default:
+            util_abort("%s: node status flag:%d not recognized - error in data file \n",__func__ , file_node->status);
+          }
+        } else {
+          /* 
+             Could not find a valid END_TAG - indicating that
+             the filesystem was shut down during the write of
+             this node.  This node will NOT be added to the
+             index.  The node will be updated to become a free node.
+          */
+          fprintf(stderr,"** Warning found node:%s at offset:%ld which was incomplete - discarded.\n",filename, file_node->node_offset);
+          long_vector_append( error_offset , file_node->node_offset );
+          file_node_free( file_node );
+          block_fs_fseek_valid_node( block_fs );
+        }
+      }
+    }
+  } while (file_node != NULL);
+  util_safe_free( filename );
+}
+
+
+/**
+   Load an index for (slightly) faster mounting of the filesystem. The
+   function starts be reading a header and check if the current index
+   file is applicable.
+
+   Will return true of the loading succedeed, and false if no index
+   was loaded.  
+*/
+
+
+static bool block_fs_load_index( block_fs_type * block_fs ) {
+  stat_type data_stat;
+  if (fstat( block_fs->data_fd , &data_stat) == 0) {
+    FILE * stream = fopen( block_fs->index_file , "r");
+    if (stream != NULL) {
+      int    id          = util_fread_int( stream );
+      int    version     = util_fread_int( stream );
+      time_t index_mtime = util_fread_time_t( stream );
+
+      time_t data_mtime  = data_stat.st_mtime;
+      fclose( stream );
+
+      if ((id == INDEX_MAGIC_INT) &&               /* This is indeed an index file. */ 
+          (version == INDEX_FORMAT_VERSION) &&     /* The version on disk agrees with this version. */
+          (index_mtime == data_mtime)) {           /* The time stamp agrees with the time stamp of the data. */
+        
+        /* Read the whole index file in one single read operation. */
+        buffer_type * buffer = buffer_fread_alloc( block_fs->index_file );
+        
+        buffer_fskip( buffer , sizeof( time_t ) + 2 * sizeof( int ));
+        /*1: Loading all the active nodes. */
+        {
+          int num_active_nodes = buffer_fread_int( buffer );
+          hash_resize( block_fs->index , num_active_nodes * 2 + 64);
+          
+          for (int i=0; i < num_active_nodes; i++) {
+            const char * filename = buffer_fread_string( buffer );
+            file_node_type * file_node = file_node_index_buffer_fread_alloc( buffer );
+            block_fs_install_node( block_fs , file_node);
+            block_fs_insert_index_node(block_fs , filename , file_node);
+          }
+        }
+        
+        /*2: Loading all the free nodes. */
+        {
+          int num_free_nodes = buffer_fread_int( buffer );
+          for (int i=0; i < num_free_nodes; i++) {
+            file_node_type * file_node = file_node_index_buffer_fread_alloc( buffer );
+            block_fs_install_node( block_fs , file_node);
+            block_fs_insert_free_node(block_fs , file_node);
+          }
+        }
+        buffer_free( buffer );
+        
+        return true;
+      }
+    } 
+  }
+  /** No index was loaded - for whatever reason. */
+  return false;
+}
+
+
+size_t block_fs_get_cache_usage( const block_fs_type * block_fs ) {
+  return block_fs->total_cache_size;
+}
+
+
+bool block_fs_is_mount( const char * mount_file ) {
+  FILE * stream            = util_fopen( mount_file , "r");
+  int id                   = util_fread_int( stream );
+
+  if (id == MOUNT_MAP_MAGIC_INT) 
+    return true;
+  else
+    return false;
+}
+
+
+bool block_fs_is_readonly( const block_fs_type * bfs ) {
+  if (bfs->data_owner)
+    return false;
+  else
+    return true;
+}
+
+
+
+block_fs_type * block_fs_mount( const char * mount_file ,
+                                int block_size ,
+                                int max_cache_size ,
+                                float fragmentation_limit ,
+                                int fsync_interval ,
+                                bool preload ,
+                                bool read_only,
+                                bool use_lockfile) {
+  block_fs_type * block_fs;
+  {
+
+    if (!util_file_exists(mount_file)) 
+      /* This is a brand new filesystem - create the mount map first. */
+      block_fs_fwrite_mount_info__( mount_file , 0 );
+    {
+      long_vector_type * fix_nodes = long_vector_alloc(0 , 0);
+      block_fs = block_fs_alloc_empty( mount_file , block_size , max_cache_size , fragmentation_limit , fsync_interval , read_only, use_lockfile);
+      /* We build up the index & free_nodes_list based on the header/index information embedded in the datafile. */
+      block_fs_open_data( block_fs , false );
+      if (block_fs->data_stream != NULL) {
+        if (!block_fs_load_index( block_fs ))
+          block_fs_build_index( block_fs , fix_nodes );
+
+        fclose(block_fs->data_stream);
+      }
+      
+      block_fs_open_data( block_fs , block_fs->data_owner ); /* The data_stream is opened for reading AND writing (IFF we are data_owner - otherwise it is still read only) */
+      block_fs_fix_nodes( block_fs , fix_nodes );  
+      long_vector_free( fix_nodes );
+    }
+  }
+  if (preload) block_fs_preload( block_fs );
+  return block_fs;
+}
+
+
+
+static void block_fs_unlink_free_node( block_fs_type * block_fs , free_node_type * node) {
+  free_node_type * prev = node->prev;
+  free_node_type * next = node->next;
+  
+  if (prev == NULL)
+    /* Special case: popping off the head of the list. */
+    block_fs->free_nodes = next;
+  else
+    prev->next = next;
+  
+  if (next != NULL)
+    next->prev = prev;
+
+  block_fs->num_free_nodes--;
+  block_fs->free_size -= node->file_node->node_size;
+  free_node_free( node );
+}
+
+
+
+/**
+   This function first checks the free nodes if any of them can be
+   used, otherwise a new node is created.
+*/
+
+static file_node_type * block_fs_get_new_node( block_fs_type * block_fs , const char * filename , size_t min_size) {
+  
+  free_node_type * current = block_fs->free_nodes;
+  
+  while (current != NULL && (current->file_node->node_size < min_size)) {
+    current = current->next;
+  }
+  if (current != NULL) {
+    /* 
+       Current points to a file_node which can be used. Before we return current we must:
+       
+       1. Remove current from the free_nodes list.
+       2. Add current to the index hash.
+       
+    */
+    file_node_type * file_node = current->file_node;
+    block_fs_unlink_free_node( block_fs , current );
+
+    return file_node;
+  } else {
+    /* No usable nodes in the free nodes list - must allocate a brand new one. */
+
+    long int offset;
+    int node_size;
+    file_node_type * new_node;
+    
+    {
+      div_t d   = div( min_size , block_fs->block_size );
+      node_size = d.quot * block_fs->block_size;
+      if (d.rem)
+        node_size += block_fs->block_size;
+    }
+
+    /* Must lock the total size here ... */
+    offset = block_fs->data_file_size;
+    new_node = file_node_alloc(NODE_IN_USE , offset , node_size);  
+    block_fs_install_node( block_fs , new_node );                   /* <- This will update the total file size. */
+    
+    return new_node;
+  }
+}
+
+
+
+
+
+bool block_fs_has_file__( const block_fs_type * block_fs , const char * filename) {
+  return hash_has_key( block_fs->index , filename );
+}
+
+
+
+bool block_fs_has_file( block_fs_type * block_fs , const char * filename) {
+  bool has_file;
+  block_fs_aquire_rlock( block_fs );
+  {
+    has_file = block_fs_has_file__( block_fs , filename );
+  }
+  block_fs_release_rwlock( block_fs );
+  return has_file;
+}
+
+
+
+
+static void block_fs_unlink_file__( block_fs_type * block_fs , const char * filename ) {
+  file_node_type * node = hash_pop( block_fs->index , filename );
+  block_fs_clear_cache_node( block_fs , node );
+
+  node->status      = NODE_FREE;
+  node->data_offset = 0;
+  node->data_size   = 0;
+  if (block_fs->data_stream != NULL) {  
+    fsync( block_fs->data_fd );
+    block_fs_fseek(block_fs , node->node_offset);
+    file_node_fwrite( node , NULL , block_fs->data_stream );
+    fsync( block_fs->data_fd );
+  }
+  block_fs_insert_free_node( block_fs , node );
+}
+
+/**
+   Returns the fraction of unused space in the block_fs instance. 
+*/
+double block_fs_get_fragmentation( const block_fs_type * block_fs ) {
+  return block_fs->free_size * 1.0 / block_fs->data_file_size;
+}
+
+
+void block_fs_unlink_file( block_fs_type * block_fs , const char * filename) {
+  block_fs_aquire_wlock( block_fs );
+
+  block_fs_unlink_file__( block_fs , filename );
+  if (block_fs_get_fragmentation( block_fs ) > block_fs->fragmentation_limit) 
+    block_fs_rotate__( block_fs );
+  
+  block_fs_release_rwlock( block_fs );
+}
+
+
+/**
+   This function can be used to initiate explicit rotate of the file
+   system, observe the following.
+
+   1. This function is called with an explicit fragmentation_limit
+   which might differ from the fragmentation limit held by the
+   filesystem
+
+   2. This function will take the write lock, it is therefor
+   essential that this function is NOT called by another function
+   which has already taken the write lock (i.e. the
+   block_fs_unlink_file() or block_fs_fwrite_file() functions),
+   that will deadlock.
+
+   The return value is whether a rotation actually has taken place.
+*/
+
+bool block_fs_rotate( block_fs_type * block_fs , double fragmentation_limit) {
+  if (block_fs_get_fragmentation( block_fs ) > fragmentation_limit) {
+    block_fs_aquire_wlock( block_fs );
+    block_fs_rotate__( block_fs );
+    block_fs_release_rwlock( block_fs );
+    return true;
+  } else
+    return false;
+}
+
+    
+/* 
+   It seems it is not enough to call fsync(); must also issue this
+   funny fseek + ftell combination to ensure that all data is on
+   disk after an uncontrolled shutdown.
+
+   Could possibly use fdatasync() to improve speed slightly?
+*/
+
+void block_fs_fsync( block_fs_type * block_fs ) {
+  if (block_fs->data_owner) {
+    //fdatasync( block_fs->data_fd );
+    fsync( block_fs->data_fd );
+    block_fs_fseek( block_fs , block_fs->data_file_size );
+    ftell( block_fs->data_stream );
+  }
+}
+
+
+
+
+/**
+   The single lowest-level write function:
+   
+   3. seek to correct position.
+   4. Write the data with util_fwrite()
+
+   7. increase the write_count
+   8. set the data_size field of the node.
+
+   Observe that when 'designing' this file-system the priority has
+   been on read-spead, one consequence of this is that all write
+   operations are sandwiched between two fsync() calls; that
+   guarantees that the read access (which should be the fast path) can
+   be without any calls to fsync().
+
+   Not necessary to lock - since all writes are protected by the
+   'global' rwlock anyway.
+*/
+
+
+static void block_fs_fwrite__(block_fs_type * block_fs , const char * filename , file_node_type * node , const void * ptr , int data_size) {
+
+#ifdef ENABLE_CACHE
+  if ((node->cache_size == data_size) && (memcmp( ptr , node->cache , data_size ) == 0)) 
+    /* The current cache is identical to the data we are attempting to write - can leave immediately. */
+    return;
+#else 
+  if (false) 
+    return;
+#endif
+
+  else {
+    block_fs_fseek(block_fs , node->node_offset);
+    node->status      = NODE_IN_USE;
+    node->data_size   = data_size; 
+    file_node_set_data_offset( node , filename );
+    
+    /* This marks the node section in the datafile as write in progress with: NODE_WRITE_ACTIVE_START ... NODE_WRITE_ACTIVE_END */
+    file_node_init_fwrite( node , block_fs->data_stream );                
+    
+    /* Writes the actual data content. */
+    block_fs_fseek_node_data(block_fs , node);
+    util_fwrite( ptr , 1 , data_size , block_fs->data_stream , __func__);
+    
+    /* Writes the file node header data, including the NODE_END_TAG. */
+    file_node_fwrite( node , filename , block_fs->data_stream );
+
+    block_fs_update_cache_node( block_fs , node , data_size , ptr);
+    block_fs->write_count++;
+    if (block_fs->fsync_interval && ((block_fs->write_count % block_fs->fsync_interval) == 0)) 
+      block_fs_fsync( block_fs );
+    
+  }
+}
+
+
+
+static void block_fs_fwrite_file_unlocked(block_fs_type * block_fs , const char * filename , const void * ptr , size_t data_size) {
+  file_node_type * file_node;
+  bool   new_node = true;   
+  size_t min_size = data_size + file_node_header_size( filename );
+  
+  if (block_fs_has_file__( block_fs , filename )) {
+    file_node = hash_get( block_fs->index , filename );
+    if (file_node->node_size < min_size) {
+      /* 
+         The current node is too small for the new content:
+         
+         1. Remove the existing node, from the index and insert it
+         into the free_nodes list.
+
+         2. Get a new node.
+        
+      */
+      block_fs_unlink_file__( block_fs , filename );
+      file_node = block_fs_get_new_node( block_fs , filename , min_size );
+    } else
+      new_node = false;  /* We are reusing the existing node. */
+  } else 
+    file_node = block_fs_get_new_node( block_fs , filename , min_size );
+  
+  
+  /* The actual writing ... */
+  block_fs_fwrite__( block_fs , filename , file_node , ptr , data_size);
+  if (new_node)
+    block_fs_insert_index_node(block_fs , filename , file_node);
+}
+
+
+
+void block_fs_fwrite_file(block_fs_type * block_fs , const char * filename , const void * ptr , size_t data_size) {
+  block_fs_aquire_wlock( block_fs );
+  {
+    block_fs_fwrite_file_unlocked( block_fs , filename , ptr , data_size );
+    
+    /* OKAY - this is going to take some time ... */
+    if ((block_fs->free_size * 1.0 / block_fs->data_file_size) > block_fs->fragmentation_limit)
+      block_fs_rotate__( block_fs );
+
+  }
+  block_fs_release_rwlock( block_fs );
+}
+
+
+void block_fs_defrag( block_fs_type * block_fs ) {
+  block_fs_aquire_wlock( block_fs );
+  block_fs_rotate__( block_fs );
+  block_fs_release_rwlock( block_fs );
+}
+
+
+void block_fs_fwrite_buffer(block_fs_type * block_fs , const char * filename , const buffer_type * buffer) {
+  block_fs_fwrite_file( block_fs , filename , buffer_get_data( buffer ) , buffer_get_size( buffer ));
+}
+
+
+/**
+   Need extra locking here - because the global rwlock allows many
+   concurrent readers.
+*/
+static void block_fs_fread__(block_fs_type * block_fs , const file_node_type * file_node , void * ptr , size_t read_bytes) {
+
+#ifdef ENABLE_CACHE  
+  if (file_node->cache != NULL) 
+    file_node_read_from_cache( file_node , ptr , read_bytes);
+  else
+#else
+    if (true) 
+#endif
+
+  {
+    pthread_mutex_lock( &block_fs->io_lock );
+    block_fs_fseek_node_data( block_fs , file_node );
+    util_fread( ptr , 1 , read_bytes , block_fs->data_stream , __func__);
+    //file_node_verify_end_tag( file_node , block_fs->data_stream );
+    pthread_mutex_unlock( &block_fs->io_lock );
+  }
+}
+
+
+/**
+   Reads the full content of 'filename' into the buffer. 
+*/
+
+void block_fs_fread_realloc_buffer( block_fs_type * block_fs , const char * filename , buffer_type * buffer) {
+  block_fs_aquire_rlock( block_fs );
+  {
+    file_node_type * node = hash_get( block_fs->index , filename);
+    
+    buffer_clear( buffer );   /* Setting: content_size = 0; pos = 0;  */
+    {
+      /* 
+         Going low-level - essentially a second implementation of
+         block_fs_fread__():
+      */
+
+#ifdef ENABLE_CACHE
+      if (node->cache != NULL) 
+        file_node_buffer_read_from_cache( node , buffer );
+      else 
+#else
+      if (true)  
+#endif
+
+      {
+        pthread_mutex_lock( &block_fs->io_lock );
+        block_fs_fseek_node_data(block_fs , node );
+        buffer_stream_fread( buffer , node->data_size , block_fs->data_stream );
+        //file_node_verify_end_tag( node , block_fs->data_stream );
+        pthread_mutex_unlock( &block_fs->io_lock );
+      }
+      
+    }
+    buffer_rewind( buffer );  /* Setting: pos = 0; */
+  }
+  block_fs_release_rwlock( block_fs );
+}
+
+
+
+
+
+
+
+/*
+  This function will read all the data stored in 'filename' - it is
+  the responsability of the calling scope that ptr is sufficiently
+  large to hold it. You can use block_fs_get_filesize() first to
+  check.
+*/
+
+
+void block_fs_fread_file( block_fs_type * block_fs , const char * filename , void * ptr) {
+  block_fs_aquire_rlock( block_fs );
+  {
+    file_node_type * node = hash_get( block_fs->index , filename);
+    block_fs_fread__( block_fs , node , ptr , node->data_size);
+  }
+  block_fs_release_rwlock( block_fs );
+}
+
+
+
+int block_fs_get_filesize( block_fs_type * block_fs , const char * filename) {
+  int data_size;
+  block_fs_aquire_rlock( block_fs );
+  {
+    file_node_type * node = hash_get( block_fs->index , filename );
+    data_size = node->data_size;
+  }
+  block_fs_release_rwlock( block_fs );
+  return data_size;
+}
+
+
+static void block_fs_dump_index( block_fs_type * block_fs ) {
+  if (block_fs->data_owner) {
+    struct stat stat_buffer;
+    int stat_return = stat(block_fs->data_file , &stat_buffer);
+    if (stat_return != 0)
+      return;
+    {
+      time_t data_mtime = stat_buffer.st_mtime;
+      FILE * index_stream = util_fopen( block_fs->index_file , "w");
+      util_fwrite_int( INDEX_MAGIC_INT , index_stream );
+      util_fwrite_int( INDEX_FORMAT_VERSION , index_stream );
+      util_fwrite_time_t( data_mtime , index_stream );
+
+      /* 1: Dumping the hash table of active nodes. */
+      {
+        hash_iter_type * index_iter = hash_iter_alloc( block_fs->index );
+        
+        util_fwrite_int( hash_get_size( block_fs->index ) , index_stream);
+        while (!hash_iter_is_complete( index_iter )) {
+          const char * key = hash_iter_get_next_key( index_iter );
+          const file_node_type * file_node = hash_get( block_fs->index , key );
+          
+          util_fwrite_string( key , index_stream);
+          file_node_dump_index( file_node , index_stream );
+        }
+        hash_iter_free( index_iter );
+      }
+      
+      /* 2: Dumping information about empty slots in the datafile. */
+      util_fwrite_int( block_fs->num_free_nodes , index_stream );
+      {
+        free_node_type * current = block_fs->free_nodes;
+        while ( current != NULL) {
+          file_node_dump_index( current->file_node , index_stream );
+          current = current->next;
+        }
+      }
+      
+      fclose( index_stream );
+    }
+  }
+}
+
+
+/**
+   Close/synchronize the open file descriptors and free all memory
+   related to the block_fs instance.
+
+   If the boolean unlink_empty is set to true all the files will be
+   unlinked if the filesystem is empty.
+*/
+
+void block_fs_close( block_fs_type * block_fs , bool unlink_empty) {
+  block_fs_fsync( block_fs );
+  
+  if (block_fs->data_owner) 
+    block_fs_aquire_wlock( block_fs );
+
+  if (block_fs->data_stream != NULL) 
+    fclose( block_fs->data_stream );
+
+  if (block_fs->data_owner) 
+    block_fs_dump_index( block_fs );
+      
+  if (block_fs->lock_fd > 0) {
+    close( block_fs->lock_fd );     /* Closing the lock_file file descriptor - and releasing the lock. */
+    util_unlink_existing( block_fs->lock_file );
+  }
+
+  if (block_fs->data_owner) {
+    if ( unlink_empty && (hash_get_size( block_fs->index) == 0)) {
+      util_unlink_existing( block_fs->data_file );
+      util_unlink_existing( block_fs->index_file );
+      util_unlink_existing( block_fs->mount_file );
+    }
+    block_fs_release_rwlock( block_fs );
+  }
+
+  free( block_fs->index_file );
+  free( block_fs->lock_file );
+  free( block_fs->base_name );
+  free( block_fs->data_file );
+  free( block_fs->path );
+  free( block_fs->mount_file );
+  
+  free_node_free_list( block_fs->free_nodes );
+  hash_free( block_fs->index );
+  vector_free( block_fs->file_nodes );
+  free( block_fs );
+}
+
+
+
+
+
+/**
+   This function will 'rotate' the datafile to a new version which has
+   been defragmented, i.e. with no 'holes' in it. In the process the
+   datafile version number is increased with one. The function works
+   by using the regular block_fs read and write functions.
+   
+   Observe that the block_fs instance should hold the write lock when
+   entering this function.
+*/
+
+static void block_fs_rotate__( block_fs_type * block_fs ) {
+  /* 
+     Write a updated mount map where the version info has been bumped
+     up with one; the new_fs will mount based on this mount_file.
+  */
+  block_fs->version++;
+  block_fs_fwrite_mount_info__( block_fs->mount_file , block_fs->version ); 
+  {
+    vector_type    * old_nodes         = block_fs->file_nodes;
+    hash_type      * old_index         = block_fs->index;
+    FILE           * old_data_stream   = block_fs->data_stream;
+    free_node_type * old_free_nodes    = block_fs->free_nodes;
+    char           * old_data_file     = util_alloc_string_copy( block_fs->data_file );
+    char           * old_lock_file     = util_alloc_string_copy( block_fs->lock_file );
+
+    block_fs_reinit( block_fs );
+    /** 
+        Now the block_fs pointers point to the new copy. Must use the
+        old_xxx pointers to access the existing.
+    */
+    block_fs_open_data( block_fs , block_fs->data_owner );
+    {
+      hash_iter_type * iter = hash_iter_alloc( old_index );
+      buffer_type * buffer  = buffer_alloc(1024);
+      
+      while (!hash_iter_is_complete( iter )) {
+        const char * key          = hash_iter_get_next_key( iter );
+        file_node_type * old_node = hash_get( old_index , key );
+        buffer_clear( buffer );
+
+        /* Low level read of the old file. */
+        fseek__( old_data_stream , old_node->node_offset + old_node->data_offset , SEEK_SET );
+        buffer_stream_fread( buffer , old_node->data_size , old_data_stream );
+        
+        block_fs_fwrite_file_unlocked( block_fs , key , buffer_get_data( buffer ) , buffer_get_size( buffer ));  /* Normal write to the new file. */
+      }
+      
+      buffer_free( buffer );
+      hash_iter_free( iter );
+    }
+    /*
+      OK - everything has been played over, and we should clean up the old fs:
+
+        1. Close the old data stream.
+        2. Unlink the old lockfile.
+        3. Delete the old data file.
+        4. Delete the old list of free nodes.
+        5. free()
+
+    */
+    fclose( old_data_stream );
+    unlink( old_data_file );
+    unlink( old_lock_file );
+    free( old_lock_file );
+    free( old_data_file );
+    
+    free_node_free_list( old_free_nodes );
+    hash_free( old_index );
+    vector_free( old_nodes );
+  }
+}
+
+
+/*****************************************************************/
+/* Functions related to 'ls' like functionality.                 */
+/*****************************************************************/
+
+
+/* 
+   Help structure used for 'ls' like funtionality. 
+*/
+
+struct user_file_node_struct {
+  const file_node_type  * file_node;
+  char                  * filename; 
+};
+
+
+static user_file_node_type * user_file_node_alloc( const char * name , const file_node_type * file_node) {
+  user_file_node_type * user_node = util_malloc( sizeof * user_node );
+
+  user_node->filename = util_alloc_string_copy( name );   /* name can be NULL */
+  user_node->file_node = file_node;
+  
+  return user_node;
+}
+
+
+static void user_file_node_free( user_file_node_type * node ) {
+  util_safe_free( node->filename );
+  free( node );
+}
+
+static void user_file_node_free__( void * node ) {
+  user_file_node_free( (user_file_node_type *) node );
+}
+
+long int user_file_node_get_node_offset( const user_file_node_type * user_file_node ) {
+  return user_file_node->file_node->node_offset;
+}
+
+long int user_file_node_get_data_offset( const user_file_node_type * user_file_node ) {
+  return user_file_node->file_node->data_offset + user_file_node->file_node->node_offset;
+}
+
+int user_file_node_get_node_size( const user_file_node_type * user_file_node ) {
+  return user_file_node->file_node->node_size;
+}
+
+int user_file_node_get_data_size( const user_file_node_type * user_file_node ) {
+  return user_file_node->file_node->data_size;
+}
+
+bool user_file_node_in_use( const user_file_node_type * user_file_node ) {
+  if (user_file_node->file_node->status == NODE_IN_USE)
+    return true;
+  else
+    return false;
+}
+
+const char * user_file_node_get_filename( const user_file_node_type * user_file_node ) {
+  return user_file_node->filename;
+}
+
+static int offset_cmp( const void * arg1 , const void * arg2 ) {
+  const user_file_node_type * node1 = (user_file_node_type *) arg1;
+  const user_file_node_type * node2 = (user_file_node_type *) arg2;
+  
+  if (node1->file_node->node_offset > node2->file_node->node_offset)
+    return 1;
+  else
+    return -1;
+}
+
+
+static int string_cmp( const void * arg1 , const void * arg2 ) {
+  const user_file_node_type * node1 = (user_file_node_type *) arg1;
+  const user_file_node_type * node2 = (user_file_node_type *) arg2;
+  
+  if (node1->filename == NULL)
+    return 1;
+  else if (node2->filename == NULL)
+    return -1;
+  else
+    return strcmp( node1->filename , node2->filename );
+}
+
+
+static bool pattern_match( const char * pattern , const char * string ) {
+  if (pattern == NULL)
+    return true;
+  else {
+    if (fnmatch( pattern , string , 0 ) == 0)
+      return true;
+    else
+      return false;
+  }
+}
+
+/**
+   If pattern == NULL all files will be selected. Observe that the
+   returned vector contains pointers to the "real" file_node instances
+   - this has two consequences:
+
+    1. The calling scope should N O T change the elements in the
+       vector - that will lead to internal corruption of the block_fs
+       instance.
+
+    2. If normal read/write/unlink operations are performed on the
+       block_fs instance while the vector is held, the content of the
+       vector will go out of sync.
+
+*/
+
+vector_type * block_fs_alloc_filelist( block_fs_type * block_fs  , const char * pattern , block_fs_sort_type sort_mode , bool include_free_nodes ) {
+  vector_type    * sort_vector = vector_alloc_new();
+
+  /* Inserting the nodes from the index. */
+  block_fs_aquire_rlock( block_fs );
+  {
+    hash_iter_type * iter        = hash_iter_alloc( block_fs->index );
+    while ( !hash_iter_is_complete( iter )) {
+      const char * key            = hash_iter_get_next_key( iter );
+      file_node_type * node = hash_get( block_fs->index , key );
+      if (pattern_match( pattern , key )) {
+        user_file_node_type * unode = user_file_node_alloc( key , node );
+        vector_append_owned_ref( sort_vector , unode , user_file_node_free__ );
+      }
+    }
+    hash_iter_free( iter );
+  }
+  block_fs_release_rwlock( block_fs );
+
+  if (pattern != NULL)
+    include_free_nodes = false;  /* Doing fnmatch on free nodes makes no sense */
+  
+  /* Inserting the free nodes - the holes. */
+  if (include_free_nodes) {
+    free_node_type * current = block_fs->free_nodes;
+    while (current != NULL) {
+      user_file_node_type * unode = user_file_node_alloc( NULL , current->file_node );
+      vector_append_owned_ref( sort_vector , unode , user_file_node_free__ );
+      current = current->next;
+    }
+  }
+
+  switch( sort_mode ) {
+  case(STRING_SORT):
+    vector_sort(sort_vector , string_cmp);
+    break;
+  case(OFFSET_SORT):
+    vector_sort(sort_vector , offset_cmp);
+    break;
+  case(NO_SORT):
+    break;
+  }
+
+  return sort_vector;
+}
+

--- a/libres_util/src/subst_list.c
+++ b/libres_util/src/subst_list.c
@@ -1,0 +1,947 @@
+/*
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'subst_list.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <ert/util/util.h>
+#include <ert/util/hash.h>
+#include <ert/util/vector.h>
+#include <ert/util/node_data.h>
+#include <ert/util/buffer.h>
+#include <ert/util/subst_func.h>
+#include <ert/util/parser.h>
+
+#include <ert/res_util/subst_list.h>
+
+/**
+   This file implements a small support struct for search-replace
+   operations, along with wrapped calls to util_string_replace_inplace().
+
+   Substitutions can be carried out on files and string in memory (char *
+   with \0 termination); and the operations can be carried out inplace, or
+   in a filtering mode where a new file/string is created.
+
+
+   Usage
+   =====
+    1. Start with allocating a subst_list instance with subst_list_alloc().
+
+    2. Insert key,value pairs to for search-replace with the functions
+
+        * subst_list_insert_ref(subst_list , key , value);
+        * subst_list_insert_owned_ref(subst_list , key , value);
+        * subst_list_insert_copy(subst_list , key , value );
+
+       The difference between these functions is who is owning the memory
+       pointed to by the value pointer.
+
+    3. Do the actual search-replace operation on a file or memory buffer:
+
+       * subst_list_filter_file()   : Does search-replace on a file.
+       * subst_list_update_string() : Does search-replace on a buffer.
+
+    4. Free the subst_list and go home.
+
+   Internally the (key,value) pairs used for substitutions are stored in a
+   vector, preserving insert order. If you insert the cascade
+
+     ("A","B")
+     ("B","C")
+       .....
+     ("Y","Z")
+
+   You will eventually end up with a string where all capital letters have
+   been transformed to 'Z'.
+*/
+
+
+typedef enum { SUBST_DEEP_COPY   = 1,
+               SUBST_MANAGED_REF = 2,
+               SUBST_SHARED_REF  = 3} subst_insert_type; /* Mode used in the subst_list_insert__() function */
+
+#define SUBST_LIST_TYPE_ID 6614320
+
+struct subst_list_struct {
+  UTIL_TYPE_ID_DECLARATION;
+  const subst_list_type       * parent;       /* A parent subst_list instance - can be NULL - no destructor is called for the parent. */
+  vector_type                 * string_data;  /* The string substitutions we should do. */
+  vector_type                 * func_data;    /* The functions we support. */
+  const subst_func_pool_type  * func_pool;    /* NOT owned by the subst_list instance - can be NULL */
+  hash_type                   * map;
+};
+
+
+
+typedef struct {
+  subst_func_type * func;         /* Pointer to the real subst_func_type - implemented in subst_func.c */
+  char            * name;         /* The name the function is recognized as - in this substitution context. */
+} subst_list_func_type;
+
+
+
+
+/*
+   The subst_list type is implemented as a hash of subst_list_node
+   instances. This node type is not exported out of this file scope at
+   all.
+*/
+
+typedef struct {
+  bool              value_owner;     /* Wether the memory pointed to by value should bee freed.*/
+  char            * value;
+  char            * key;
+  char            * doc_string;      /* A doc_string of this substitution - only for documentation - can be NULL. */
+} subst_list_string_type;
+
+
+
+/*****************************************************************/
+/* Here comes functions implementing the small
+   subst_list_string_type */
+
+/** Allocates an empty instance with no values. */
+static subst_list_string_type * subst_list_string_alloc(const char * key) {
+  subst_list_string_type * node = util_malloc(sizeof * node );
+  node->value_owner       = false;
+  node->value             = NULL;
+  node->doc_string        = NULL;
+  node->key               = util_alloc_string_copy( key );
+  return node;
+}
+
+
+static void subst_list_string_free_content( subst_list_string_type * node ) {
+  if (node->value_owner)
+    util_safe_free( node->value );
+}
+
+
+static void subst_list_string_free(subst_list_string_type * node) {
+  subst_list_string_free_content( node );
+  util_safe_free( node->doc_string );
+  free(node->key);
+  free(node);
+}
+
+
+static void subst_list_string_free__(void * node) {
+  subst_list_string_free( (subst_list_string_type *) node );
+}
+
+
+
+
+/**
+   input_value can be NULL.
+*/
+static void subst_list_string_set_value(subst_list_string_type * node, const char * input_value , const char * doc_string , subst_insert_type insert_mode) {
+  subst_list_string_free_content( node );
+  {
+    char * value;
+    if (insert_mode == SUBST_DEEP_COPY)
+      value = util_alloc_string_copy(input_value);
+    else
+      value = (char *) input_value;
+
+    if (insert_mode == SUBST_SHARED_REF)
+      node->value_owner = false;
+    else
+      node->value_owner = true;
+
+    node->value = value;
+  }
+
+  if (doc_string != NULL)
+    node->doc_string = util_realloc_string_copy( node->doc_string , doc_string );
+}
+
+/*****************************************************************/
+/**
+   When arriving at this function the main subst scope should already have verified that
+   the requested function is available in the function pool.
+*/
+
+static subst_list_func_type * subst_list_func_alloc( const char * func_name, subst_func_type * func) {
+  subst_list_func_type * subst_func = util_malloc( sizeof * subst_func );
+  subst_func->name      = util_alloc_string_copy( func_name );
+  subst_func->func      = func;
+  return subst_func;
+}
+
+
+static void subst_list_func_free( subst_list_func_type * subst_func ) {
+  free( subst_func->name );
+  free( subst_func );
+}
+
+
+static void subst_list_func_free__(void * node) {
+  subst_list_func_free( (subst_list_func_type *) node );
+}
+
+static char * subst_list_func_eval( const subst_list_func_type * subst_func , const stringlist_type * arglist) {
+  return subst_func_eval(subst_func->func , arglist );
+}
+
+/*****************************************************************/
+
+/**
+   Find the node corresponding to 'key' -  returning NULL if it is not found.
+*/
+
+static subst_list_string_type * subst_list_get_string_node(const subst_list_type * subst_list , const char * key) {
+  subst_list_string_type * node = NULL;
+  int  index                  = 0;
+
+  /* Linear search ... */  /*Should use map*/
+  while ((index < vector_get_size(subst_list->string_data)) && (node == NULL)) {
+    subst_list_string_type * inode = vector_iget( subst_list->string_data , index);
+
+    if (strcmp(inode->key , key) == 0)  /* Found it */
+      node = inode;
+    else
+      index++;
+  }
+
+  return node;
+}
+
+
+
+static subst_list_string_type * subst_list_insert_new_node(subst_list_type * subst_list , const char * key , bool append) {
+  subst_list_string_type * new_node = subst_list_string_alloc(key);
+
+  if (append)
+    vector_append_owned_ref( subst_list->string_data , new_node , subst_list_string_free__ );
+  else
+    vector_insert_owned_ref( subst_list->string_data , 0 , new_node , subst_list_string_free__ );
+
+  hash_insert_ref( subst_list->map , key , new_node );
+  return new_node;
+}
+
+/*****************************************************************/
+
+UTIL_IS_INSTANCE_FUNCTION( subst_list , SUBST_LIST_TYPE_ID )
+
+
+/**
+   Observe that this function sets both the subst parent, and the pool
+   of available functions. If this is call is repeated it is possible
+   to create a weird config with dangling function pointers - that is
+   a somewhat contrived and pathological use case, and not checked
+   for.
+*/
+
+void subst_list_set_parent( subst_list_type * subst_list , const subst_list_type * parent) {
+  subst_list->parent = parent;
+  if (parent != NULL)
+    subst_list->func_pool = subst_list->parent->func_pool;
+}
+
+
+const subst_list_type * subst_list_get_parent( const subst_list_type * subst_list ) {
+  return subst_list->parent;
+}
+
+
+bool subst_list_has_key( const subst_list_type * subst_list , const char * key) {
+  return hash_has_key( subst_list->map , key );
+}
+
+
+/*
+   The input argument is currently only (void *), runtime it will be
+   checked whether it is of type subst_list_type, in which case it is
+   interpreted as a parent instance, if it is of type
+   subst_func_pool_type it is interpreted as a func_pool instance,
+   otherwise the function will fail hard.
+
+   If the the input argument is a subst_list parent, the func_pool of
+   the parent is used also for the newly allocated subst_list
+   instance.
+*/
+
+
+subst_list_type * subst_list_alloc(const void * input_arg) {
+  subst_list_type * subst_list = util_malloc(sizeof * subst_list );
+  UTIL_TYPE_ID_INIT( subst_list , SUBST_LIST_TYPE_ID);
+  subst_list->parent           = NULL;
+  subst_list->func_pool        = NULL;
+  subst_list->map              = hash_alloc();
+  subst_list->string_data      = vector_alloc_new();
+  subst_list->func_data        = vector_alloc_new();
+
+  if (input_arg != NULL) {
+    if (subst_list_is_instance( input_arg ))
+      subst_list_set_parent( subst_list , input_arg );
+    else if (subst_func_pool_is_instance( input_arg ))
+      subst_list->func_pool = input_arg;
+    else
+      util_abort("%s: run_time cast failed - invalid type on input argument.\n",__func__);
+  }
+
+  return subst_list;
+}
+
+
+/**
+   The semantics of the doc_string string is as follows:
+
+    1. If doc_string is different from NULL the doc_string is stored in the node.
+
+    2. If a NULL value follows a non-NULL value (i.e. the substitution
+       is updated) the doc_string is not changed.
+
+   The idea is that the doc_string must just be included the first
+   time a (key,value) pair is added. On subsequent updates of the
+   value, the doc_string string can be NULL.
+*/
+
+
+static void subst_list_insert__(subst_list_type * subst_list , const char * key , const char * value , const char * doc_string, bool append ,
+                                subst_insert_type insert_mode) {
+  subst_list_string_type * node = subst_list_get_string_node(subst_list , key);
+
+  if (node == NULL) /* Did not have the node. */
+    node = subst_list_insert_new_node(subst_list , key ,append);
+  subst_list_string_set_value(node , value , doc_string , insert_mode);
+}
+
+
+/**
+   There are three different functions for inserting a key-value pair
+   in the subst_list instance. The difference between the three is in
+   which scope takes/has ownership of 'value'. The alternatives are:
+
+    subst_list_insert_ref: In this case the calling scope has full
+       ownership of value, and is consquently responsible for freeing
+       it, and ensuring that it stays a valid pointer for the subst_list
+       instance. Probably the most natural function to use when used
+       with static storage, i.e. typically string literals.
+
+    subst_list_insert_owned_ref: In this case the subst_list takes
+       ownership of the value reference, in the sense that it will
+       free it when it is done.
+
+    subst_list_insert_copy: In this case the subst_list takes a copy
+       of value and inserts it. Meaning that the substs_list instance
+       takes repsonibility of freeing, _AND_ the calling scope is free
+       to do whatever it wants with the value pointer.
+
+*/
+
+void subst_list_append_ref(subst_list_type * subst_list , const char * key , const char * value, const char * doc_string) {
+  subst_list_insert__(subst_list , key , value , doc_string , true , SUBST_SHARED_REF);
+}
+
+void subst_list_append_owned_ref(subst_list_type * subst_list , const char * key , const char * value, const char * doc_string) {
+  subst_list_insert__(subst_list , key , value , doc_string , true , SUBST_MANAGED_REF);
+}
+
+void subst_list_append_copy(subst_list_type * subst_list , const char * key , const char * value, const char * doc_string) {
+  subst_list_insert__(subst_list , key , value , doc_string , true , SUBST_DEEP_COPY);
+}
+
+void subst_list_prepend_ref(subst_list_type * subst_list , const char * key , const char * value, const char * doc_string) {
+  subst_list_insert__(subst_list , key , value , doc_string , false , SUBST_SHARED_REF);
+}
+
+void subst_list_prepend_owned_ref(subst_list_type * subst_list , const char * key , const char * value, const char * doc_string) {
+  subst_list_insert__(subst_list , key , value , doc_string , false , SUBST_MANAGED_REF);
+}
+
+void subst_list_prepend_copy(subst_list_type * subst_list , const char * key , const char * value, const char * doc_string) {
+  subst_list_insert__(subst_list , key , value , doc_string , false , SUBST_DEEP_COPY);
+}
+
+
+
+/**
+   This function will install the function @func_name from the current
+   subst_func_pool, it will be made available to this subst_list
+   instance with the function name @local_func_name. If @func_name is
+   not available, the function will fail hard.
+*/
+
+void subst_list_insert_func(subst_list_type * subst_list , const char * func_name , const char * local_func_name) {
+
+  if (subst_list->func_pool != NULL && subst_func_pool_has_func( subst_list->func_pool , func_name )) {
+    subst_list_func_type * subst_func = subst_list_func_alloc( local_func_name , subst_func_pool_get_func( subst_list->func_pool , func_name ));
+    vector_append_owned_ref( subst_list->func_data , subst_func , subst_list_func_free__ );
+  } else
+    util_abort("%s: function:%s not available \n",__func__ , func_name);
+}
+
+
+void subst_list_clear( subst_list_type * subst_list ) {
+  vector_clear( subst_list->string_data );
+}
+
+
+void subst_list_free(subst_list_type * subst_list) {
+  vector_free( subst_list->string_data );
+  vector_free( subst_list->func_data );
+  hash_free( subst_list->map );
+  free(subst_list);
+}
+
+
+/*****************************************************************/
+/*
+  Below comes many different functions for doing the actual updating
+  the functions differ in the form of the input and output. At the
+  lowest level, is the function
+
+    subst_list_uppdate_buffer()
+
+  which will update a buffer instance. This function again will call
+  two separate functions for pure string substitutions and for
+  function evaluation.
+
+  The update replace functions will first apply all the string
+  substitutions for this particular instance, and afterwards calling
+  all the string substititions of the parent (recursively); the same
+  applies to the function replacements.
+*/
+
+/*****************************************************************/
+
+
+/**
+   Updates the buffer inplace with all the string substitutions in the
+   subst_list. This is the lowest level function, which does *NOT*
+   consider the parent pointer.
+*/
+static bool subst_list_replace_strings__(const subst_list_type * subst_list , buffer_type * buffer) {
+  int index;
+  bool global_match = false;
+  for (index = 0; index < vector_get_size( subst_list->string_data ); index++) {
+    const subst_list_string_type * node = vector_iget_const( subst_list->string_data , index );
+    if (node->value != NULL) {
+      bool match;
+      buffer_rewind( buffer );
+      do {
+        match = buffer_search_replace( buffer , node->key , node->value);
+        if (match)
+          global_match = true;
+      } while (match);
+    }
+  }
+  return global_match;
+}
+
+
+
+
+/**
+   Updates the buffer inplace by evaluationg all the string functions
+   in the subst_list. Last performing all the replacements in the
+   parent.
+
+   The rules for function evaluation are as follows:
+
+    1. Every function MUST have a '()', IMMEDIATELY following the
+       function name, this also applies to functions which do not have
+       any arguments.
+
+    2. The function parser is quite primitive, and can (at least
+       currently) not handle nested functions, i.e.
+
+          __SUM__( __SUM__(1 ,2 ) , 3)
+
+       will fail.
+
+    3. If the function evaluation fails; typicall because of wrong
+       type/number of arguments the buffer will not updated.
+
+
+    4. The functions will return a freshly allocated (char *) pointer,
+       or NULL if the evaluation fails, and the input value is a list
+       of strings extracted from the parsing context - i.e. the
+       function is in no way limited to numeric functions like sum()
+       and exp().
+
+*/
+
+static bool subst_list_eval_funcs____(const subst_list_type * subst_list , const basic_parser_type * parser , buffer_type * buffer) {
+  bool global_match = false;
+  int index;
+  for (index = 0; index < vector_get_size( subst_list->func_data); index++) {
+    const subst_list_func_type * subst_func = vector_iget_const( subst_list->func_data , index );
+    const char                 * func_name  = subst_func->name;
+
+    bool match;
+    buffer_rewind( buffer );
+    do {
+      size_t match_pos;
+      match     = buffer_strstr( buffer , func_name );
+      match_pos = buffer_get_offset( buffer );
+
+      if (match) {
+        bool   update     = false;
+        char * arg_start  = buffer_get_data( buffer );
+        arg_start        += buffer_get_offset( buffer ) + strlen( func_name );
+
+        if (arg_start[0] == '(') {  /* We require that an opening paren follows immediately behind the function name. */
+          char * arg_end = strchr( arg_start , ')');
+          if (arg_end != NULL) {
+            /* OK - we found an enclosing () pair. */
+            char            * arg_content = util_alloc_substring_copy( arg_start, 1 , arg_end - arg_start - 1);
+            stringlist_type * arg_list    = basic_parser_tokenize_buffer( parser , arg_content , true);
+            char            * func_eval   = subst_list_func_eval( subst_func , arg_list );
+            int               old_len     = strlen(func_name) + strlen( arg_content) + 2;
+
+            if (func_eval != NULL) {
+              buffer_memshift( buffer , match_pos + old_len , strlen( func_eval ) - old_len);
+              buffer_fwrite( buffer , func_eval , strlen( func_eval ) , sizeof * func_eval );
+              free( func_eval );
+              update = true;
+              global_match = true;
+            }
+
+            free( arg_content );
+            stringlist_free( arg_list );
+          }
+        }
+        if (!update)
+          buffer_fseek( buffer , match_pos + strlen( func_name ) , SEEK_SET);
+      }
+    } while (match);
+  }
+  if (subst_list->parent != NULL)
+    global_match = (subst_list_eval_funcs____( subst_list->parent , parser , buffer ) || global_match);
+  return global_match;
+}
+
+
+static bool subst_list_eval_funcs__(const subst_list_type * subst_list , buffer_type * buffer) {
+  basic_parser_type     * parser     = basic_parser_alloc( "," , "\"\'" , NULL , " \t" , NULL , NULL );
+  bool match = subst_list_eval_funcs____( subst_list , parser , buffer );
+
+  basic_parser_free( parser );
+  return match;
+}
+
+
+
+/**
+   Should we evaluate the parent first (i.e. top down), or this
+   instance first and then subsequently the parent (i.e. bottom
+   up). The problem is with inherited defintions:
+
+     Inherited defintions
+     --------------------
+
+     In this situation we have defined a (key,value) substitution,
+     where the value depends on a value following afterwards:
+
+       ("<PATH>" , "/tmp/run/<CASE>")
+       ("<CASE>" , "Test4")
+
+     I.e. first <PATH> is replaced with "/tmp/run/<CASE>" and then
+     subsequently "<CASE>" is replaced with "Test4". A typical use
+     case here is that the common definition of "<PATH>" is in the
+     parent, and consequently parent should run first (i.e. top
+     down).
+
+     However, in other cases the order of defintion might very well be
+     opposite, i.e. with "<CASE>" first and then things will blow up:
+
+       1. <CASE>: Not found
+       2. <PATH> -> /tmp/run/<CASE>
+
+     and, the final <CASE> will not be resolved. I.e. there is no
+     obvious 'right' way to do it.
+
+
+
+     Overriding defaults
+     -------------------
+
+     The parent has defined:
+
+        ("<PATH>" , "/tmp/run/default")
+
+     But for a particular instance we would like to overwrite <PATH>
+     with another definition:
+
+        ("<PATH>" , "/tmp/run/special_case")
+
+     This will require evaluating the bottom first, i.e. a bottom up
+     approach.
+
+
+   Currently the implementation is purely top down, the latter case
+   above is not supported. The actual implementation here is in terms
+   of recursion, the low level function doing the stuff is
+   subst_list_replace_strings__() which is not recursive.
+*/
+
+static bool subst_list_replace_strings( const subst_list_type * subst_list , buffer_type * buffer ) {
+  bool match = false;
+  if (subst_list->parent != NULL)
+    match = subst_list_replace_strings( subst_list->parent , buffer );
+
+  /* The actual string replace */
+  match = (subst_list_replace_strings__( subst_list , buffer ) || match);
+  return match;
+}
+
+
+/*
+  This function updates a buffer instance inplace with all the
+  substitutions in the subst_list.
+
+  This is the common low-level function employed by all the the
+  subst_update_xxx() functions. Observe that it is a hard assumption
+  that the buffer has a \0 terminated string.
+*/
+
+
+bool subst_list_update_buffer( const subst_list_type * subst_list , buffer_type * buffer ) {
+  bool match1 = subst_list_replace_strings( subst_list , buffer );
+  bool match2 = subst_list_eval_funcs__( subst_list , buffer );
+  return (match1 || match2);   // Funny construction to ensure to avoid fault short circuit.
+}
+
+
+/**
+   This function reads the content of a file, and writes a new file
+   where all substitutions in subst_list have been performed. Observe
+   that target_file and src_file *CAN* point to the same file, in
+   which case this will amount to an inplace update. In that case a
+   backup file is written, and held, during the execution of the
+   function.
+
+   Observe that @target_file can contain a path component, that
+   component will be created if it does not exist.
+*/
+
+
+bool subst_list_filter_file(const subst_list_type * subst_list , const char * src_file , const char * target_file) {
+  bool   match;
+  char * backup_file   = NULL;
+  buffer_type * buffer = buffer_fread_alloc( src_file );
+  buffer_fseek( buffer , 0 , SEEK_END );  /* Ensure that the buffer is a \0 terminated string. */
+  buffer_fwrite_char( buffer , '\0');
+
+  /*****************************************************************/
+  /* Backup file ??  */
+  if (util_same_file(src_file , target_file)) {
+    char * backup_prefix = util_alloc_sprintf("%s-%s" , src_file , __func__);
+    backup_file = util_alloc_tmp_file("/tmp" , backup_prefix , false);
+    free(backup_prefix);
+  }
+
+
+  /* Writing backup file */
+  if (backup_file != NULL) {
+    FILE * stream = util_fopen(backup_file , "w");
+    buffer_stream_fwrite_n( buffer , 0 , -1 , stream );  /* -1: Do not write the trailing \0. */
+    fclose(stream);
+  }
+
+
+  /* Doing the actual update */
+  match = subst_list_update_buffer(subst_list , buffer);
+
+
+  /* Writing updated file */
+  {
+    FILE * stream = util_mkdir_fopen(target_file , "w");
+    buffer_stream_fwrite_n( buffer , 0 , -1 , stream );  /* -1: Do not write the trailing \0. */
+    fclose(stream);
+  }
+
+  /* OK - all went hunka dory - unlink the backup file and leave the building. */
+  if (backup_file != NULL) {
+    remove( backup_file );
+    free( backup_file );
+  }
+  buffer_free( buffer );
+  return match;
+}
+
+/**
+   This function does search-replace on a file inplace.
+*/
+
+bool subst_list_update_file(const subst_list_type * subst_list , const char * file) {
+  return subst_list_filter_file( subst_list , file , file );
+}
+
+
+
+/**
+   This function does search-replace on string instance inplace.
+*/
+bool subst_list_update_string(const subst_list_type * subst_list , char ** string) {
+  buffer_type * buffer = buffer_alloc_private_wrapper( *string , strlen( *string ) + 1);
+  bool match = subst_list_update_buffer(subst_list , buffer);
+  *string = buffer_get_data( buffer );
+  buffer_free_container( buffer );
+
+  return match;
+}
+
+
+
+/**
+   This function allocates a new string where the search-replace
+   operation has been performed.
+*/
+
+char * subst_list_alloc_filtered_string(const subst_list_type * subst_list , const char * string) {
+  char * filtered_string = util_alloc_string_copy( string );
+  subst_list_update_string( subst_list , &filtered_string );
+  return filtered_string;
+}
+
+
+
+/**
+   This function writes a filtered version of string to a file.
+*/
+void subst_list_filtered_fprintf(const subst_list_type * subst_list , const char * string , FILE * stream) {
+  buffer_type * buffer = buffer_alloc( strlen(string) + 1 );
+  buffer_fwrite( buffer , string , 1 , strlen( string ) + 1);
+  subst_list_update_buffer(subst_list , buffer);
+  buffer_stream_fwrite_n( buffer , 0 , -1 , stream );  /* -1: The trailing \0 is not explicitly written to file. */
+  buffer_free(buffer);
+}
+
+
+
+/**
+   This function will perform subst-based substitution on all the
+   elements in the stringlist. The stringlist is modified in place,
+   and the following applies to memory:
+
+    o Elements inserted with _ref() are just dropped on the floor,
+      they were the responsability of the calling scope anyway.
+
+    o Elements inserted with _owned_ref() are freed - INVALIDATING A
+      POSSIBLE POINTER IN THE CALLING SCOPE.
+
+    o The newly inserted element is inserted as _owned_ref() -
+      i.e. with a destructor.
+*/
+
+
+void stringlist_apply_subst(stringlist_type * stringlist , const subst_list_type * subst_list) {
+  int i;
+  for (i=0; i < stringlist_get_size( stringlist ); i++) {
+    const char * old_string = stringlist_iget( stringlist , i );
+    char * new_string = subst_list_alloc_filtered_string( subst_list , old_string );
+    stringlist_iset_owned_ref( stringlist , i , new_string );
+  }
+}
+
+/*****************************************************************/
+/*  End of update/apply functions                                */
+/*****************************************************************/
+
+
+
+
+/**
+   This allocates a new subst_list instance, the copy process is deep,
+   in the sense that all srings inserted in the new subst_list
+   instance have their own storage, irrespective of the ownership in
+   the original subst_list instance.
+*/
+
+subst_list_type * subst_list_alloc_deep_copy(const subst_list_type * src) {
+  subst_list_type * copy;
+  if (src->parent != NULL)
+    copy = subst_list_alloc( src->parent );
+  else
+    copy = subst_list_alloc( src->func_pool);
+
+  {
+    int index;
+    for (index = 0; index < vector_get_size( src->string_data ); index++) {
+      const subst_list_string_type * node = vector_iget_const( src->string_data , index );
+      subst_list_insert__( copy , node->key , node->value , node->doc_string , true , SUBST_DEEP_COPY);
+    }
+
+    for (index = 0; index < vector_get_size( src->func_data ); index++) {
+      const subst_list_func_type * src_node  = vector_iget_const( src->func_data , index );
+      subst_list_func_type       * copy_node = subst_list_func_alloc( src_node->name , src_node->func );
+      vector_append_owned_ref( copy->func_data , copy_node , subst_list_func_free__ );
+    }
+
+  }
+  return copy;
+}
+
+
+int subst_list_get_size( const subst_list_type * subst_list) {
+  return vector_get_size(subst_list->string_data);
+}
+
+
+const char * subst_list_iget_key( const subst_list_type * subst_list , int index) {
+  if (index < vector_get_size(subst_list->string_data)) {
+    const subst_list_string_type * node = vector_iget_const( subst_list->string_data , index );
+    return node->key;
+  } else {
+    util_abort("%s: index:%d to large \n",__func__ , index);
+    return NULL;
+  }
+}
+
+
+const char * subst_list_iget_value( const subst_list_type * subst_list , int index) {
+  if (index < vector_get_size(subst_list->string_data)) {
+    const subst_list_string_type * node = vector_iget_const( subst_list->string_data , index );
+    return node->value;
+  } else {
+    util_abort("%s: index:%d to large \n",__func__ , index);
+    return NULL;
+  }
+}
+
+const char * subst_list_get_value( const subst_list_type * subst_list , const char * key) {
+  const subst_list_string_type * node = hash_get( subst_list->map , key );
+  return node->value;
+}
+
+
+
+const char * subst_list_get_doc_string( const subst_list_type * subst_list , const char * key) {
+  const subst_list_string_type * node = hash_get( subst_list->map , key );
+  return node->doc_string;
+}
+
+
+const char * subst_list_iget_doc_string( const subst_list_type * subst_list , int index) {
+  if (index < vector_get_size(subst_list->string_data)) {
+    const subst_list_string_type * node = vector_iget_const( subst_list->string_data , index );
+    return node->doc_string;
+  } else {
+    util_abort("%s: index:%d to large \n",__func__ , index);
+    return NULL;
+  }
+}
+
+
+
+void subst_list_fprintf(const subst_list_type * subst_list , FILE * stream) {
+  int index;
+  for (index=0; index < vector_get_size( subst_list->string_data ); index++) {
+    const subst_list_string_type * node = vector_iget_const( subst_list->string_data , index );
+    fprintf(stream , "%s = %s\n" , node->key , node->value);
+  }
+}
+
+
+
+
+
+
+/**
+   Will allocate string representation of the subst_list as:
+   KEY1=Value1, Key2=Value2, Key3=Value3. Will return NULL is there
+   are no elements in the subst_list.
+*/
+
+char * subst_list_alloc_string_representation( const subst_list_type * subst_list ) {
+  int size = subst_list_get_size( subst_list );
+  char * return_string = NULL;
+  if (size > 0) {
+    buffer_type * buffer = buffer_alloc( 512 );
+    int i;
+
+    for (i=0; i < size; i++) {
+      buffer_fwrite_char_ptr( buffer , subst_list_iget_key( subst_list , i));
+      buffer_strcat(buffer , "=");
+      buffer_strcat( buffer , subst_list_iget_value( subst_list , i));
+      if (i < (size - 1))
+        buffer_strcat( buffer , ", ");
+    }
+    buffer_shrink_to_fit( buffer );
+    return_string = buffer_get_data( buffer );
+    buffer_free_container( buffer );
+  }
+  return return_string;
+}
+
+
+/** Will loose tagging .... */
+int subst_list_add_from_string( subst_list_type * subst_list , const char * arg_string, bool append) {
+  int     error_count = 0;
+  if (arg_string != NULL) {
+    char ** key_value_list;
+    int     num_arg, iarg;
+
+    util_split_string(arg_string , "," , &num_arg , &key_value_list);
+    for (iarg = 0; iarg < num_arg; iarg++) {
+      if (strchr(key_value_list[iarg] , '=') == NULL)
+        //util_abort("%s: could not find \'=\' in argument string:%s \n",__func__ , key_value_list[iarg]);
+        /*
+          Could not find '=' in the argument string, this argument will
+          be ignored, and the error_count will be increased by one.
+        */
+        error_count += 1;
+      else {
+        char * key , * value;
+        char * tmp     = key_value_list[iarg];
+        int arg_length , value_length;
+        while (isspace(*tmp))  /* Skipping initial space */
+          tmp++;
+
+        arg_length = strcspn(tmp , " =");
+        key  = util_alloc_substring_copy(tmp , 0 , arg_length);
+        tmp += arg_length;
+        while ((*tmp == ' ') || (*tmp == '='))
+          tmp++;
+
+        value_length = strcspn(tmp , " ");
+        value = util_alloc_substring_copy( tmp , 0 , value_length);
+
+        /* Setting the argument */
+        if (append)
+          subst_list_append_copy( subst_list , key , value , NULL);
+        else
+          subst_list_prepend_copy( subst_list , key , value , NULL);
+
+        free(key);
+        free(value);
+        tmp += value_length;
+
+
+        /* Accept only trailing space - any other character indicates a failed parsing. */
+        while (*tmp != '\0') {
+          if (!isspace(*tmp))
+            util_abort("%s: something wrong with:%s  - spaces are not allowed in key or value part.\n",__func__ , key_value_list[iarg]);
+          tmp++;
+        }
+      }
+    }
+    util_free_stringlist(key_value_list , num_arg);
+  }
+  return error_count;
+}
+
+
+
+/*****************************************************************/

--- a/libres_util/src/template.c
+++ b/libres_util/src/template.c
@@ -1,0 +1,228 @@
+/*
+   Copyright (C) 2011  Statoil ASA, Norway. 
+    
+   The file 'template.c' is part of ERT - Ensemble based Reservoir Tool. 
+    
+   ERT is free software: you can redistribute it and/or modify 
+   it under the terms of the GNU General Public License as published by 
+   the Free Software Foundation, either version 3 of the License, or 
+   (at your option) any later version. 
+    
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+   FITNESS FOR A PARTICULAR PURPOSE.   
+    
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+   for more details. 
+*/
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <ert/util/ert_api_config.h>
+
+#include <ert/util/util.h>
+#include <ert/util/subst_func.h>
+#include <ert/util/stringlist.h>
+
+#include <ert/res_util/subst_list.h>
+#include <ert/res_util/template.h>
+#include <ert/res_util/template_type.h>
+
+/**
+   Iff the template is set up with internaliz_template == false the
+   template content is loaded at instantiation time, and in that case
+   the name of the template file can contain substitution characters -
+   i.e. in this case different instance can use different source
+   templates.
+
+   To avoid race issues this function does not set actually update the
+   state of the template object.
+*/
+
+static char * template_load( const template_type * template , const subst_list_type * ext_arg_list) {
+  int buffer_size;
+  char * template_file = util_alloc_string_copy( template->template_file );
+  char * template_buffer;
+  
+  subst_list_update_string( template->arg_list , &template_file);
+  if (ext_arg_list != NULL)
+    subst_list_update_string( ext_arg_list , &template_file);
+  
+  template_buffer = util_fread_alloc_file_content( template_file , &buffer_size );
+  free( template_file );
+  
+  return template_buffer;
+}
+
+
+
+void template_set_template_file( template_type * template , const char * template_file) {
+  template->template_file = util_realloc_string_copy( template->template_file , template_file );
+  if (template->internalize_template) {
+    util_safe_free( template->template_buffer );
+    template->template_buffer = template_load( template , NULL );  
+  }
+}
+
+/** This will not instantiate */
+const char * template_get_template_file( const template_type * template ) {
+  return template->template_file; 
+}
+
+
+
+/**
+   This function allocates a template object based on the source file
+   'template_file'. If @internalize_template is true the template
+   content will be read and internalized at boot time, otherwise that
+   is deferred to template instantiation time (in which case the
+   template file can change dynamically).
+*/
+
+
+template_type * template_alloc( const char * template_file , bool internalize_template , subst_list_type * parent_subst) {
+  template_type * template = util_malloc( sizeof * template );
+  UTIL_TYPE_ID_INIT(template , TEMPLATE_TYPE_ID);
+  template->arg_list             = subst_list_alloc( parent_subst );
+  template->template_buffer      = NULL;
+  template->template_file        = NULL;
+  template->internalize_template = internalize_template;
+  template->arg_string           = NULL;
+  template_set_template_file( template , template_file );
+
+#ifdef ERT_HAVE_REGEXP
+  template_init_loop_regexp( template );
+#endif
+  return template;
+}
+
+
+
+
+
+
+
+void template_free( template_type * template ) {
+  subst_list_free( template->arg_list );
+  util_safe_free( template->template_file );
+  util_safe_free( template->template_buffer );
+  util_safe_free( template->arg_string );
+
+#ifdef ERT_HAVE_REGEXP
+  regfree( &template->start_regexp );
+  regfree( &template->end_regexp );
+#endif
+  
+  free( template );
+}
+
+
+
+/**
+   This function will create the file @__target_file based on the
+   template instance. Before the target file is written all the
+   internal substitutions and then subsequently the subsititutions in
+   @arg_list will be performed. The input @arg_list can be NULL - in
+   which case this is more like copy operation.
+
+   Observe that:
+   
+    1. Substitutions will be performed on @__target_file
+
+    2. @__target_file can contain path components.
+
+    3. If internalize_template == false subsititions will be performed
+       on the filename of the file with template content.
+  
+    4. If the parameter @override_symlink is true the function will
+       have the following behaviour:
+
+         If the target_file already exists as a symbolic link, the
+         symbolic link will be removed prior to creating the instance,
+         ensuring that a remote file is not updated.
+
+*/
+   
+
+
+void template_instantiate( const template_type * template , const char * __target_file , const subst_list_type * arg_list , bool override_symlink) {
+  char * target_file = util_alloc_string_copy( __target_file );
+
+  /* Finding the name of the target file. */
+  subst_list_update_string( template->arg_list , &target_file);
+  if (arg_list != NULL) subst_list_update_string( arg_list , &target_file );
+
+  {
+    char * char_buffer;
+    /* Loading the template - possibly expanding keys in the filename */
+    if (template->internalize_template)
+      char_buffer = util_alloc_string_copy( template->template_buffer);
+    else
+      char_buffer = template_load( template , arg_list );
+    
+    /* Substitutions on the content. */
+    subst_list_update_string( template->arg_list , &char_buffer );
+    if (arg_list != NULL) subst_list_update_string( arg_list , &char_buffer );
+
+    
+#ifdef ERT_HAVE_REGEXP
+    {
+      buffer_type * buffer = buffer_alloc_private_wrapper( char_buffer , strlen( char_buffer ) + 1);
+      template_eval_loops( template , buffer );
+      char_buffer = buffer_get_data( buffer );
+      buffer_free_container( buffer );
+    }
+#endif
+
+    /* 
+       Check if target file already exists as a symlink, 
+       and remove it if override_symlink is true. 
+    */
+    if (override_symlink) {
+      if (util_is_link( target_file ))
+        remove( target_file );
+    }
+    
+    /* Write the content out. */
+    {
+      FILE * stream = util_mkdir_fopen( target_file , "w");
+      fprintf(stream , "%s" , char_buffer);
+      fclose( stream );
+    }
+    free( char_buffer );
+  }
+  
+  free( target_file );
+}
+
+
+/**
+   Add an internal key_value pair. This substitution will be performed
+   before the internal substitutions.
+*/
+void template_add_arg( template_type * template , const char * key , const char * value ) {
+  subst_list_append_copy( template->arg_list , key , value , NULL /* No doc_string */);
+}
+
+
+void template_clear_args( template_type * template ) {
+  subst_list_clear( template->arg_list );
+}
+
+
+int template_add_args_from_string( template_type * template , const char * arg_string) {
+  return subst_list_add_from_string( template->arg_list , arg_string , true);
+}
+
+
+char * template_get_args_as_string( template_type * template ) {
+  util_safe_free( template->arg_string );
+  template->arg_string = subst_list_alloc_string_representation( template->arg_list );
+  return template->arg_string;
+}
+
+/*****************************************************************/
+
+

--- a/libres_util/src/template_loop.c
+++ b/libres_util/src/template_loop.c
@@ -1,0 +1,293 @@
+/*
+   Copyright (C) 2012  Statoil ASA, Norway. 
+    
+   The file 'template_loop.c' is part of ERT - Ensemble based Reservoir Tool. 
+    
+   ERT is free software: you can redistribute it and/or modify 
+   it under the terms of the GNU General Public License as published by 
+   the Free Software Foundation, either version 3 of the License, or 
+   (at your option) any later version. 
+    
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+   FITNESS FOR A PARTICULAR PURPOSE.   
+    
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+   for more details. 
+*/
+
+#include <ert/util/ert_api_config.h>
+
+#include <ctype.h>
+#include <sys/types.h>
+#include <regex.h>
+
+#include <ert/util/parser.h>
+#include <ert/util/stringlist.h>
+
+#include <ert/res_util/template_type.h>
+#include <ert/res_util/template.h>
+
+#define END_REGEXP           "[{]%[[:space:]]+endfor[[:space:]]+%[}]"
+#define LOOP_REGEXP          "[{]%[[:space:]]+for[[:space:]]+([$]?[[:alpha:]][[:alnum:]]*)[[:space:]]+in[[:space:]]+[[]([^]]*)[]][[:space:]]+%[}]"
+
+#define LOOP_OPTIONS REG_EXTENDED
+#define END_OPTIONS  REG_EXTENDED
+
+#define DOLLAR  '$'
+/*
+  This file implements a simple looping construct in the templates. The support
+  is strongly based on the POSIX regexp functionality; and this file will not
+  be compiled unless that support is present.
+*/
+
+struct loop_struct {
+  int               opentag_offset;
+  int               opentag_length;
+
+  int               endtag_offset;
+  int               endtag_length;
+
+  int               body_offset;
+  int               body_length;
+
+  bool              replace_substring; 
+  int               var_length;
+  char            * loop_var;
+  stringlist_type * items;
+};
+
+static void regcompile(regex_t * reg , const char * reg_string , int flags) {
+  int error = regcomp(reg , reg_string , flags);
+  if (error) {
+    int error_size = 256;
+    char error_buffer[256];
+    regerror(error , reg , error_buffer , error_size);
+    util_exit("Compile of %s failed: %s \n",LOOP_REGEXP, error_buffer);
+  }
+}
+
+
+
+
+static loop_type * loop_alloc( const char * buffer , int global_offset , regmatch_t tag_offset , regmatch_t __var_offset , regmatch_t __items_offset) {
+  loop_type * loop  = util_malloc( sizeof * loop);
+
+  loop->opentag_offset  = global_offset + tag_offset.rm_so;
+  loop->opentag_length  = tag_offset.rm_eo - tag_offset.rm_so;
+  
+  loop->endtag_offset  = -1;
+  loop->endtag_length  = -1;
+  
+  loop->body_offset = loop->opentag_offset + loop->opentag_length;
+  loop->body_length = -1;
+  {
+    int var_offset = global_offset + __var_offset.rm_so;
+    int var_length = __var_offset.rm_eo - __var_offset.rm_so;
+    loop->loop_var   = util_alloc_substring_copy( buffer , var_offset , var_length );
+    loop->var_length = strlen( loop->loop_var );
+    if (loop->loop_var[0] == DOLLAR)
+      loop->replace_substring = true;
+    else
+      loop->replace_substring = false;
+  }
+  {
+    int items_offset = global_offset + __items_offset.rm_so;
+    int items_length = __items_offset.rm_eo - __items_offset.rm_so;
+    char * items_string = util_alloc_substring_copy( buffer , items_offset , items_length );
+    basic_parser_type * parser = basic_parser_alloc("," , NULL , NULL , NULL , NULL , NULL); // Does not tolerate spaces around the splitting ","
+
+    loop->items          = basic_parser_tokenize_buffer( parser , items_string , false);
+
+    basic_parser_free( parser );
+    free( items_string );
+  }
+  return loop;
+}
+
+static void loop_set_endmatch( loop_type * loop , int global_offset , regmatch_t end_offset) {
+  loop->endtag_offset = global_offset + end_offset.rm_so;
+  loop->endtag_length = end_offset.rm_eo - end_offset.rm_so;
+  loop->body_length   = loop->endtag_offset - loop->opentag_offset - loop->opentag_length;
+}
+
+
+static void loop_free( loop_type * loop ) {
+  free( loop->loop_var );
+  stringlist_free( loop->items );
+  free( loop );
+}
+
+
+
+
+static void replace_1var( buffer_type * var_expansion , int shift , int write_offset , int shift_offset , const char * value) {
+  buffer_memshift( var_expansion , shift_offset , shift );
+  buffer_fseek( var_expansion , write_offset , SEEK_SET );
+  buffer_fwrite( var_expansion , value , strlen(value) , 1);
+}
+
+
+static void loop_eval( const loop_type * loop , const char * body , buffer_type * var_expansion , int ivar) {
+  buffer_clear( var_expansion );
+  buffer_fwrite_char_ptr( var_expansion , body );
+  {
+    const char * value = stringlist_iget( loop->items , ivar );
+    int value_length = strlen( value );
+    int shift        = value_length - loop->var_length;
+    int search_offset = 0;
+    
+    
+    while (true) {
+      char * data = buffer_get_data( var_expansion );
+      char * match_ptr = strstr( &data[search_offset] , loop->loop_var );
+      
+      if (match_ptr == NULL) 
+        break;
+      else {
+
+        /* Check that the match is either at the very start of the
+           string, or alternatively NOT preceeded by alphanumeric
+           character. If the variable starts with a '$' we ignore this
+           test.
+        */  
+        if (!loop->replace_substring) {
+          if (match_ptr != &data[search_offset]) { char
+              pre_char = match_ptr[-1]; if (isalnum( pre_char )) {
+              search_offset = match_ptr - data + 1;
+              
+              if (search_offset >= strlen(data))
+                break;
+              else
+                continue;
+            }
+          }
+
+
+          /* 
+             Check that the match is at the very end of the string, or
+             alternatively followed by a NON alphanumeric character. */
+          if (strlen(match_ptr) > loop->var_length) {
+            char end_char = match_ptr[ loop->var_length ];
+            if (isalnum( end_char )) 
+              break;
+          }
+        }
+          
+        /* OK - this is a valid match; update the string buffer. */
+        {
+          int write_offset = match_ptr - data;
+          int shift_offset = write_offset + loop->var_length;
+          
+          replace_1var( var_expansion , shift , write_offset , shift_offset , value );
+          search_offset = write_offset + loop->var_length;
+        }
+      }
+    }
+  }
+}
+
+
+int template_eval_loop( const template_type * template , buffer_type * buffer , int global_offset , loop_type * loop) {
+  int flags = 0;
+  int NMATCH = 3;
+  regmatch_t match_list_loop[NMATCH];
+  regmatch_t match_list_end[NMATCH];
+  int search_offset = loop->opentag_offset + loop->opentag_length;
+  {
+    int end_match , loop_match;
+    {
+      char * search_data = buffer_get_data( buffer );  // This pointer must be refetched because the buffer can realloc and move it.
+      loop_match  = regexec( &template->start_regexp , &search_data[search_offset] , NMATCH , match_list_loop , flags );
+      end_match   = regexec( &template->end_regexp   , &search_data[search_offset] , NMATCH , match_list_end , flags );
+    }
+
+    if (end_match == REG_NOMATCH)
+      return -1; // This for loop does not have a matching {% endfor %}
+
+    if (loop_match == 0) {
+      if (match_list_loop[0].rm_so < match_list_end[0].rm_so) {
+        // This is a nested sub loop - evaluate that recursively.
+        char * search_data = buffer_get_data( buffer );
+        loop_type * sub_loop = loop_alloc( search_data , search_offset , match_list_loop[0] , match_list_loop[1] , match_list_loop[2]);
+        global_offset = template_eval_loop( template , buffer , global_offset , sub_loop );
+      }
+    } 
+
+    /*****************************************************************/
+    /* We have completed the sub loops; the buffer has (possibly)
+       changed so we must search for the end again - to get the right
+       offset. */
+    {
+      char * search_data = buffer_get_data( buffer );
+      search_offset = global_offset;
+      end_match   = regexec( &template->end_regexp   , &search_data[search_offset] , NMATCH , match_list_end , flags );
+      if (end_match == REG_NOMATCH)
+        util_exit("Fatal error - have lost a {% endfor %} marker \n");
+    }
+    
+    /* This loop is the inner loop - expand it. */
+    loop_set_endmatch( loop , search_offset , match_list_end[0]);
+    {
+      buffer_type * loop_expansion = buffer_alloc( loop->body_length * stringlist_get_size( loop->items) );
+      {
+        char * src_data = buffer_get_data( buffer );
+        char * body = util_alloc_substring_copy( src_data , loop->body_offset , loop->body_length );
+        buffer_type * var_expansion = buffer_alloc( 0 );
+        int ivar;
+        
+        for (ivar =0; ivar < stringlist_get_size( loop->items ); ivar++) {
+          loop_eval(loop , body , var_expansion , ivar );
+          buffer_strcat( loop_expansion , buffer_get_data( var_expansion ));
+        }
+        
+        buffer_free( var_expansion );
+        util_safe_free( body );
+      }
+      {
+        int tag_length = loop->endtag_offset + loop->endtag_length - loop->opentag_offset;
+        int offset = loop->endtag_offset + loop->endtag_length;
+        int shift = buffer_get_string_size( loop_expansion ) - tag_length;
+        
+        buffer_memshift( buffer , offset , shift );
+        buffer_fseek( buffer , loop->opentag_offset , SEEK_SET );
+        buffer_fwrite( buffer , buffer_get_data( loop_expansion ) , 1 , buffer_get_string_size( loop_expansion ));
+        
+        global_offset = loop->opentag_offset + buffer_get_string_size( loop_expansion );
+      }
+      buffer_free( loop_expansion );
+    }
+    loop_free( loop );
+  }
+  return global_offset;
+}
+
+
+
+
+void template_init_loop_regexp( template_type * template ) {
+  regcompile( &template->start_regexp , LOOP_REGEXP , LOOP_OPTIONS );
+  regcompile( &template->end_regexp , END_REGEXP , END_OPTIONS );
+}
+
+
+void template_eval_loops( const template_type * template , buffer_type * buffer ) {
+  int NMATCH = 10;
+  regmatch_t match_list[NMATCH];
+  {
+    int global_offset = 0;
+    while( true ) {
+      char * src_data = buffer_get_data( buffer );
+      int match = regexec(&template->start_regexp , &src_data[global_offset] , NMATCH , match_list , 0);
+      if (match == 0) {
+        loop_type * loop = loop_alloc( src_data , global_offset , match_list[0] , match_list[1] , match_list[2]);
+        global_offset = template_eval_loop( template , buffer , global_offset , loop );
+        if (global_offset < 0) {
+          fprintf(stderr,"** Warning ** : found {%% for .... %%} loop construct without mathcing {%% endfor %%}\n");
+          break;
+        }
+      } else if (match == REG_NOMATCH) 
+        break;
+    }
+  }
+}

--- a/libres_util/tests/ert_util_block_fs.c
+++ b/libres_util/tests/ert_util_block_fs.c
@@ -1,0 +1,109 @@
+/*                
+   Copyright (C) 2014  Statoil ASA, Norway. 
+   
+   The file 'ert_util_block_fs.c' is part of ERT - Ensemble based Reservoir Tool. 
+    
+   ERT is free software: you can redistribute it and/or modify 
+   it under the terms of the GNU General Public License as published by 
+   the Free Software Foundation, either version 3 of the License, or 
+   (at your option) any later version. 
+    
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+   FITNESS FOR A PARTICULAR PURPOSE.   
+    
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+   for more details. 
+*/
+#include <stdlib.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+
+#include <ert/util/test_util.h>
+#include <ert/util/test_work_area.h>
+#include <ert/res_util/block_fs.h>
+
+void test_assert_util_abort(const char * function_name , void call_func (void *) , void * arg);
+
+
+void violating_fwrite( void * arg ) {
+  block_fs_type * bfs = block_fs_safe_cast( arg );
+  block_fs_fwrite_file( bfs , "name" , NULL , 100 );
+}
+
+
+void test_readonly( ) {
+  test_work_area_type * work_area = test_work_area_alloc("block_fs/read_only");
+  block_fs_type * bfs = block_fs_mount( "test.mnt" , 1000 , 10000 , 0.67 , 10 , true , true , false );
+  test_assert_true( block_fs_is_readonly( bfs ));
+  test_assert_util_abort("block_fs_aquire_wlock" , violating_fwrite , bfs );
+  block_fs_close(bfs , true);
+  test_work_area_free( work_area );
+}
+
+
+void createFS1() {
+  pid_t pid = fork();
+
+  if (pid == 0) {
+    block_fs_type * bfs = block_fs_mount( "test.mnt" , 1000 , 10000 , 0.67 , 10 , true , false , true );
+    test_assert_false( block_fs_is_readonly( bfs ) );
+    test_assert_true( util_file_exists("test.lock_0"));
+    {
+      int total_sleep = 0;
+      while (true) {
+        if (util_file_exists( "stop")) {
+          unlink("stop");
+          break;
+        }
+        
+        usleep(1000);
+        total_sleep += 1000;
+        if (total_sleep > 1000000 * 5) {
+          fprintf(stderr,"Test failure - never receieved \"stop\" file from parent process \n");
+          break;
+        }
+      }
+    }
+    block_fs_close( bfs , false );
+    exit(0);
+  } 
+  usleep(10000);
+}
+
+
+
+void test_lock_conflict() {
+  test_work_area_type * work_area = test_work_area_alloc("block_fs/lock_conflict");
+  createFS1();
+  while (true) {
+    if (util_file_exists("test.lock_0"))
+      break;
+  }
+  
+  {
+    block_fs_type * bfs = block_fs_mount( "test.mnt" , 1000 , 10000 , 0.67 , 10 , true , false , true );
+    test_assert_true( block_fs_is_readonly( bfs ) );
+  }
+  {
+    FILE * stream = util_fopen("stop" , "w");
+    fclose( stream );
+  }
+  
+  while (util_file_exists( "stop")) {
+    usleep( 1000 );
+  }      
+
+  test_work_area_free( work_area );
+}
+
+
+
+
+int main(int argc , char ** argv) {
+  test_readonly();
+  test_lock_conflict();
+  exit(0);
+}

--- a/libres_util/tests/ert_util_subst_list.c
+++ b/libres_util/tests/ert_util_subst_list.c
@@ -1,0 +1,97 @@
+/*
+   Copyright (C) 2015  Statoil ASA, Norway.
+
+   The file 'ert_util_subst_list.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <ert/util/test_work_area.h>
+#include <ert/util/test_util.h>
+#include <ert/res_util/subst_list.h>
+
+
+void test_create() {
+  subst_list_type * subst_list = subst_list_alloc( NULL );
+  test_assert_true( subst_list_is_instance( subst_list ) );
+  subst_list_free( subst_list );
+}
+
+
+void test_filter_file1() {
+  subst_list_type * subst_list = subst_list_alloc( NULL );
+  test_work_area_type * work_area = test_work_area_alloc("subst_list/filter1");
+  {
+    FILE * stream = util_fopen("template" , "w");
+    fprintf(stream , "<KEY1>\n<KEY2>\n<KEY3>\n<KEY4>\n");
+    fclose(stream);
+  }
+  subst_list_append_copy( subst_list , "<KEY1>" , "Value1" , NULL);
+  subst_list_append_copy( subst_list , "<KEY2>" , "Value2" , NULL);
+  subst_list_append_copy( subst_list , "<KEY3>" , "Value3" , NULL);
+  subst_list_append_copy( subst_list , "<KEY4>" , "Value4" , NULL);
+
+  subst_list_filter_file( subst_list , "template" , "target");
+
+  {
+    FILE * stream = util_fopen("target" , "r");
+    char s1[128],s2[128],s3[128],s4[128];
+
+    test_assert_int_equal( 4 , fscanf( stream , "%s %s %s %s" , s1,s2,s3,s4));
+    fclose(stream);
+
+    test_assert_string_equal( s1 , "Value1");
+    test_assert_string_equal( s2 , "Value2");
+    test_assert_string_equal( s3 , "Value3");
+    test_assert_string_equal( s4 , "Value4");
+  }
+  test_work_area_free( work_area );
+  subst_list_free( subst_list );
+}
+
+
+void test_filter_file2() {
+  subst_list_type * subst_list = subst_list_alloc( NULL );
+  test_work_area_type * work_area = test_work_area_alloc("subst_list/filter2");
+  {
+    FILE * stream = util_fopen("template" , "w");
+    fprintf(stream , "MAGIC_PRINT  magic-list.txt  <ERTCASE>  __MAGIC__");
+    fclose(stream);
+  }
+
+  subst_list_append_copy( subst_list , "<QC_PATH>" , "QC" , NULL);
+  subst_list_append_copy( subst_list , "__MAGIC__" , "MagicAllTheWayToWorkFlow" , NULL);
+  subst_list_append_copy( subst_list , "<CASE>" , "SUPERcase" , NULL);
+  subst_list_append_copy( subst_list , "<ERTCASE>" , "default" , NULL);
+  subst_list_filter_file( subst_list , "template" , "target");
+
+  {
+    char * target_string = util_fread_alloc_file_content( "target" , NULL );
+    test_assert_string_equal( target_string , "MAGIC_PRINT  magic-list.txt  default  MagicAllTheWayToWorkFlow");
+    free( target_string );
+  }
+  test_work_area_free( work_area );
+  subst_list_free( subst_list );
+}
+
+
+
+
+int main(int argc , char ** argv) {
+  test_create();
+  test_filter_file1();
+  test_filter_file2();
+}

--- a/python/python/res/enkf/enkf_main.py
+++ b/python/python/res/enkf/enkf_main.py
@@ -17,7 +17,8 @@ import ctypes, warnings
 
 from os.path import isfile
 from cwrap import BaseCClass
-from ecl.util import SubstitutionList, Log
+from ecl.util import Log
+from res.util.substitution_list import SubstitutionList
 
 from res.enkf import (EnkfPrototype, EnkfObs, EnKFState, ENKF_LIB,
                       EnkfSimulationRunner, EnkfFsManager)

--- a/python/python/res/enkf/ert_workflow_list.py
+++ b/python/python/res/enkf/ert_workflow_list.py
@@ -1,6 +1,7 @@
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
-from ecl.util import StringList, SubstitutionList
+from ecl.util import StringList
+from res.util.substitution_list import SubstitutionList
 from res.job_queue import Workflow, WorkflowJob
 
 

--- a/python/python/res/job_queue/forward_model.py
+++ b/python/python/res/job_queue/forward_model.py
@@ -15,7 +15,8 @@
 #  for more details.
 from cwrap import BaseCClass
 from res.job_queue import ExtJob, QueuePrototype, ExtJoblist
-from ecl.util import StringList, SubstitutionList
+from ecl.util import StringList
+from res.util.substitution_list import SubstitutionList
 
 
 class ForwardModel(BaseCClass):

--- a/python/python/res/job_queue/workflow.py
+++ b/python/python/res/job_queue/workflow.py
@@ -2,7 +2,7 @@ import time
 from res.config import ConfigError
 from cwrap import BaseCClass
 from res.job_queue import QueuePrototype, WorkflowJoblist, WorkflowJob
-from ecl.util import SubstitutionList
+from res.util.substitution_list import SubstitutionList
 
 
 class Workflow(BaseCClass):

--- a/python/python/res/job_queue/workflow_runner.py
+++ b/python/python/res/job_queue/workflow_runner.py
@@ -1,6 +1,6 @@
 from threading import Thread
 from res.job_queue import Workflow
-from ecl.util.substitution_list import SubstitutionList
+from res.util.substitution_list import SubstitutionList
 
 
 class WorkflowRunner(object):

--- a/python/python/res/util/CMakeLists.txt
+++ b/python/python/res/util/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PYTHON_SOURCES
     __init__.py
     res_log.py
+    substitution_list.py
 )
 
 add_python_package("python.res.util"  ${PYTHON_INSTALL_PREFIX}/res/util "${PYTHON_SOURCES}" True)

--- a/python/python/res/util/substitution_list.py
+++ b/python/python/res/util/substitution_list.py
@@ -1,0 +1,84 @@
+from cwrap import BaseCClass
+from res.util import ResUtilPrototype
+
+
+class SubstitutionList(BaseCClass):
+    TYPE_NAME = "subst_list"
+
+    _alloc = ResUtilPrototype("void* subst_list_alloc(void*)" , bind = False)
+    _free = ResUtilPrototype("void subst_list_free(subst_list)")
+    _size = ResUtilPrototype("int subst_list_get_size(subst_list)")
+    _iget_key = ResUtilPrototype("char* subst_list_iget_key(subst_list, int)")
+    _iget_value = ResUtilPrototype("char* subst_list_iget_value(subst_list, int)")
+    _get_value = ResUtilPrototype("char* subst_list_get_value(subst_list, char*)")
+    _has_key = ResUtilPrototype("bool subst_list_has_key(subst_list, char*)")
+    _get_doc = ResUtilPrototype("char* subst_list_get_doc_string(subst_list, char*)")
+    _append_copy = ResUtilPrototype("void subst_list_append_copy(subst_list, char*, char*, char*)")
+
+
+    def __init__(self):
+        c_ptr = self._alloc(0)
+        super(SubstitutionList, self).__init__(c_ptr)
+
+    def __len__(self):
+        return self._size()
+
+    def addItem(self, key, value, doc_string=""):
+        self._append_copy(key, value, doc_string)
+
+
+    def keys(self):
+        key_list = []
+        for i in range(len(self)):
+            key_list.append( self._iget_key( i ))
+        return key_list
+
+
+    def __iter__(self):
+        index = 0
+        keys = self.keys( )
+        for index in range(len(self)):
+            key = keys[index]
+            yield (key , self[key], self.doc(key))
+
+    def __contains__(self, key):
+        if not isinstance(key, str):
+            return False
+        return self._has_key( key )
+
+    def __getitem__(self, key):
+        if key in self:
+            return self._get_value( key )
+        else:
+            raise KeyError("No such key:%s" % key)
+
+
+    def get(self, key, default=None):
+        return self[key] if key in self else default
+
+    def doc(self,key):
+        if key in self:
+            return self._get_doc( key )
+        else:
+            raise KeyError("No such key:%s" % key)
+
+
+    def indexForKey(self, key):
+        if not key in self:
+            raise KeyError("Key '%s' not in substitution list!" % key)
+
+        for index, key_val_doc in enumerate(self):
+            if key == key_val_doc[0]:
+                return index
+
+        return None  # Should never happen!
+
+    def free(self):
+        self._free()
+
+
+    def __repr__(self):
+        return self._create_repr('len=%d' % len(self))
+
+    def __str__(self):
+        return 'SubstitutionList{%s}' % ", ".join(map(str, self.keys()))

--- a/python/tests/res/enkf/test_run_context.py
+++ b/python/tests/res/enkf/test_run_context.py
@@ -1,4 +1,5 @@
-from ecl.util import BoolVector, PathFormat, SubstitutionList
+from ecl.util import BoolVector, PathFormat
+from res.util.substitution_list import SubstitutionList
 from ecl.test import ExtendedTestCase, TestAreaContext
 from res.enkf import ErtRunContext
 from res.enkf.enums import EnkfRunType

--- a/python/tests/res/enkf/test_runpath_list.py
+++ b/python/tests/res/enkf/test_runpath_list.py
@@ -5,7 +5,7 @@ from res.test import ErtTestContext
 from res.enkf import RunpathList, RunpathNode, ErtRunContext
 from res.enkf.enums import EnkfInitModeEnum,EnkfRunType
 from ecl.util import BoolVector
-from ecl.util import SubstitutionList
+from res.util.substitution_list import SubstitutionList
 
 class RunpathListTest(ExtendedTestCase):
 

--- a/python/tests/res/job_queue/test_forward_model_formatted_print.py
+++ b/python/tests/res/job_queue/test_forward_model_formatted_print.py
@@ -2,7 +2,8 @@ import os.path
 import json
 
 from ecl.test import TestAreaContext, ExtendedTestCase
-from ecl.util import SubstitutionList, Version
+from ecl.util import Version
+from res.util.substitution_list import SubstitutionList
 from res.job_queue.forward_model import ForwardModel
 from res.job_queue.ext_job import ExtJob
 from res.job_queue.ext_joblist import ExtJoblist

--- a/python/tests/res/job_queue/test_workflow.py
+++ b/python/tests/res/job_queue/test_workflow.py
@@ -1,6 +1,6 @@
 from res.job_queue import Workflow, WorkflowJoblist
 from ecl.test import ExtendedTestCase, TestAreaContext
-from ecl.util import SubstitutionList
+from res.util.substitution_list import SubstitutionList
 from .workflow_common import WorkflowCommon
 
 

--- a/python/tests/res/job_queue/test_workflow_runner.py
+++ b/python/tests/res/job_queue/test_workflow_runner.py
@@ -2,7 +2,7 @@ import os
 import time
 from res.job_queue import WorkflowJoblist, Workflow, WorkflowRunner
 from ecl.test import TestAreaContext, ExtendedTestCase
-from ecl.util.substitution_list import SubstitutionList
+from res.util.substitution_list import SubstitutionList
 from .workflow_common import WorkflowCommon
 
 

--- a/python/tests/res/util/CMakeLists.txt
+++ b/python/tests/res/util/CMakeLists.txt
@@ -1,8 +1,10 @@
 set(TEST_SOURCES
     __init__.py
     test_res_log.py
+    test_substitution_list.py
 )
 
 add_python_package("python.tests.res.util" ${PYTHON_INSTALL_PREFIX}/tests/res/util "${TEST_SOURCES}" False)
 
 addPythonTest(tests.res.util.test_res_log.ResLogTest)
+addPythonTest(tests.res.util.test_substitution_list.SubstitutionListTest)

--- a/python/tests/res/util/test_substitution_list.py
+++ b/python/tests/res/util/test_substitution_list.py
@@ -1,0 +1,41 @@
+from ecl.test import ExtendedTestCase
+from res.util.substitution_list import SubstitutionList
+
+
+class SubstitutionListTest(ExtendedTestCase):
+    def test_substitution_list(self):
+        subst_list = SubstitutionList()
+
+        subst_list.addItem("Key", "Value", "Doc String")
+
+        self.assertEqual(len(subst_list), 1)
+
+        with self.assertRaises(KeyError):
+            item = subst_list[2]
+
+        with self.assertRaises(KeyError):
+            item = subst_list["NoSuchKey"]
+
+        with self.assertRaises(KeyError):
+            item = subst_list.doc("NoSuchKey")
+
+        self.assertTrue("Key" in subst_list)
+        self.assertEqual(subst_list["Key"] , "Value")
+        self.assertEqual(subst_list.doc("Key") , "Doc String")
+
+        subst_list.addItem("Key2", "Value2", "Doc String2")
+        self.assertEqual(len(subst_list), 2)
+
+        keys = subst_list.keys( )
+        self.assertEqual(keys[0] , "Key")
+        self.assertEqual(keys[1] , "Key2")
+
+        self.assertIn('Key', str(subst_list))
+        self.assertIn('SubstitutionList', repr(subst_list))
+        self.assertIn('2', repr(subst_list))
+
+        self.assertEqual(1729, subst_list.get('nosuchkey', 1729))
+        self.assertIsNone(subst_list.get('nosuchkey'))
+        self.assertIsNone(subst_list.get(513))
+        for key in ('Key', 'Key2'):
+            self.assertEqual(subst_list[key], subst_list.get(key))


### PR DESCRIPTION
Files to be moved to libres
/lib/util/subst_list.c
/lib/util/block.c
/applications/block_fs

Headerfiles, tests and dependencies are also moved to libres
Updated referencmoved files in libres

**Task**
When splitting the ert repository into libecl and libres some files ended up in a slightly illogical place. The purpose of this task is to move files from the libecl repository to the libres repository. The files in question include:

/lib/util/subst_list.c
/lib/util/block.c
/applications/block_fs

**Approach**
The files in question, including header files and tests is added to the libres_util. Also some additional files that is dependent on the files in question is moved, this includes:

/util/template.c
/util/template_loop.c
template.h 

All files with dependencies to the moved files are updated

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#147
* Statoil/ert#51
