### PR TITLE
Config parser refactoring

### DIFF
--- a/python/python/res/config/config_parser.py
+++ b/python/python/res/config/config_parser.py
@@ -18,34 +18,41 @@ import sys
 import os.path
 import warnings
 
-from res.config import UnrecognizedEnum, ContentTypeEnum , ConfigContent, ConfigPrototype
 from cwrap import BaseCClass
+from res.config import UnrecognizedEnum
+from res.config import ContentTypeEnum, ConfigContent, ConfigPrototype
 
 
 class ConfigParser(BaseCClass):
     TYPE_NAME = "config_parser"
 
-    _alloc = ConfigPrototype("void* config_alloc( )", bind=False)
-    _add = ConfigPrototype("schema_item_ref config_add_schema_item( config_parser , char* , bool)")
-    _free = ConfigPrototype("void config_free( config_parser )")
-    _parse = ConfigPrototype("config_content_obj config_parse( config_parser , char* , char* , char* , char* , hash , config_unrecognized_enum , bool )")
-    _get_schema_item = ConfigPrototype("schema_item_ref config_get_schema_item( config_parser , char*)")
-    _has_schema_item = ConfigPrototype("bool config_has_schema_item( config_parser , char*)")
+    _alloc = ConfigPrototype("void* config_alloc()", bind=False)
+    _add   = ConfigPrototype("schema_item_ref config_add_schema_item(config_parser, char*, bool)")
+    _free  = ConfigPrototype("void config_free(config_parser)")
+    _parse = ConfigPrototype("config_content_obj config_parse(config_parser, char*, char*, char*, char*, hash, config_unrecognized_enum, bool)")
+    _size  = ConfigPrototype("int config_get_schema_size(config_parser)");
+    _get_schema_item = ConfigPrototype("schema_item_ref config_get_schema_item(config_parser, char*)")
+    _has_schema_item = ConfigPrototype("bool config_has_schema_item(config_parser, char*)")
+
 
     def __init__(self):
         c_ptr = self._alloc()
         super(ConfigParser, self).__init__(c_ptr)
 
 
-    def __contains__(self , keyword):
-        return self._has_schema_item( keyword )
+    def __contains__(self, keyword):
+        return self._has_schema_item(keyword)
 
+    def __len__(self):
+        return self._size()
 
-    def add(self, keyword, required=False , value_type = None):
-        item = self._add(keyword, required).setParent( self )
+    def __repr__(self):
+        return self._create_repr('size=%d' % len(self))
+
+    def add(self, keyword, required=False, value_type=None):
+        item = self._add(keyword, required).setParent(self)
         if value_type:
-            item.iset_type( 0 , value_type )
-
+            item.iset_type(0, value_type)
         return item
 
 
@@ -53,37 +60,45 @@ class ConfigParser(BaseCClass):
         warnings.warn('deprecated, use conf[kw]', DeprecationWarning)
         return self[keyword]
 
-    def __getitem__(self , keyword):
+    def __getitem__(self, keyword):
         if keyword in self:
             item = self._get_schema_item(keyword)
-            item.setParent( self )
+            item.setParent(self)
             return item
         else:
             raise KeyError("Config parser does not have item:%s" % keyword)
 
 
-    def parse(self, config_file, comment_string="--", include_kw="INCLUDE", define_kw="DEFINE",
-              pre_defined_kw_map=None, unrecognized=UnrecognizedEnum.CONFIG_UNRECOGNIZED_WARN, validate=True):
+    def parse(self,
+              config_file,
+              comment_string="--",
+              include_kw="INCLUDE",
+              define_kw="DEFINE",
+              pre_defined_kw_map=None,
+              unrecognized=UnrecognizedEnum.CONFIG_UNRECOGNIZED_WARN,
+              validate=True):
         """ @rtype: ConfigContent """
 
         assert isinstance(unrecognized, UnrecognizedEnum)
 
-
-        if os.path.exists(config_file):
-            config_content = self._parse(config_file, comment_string, include_kw, define_kw, pre_defined_kw_map, unrecognized, validate)
-            config_content.setParser( self )
-
-            if not config_content.isValid():
-                if validate:
-                    sys.stderr.write("Errors parsing:%s \n" % config_file)
-                    for count, error in enumerate(config_content.getErrors()):
-                        sys.stderr.write("  %02d:%s\n" % (count , error))
-
-                    raise ValueError("Parsing:%s failed" % config_file)
-
-            return config_content
-        else:
+        if not os.path.exists(config_file):
             raise IOError("File: %s does not exists" % config_file)
+        config_content = self._parse(config_file,
+                                     comment_string,
+                                     include_kw,
+                                     define_kw,
+                                     pre_defined_kw_map,
+                                     unrecognized,
+                                     validate)
+        config_content.setParser(self)
+
+        if validate and not config_content.isValid():
+            sys.stderr.write("Errors parsing:%s \n" % config_file)
+            for count, error in enumerate(config_content.getErrors()):
+                sys.stderr.write("  %02d:%s\n" % (count, error))
+            raise ValueError("Parsing:%s failed" % config_file)
+
+        return config_content
 
 
     def free(self):

--- a/python/python/res/config/config_parser.py
+++ b/python/python/res/config/config_parser.py
@@ -16,6 +16,7 @@
 
 import sys
 import os.path
+import warnings
 
 from res.config import UnrecognizedEnum, ContentTypeEnum , ConfigContent, ConfigPrototype
 from cwrap import BaseCClass
@@ -48,10 +49,15 @@ class ConfigParser(BaseCClass):
         return item
 
 
-    def getSchemaItem(self , keyword):
+    def getSchemaItem(self, keyword):
+        warnings.warn('deprecated, use conf[kw]', DeprecationWarning)
+        return self[keyword]
+
+    def __getitem__(self , keyword):
         if keyword in self:
             item = self._get_schema_item(keyword)
             item.setParent( self )
+            return item
         else:
             raise KeyError("Config parser does not have item:%s" % keyword)
 

--- a/python/tests/res/config/test_config.py
+++ b/python/tests/res/config/test_config.py
@@ -1,50 +1,48 @@
 #!/usr/bin/env python
-#  Copyright (C) 2012  Statoil ASA, Norway. 
-#   
+#  Copyright (C) 2012  Statoil ASA, Norway.
+#
 #  The file 'test_config.py' is part of ERT - Ensemble based Reservoir Tool.
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-#  for more details. 
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
 import os
-
-import res
-import ecl
-
-from res.config import (ContentTypeEnum, UnrecognizedEnum, SchemaItem,
-                        ContentItem, ContentNode, ConfigParser, ConfigContent,
-                        ConfigSettings)
 
 from cwrap import Prototype, clib
 from ecl.test import ExtendedTestCase, TestAreaContext
 
+from res import load as resload
+from res.config import UnrecognizedEnum, SchemaItem
+from res.config import ContentTypeEnum, ContentItem, ContentNode
+from res.config import ConfigContent, ConfigParser, ConfigSettings
+
 
 class TestConfigPrototype(Prototype):
-    lib = res.load("libconfig")
+    lib = resload("libconfig")
 
     def __init__(self, prototype, bind=False):
         super(TestConfigPrototype, self).__init__(TestConfigPrototype.lib, prototype, bind=bind)
 
 # Adding extra functions to the ConfigContent object for the ability
 # to test low level C functions which are not exposed in Python.
-_safe_iget      = TestConfigPrototype("char* config_content_safe_iget( config_content , char* , int , int)")
-_iget           = TestConfigPrototype("char* config_content_iget( config_content , char* , int , int)")
-_iget_as_int    = TestConfigPrototype("int config_content_iget_as_int( config_content , char* , int , int)")
-_iget_as_bool   = TestConfigPrototype("bool config_content_iget_as_bool( config_content , char* , int , int)")
-_iget_as_double = TestConfigPrototype("double config_content_iget_as_double( config_content , char* , int , int)")
-_get_occurences = TestConfigPrototype("int config_content_get_occurences( config_content , char* )")
+_safe_iget      = TestConfigPrototype("char* config_content_safe_iget(config_content, char*, int, int)")
+_iget           = TestConfigPrototype("char* config_content_iget(config_content, char*, int, int)")
+_iget_as_int    = TestConfigPrototype("int config_content_iget_as_int(config_content, char*, int, int)")
+_iget_as_bool   = TestConfigPrototype("bool config_content_iget_as_bool(config_content, char*, int, int)")
+_iget_as_double = TestConfigPrototype("double config_content_iget_as_double(config_content, char*, int, int)")
+_get_occurences = TestConfigPrototype("int config_content_get_occurences(config_content, char*)")
 
 
 class ConfigTest(ExtendedTestCase):
-    def setUp( self ):
+    def setUp(self):
         self.file_list = []
 
 
@@ -56,46 +54,51 @@ class ConfigTest(ExtendedTestCase):
 
     def test_item_types(self):
         with TestAreaContext("config/types") as test_area:
-            with open("config" , "w") as f:
+            with open("config", "w") as f:
                 f.write("TYPE_ITEM 10 3.14 TruE  String  file\n")
-                
+
             conf = ConfigParser()
+            self.assertEqual(0, len(conf))
             schema_item = conf.add("TYPE_ITEM", False)
-            schema_item.iset_type(0 , ContentTypeEnum.CONFIG_INT )
-            schema_item.iset_type(1 , ContentTypeEnum.CONFIG_FLOAT )
-            schema_item.iset_type(2 , ContentTypeEnum.CONFIG_BOOL )
-            schema_item.iset_type(3 , ContentTypeEnum.CONFIG_STRING )
-            schema_item.iset_type(4 , ContentTypeEnum.CONFIG_PATH )
-            self.assertNotIn( "TYPE_XX", conf )
-            self.assertIn( "TYPE_ITEM", conf )
-            
+            schema_item.iset_type(0, ContentTypeEnum.CONFIG_INT)
+            schema_item.iset_type(1, ContentTypeEnum.CONFIG_FLOAT)
+            schema_item.iset_type(2, ContentTypeEnum.CONFIG_BOOL)
+            schema_item.iset_type(3, ContentTypeEnum.CONFIG_STRING)
+            schema_item.iset_type(4, ContentTypeEnum.CONFIG_PATH)
+            self.assertEqual(1, len(conf))
+            self.assertNotIn("TYPE_XX", conf)
+            self.assertIn("TYPE_ITEM", conf)
+
             content = conf.parse("config")
             type_item = content["TYPE_ITEM"][0]
             int_value = type_item[0]
-            self.assertEqual( int_value , 10 )
-            self.assertEqual( type_item.igetString(0) , "10")
+            self.assertEqual(int_value, 10)
+            self.assertEqual(type_item.igetString(0), "10")
 
             float_value = type_item[1]
-            self.assertEqual( float_value , 3.14 )
-            self.assertEqual( type_item.igetString(1) , "3.14")
+            self.assertEqual(float_value, 3.14)
+            self.assertEqual(type_item.igetString(1), "3.14")
 
             bool_value = type_item[2]
-            self.assertEqual( bool_value , True)
-            self.assertEqual( type_item.igetString(2) , "TruE")
-            
+            self.assertEqual(bool_value, True)
+            self.assertEqual(type_item.igetString(2), "TruE")
+
             string_value = type_item[3]
-            self.assertEqual( string_value , "String")
-            self.assertEqual( type_item.igetString(3) , "String")
-            
+            self.assertEqual(string_value, "String")
+            self.assertEqual(type_item.igetString(3), "String")
+
             path_value = type_item[4]
-            self.assertEqual( path_value , "file")
-            self.assertEqual( type_item.igetString(4) , "file")
+            self.assertEqual(path_value, "file")
+            self.assertEqual(type_item.igetString(4), "file")
 
             # test __getitem__
             self.assertTrue(conf['TYPE_ITEM'])
             with self.assertRaises(KeyError):
                 _ = conf['TYPE_XX']
-            
+
+            self.assertIn('ConfigParser', repr(conf))
+            self.assertIn('size=1', repr(conf))
+
 
 
     def test_parse(self):
@@ -105,15 +108,15 @@ class ConfigTest(ExtendedTestCase):
         self.assertIsInstance(schema_item, SchemaItem)
         test_path = self.createTestPath("local/config/simple_config")
         content = conf.parse(test_path, unrecognized=UnrecognizedEnum.CONFIG_UNRECOGNIZED_IGNORE)
-        self.assertTrue( content.isValid() )
-        
-        
+        self.assertTrue(content.isValid())
+
+
         content_item = content["RSH_HOST"]
         self.assertIsInstance(content_item, ContentItem)
         self.assertEqual(len(content_item), 1)
         with self.assertRaises(TypeError):
             content_item["BJARNE"]
-        
+
         with self.assertRaises(IndexError):
             content_item[10]
 
@@ -129,11 +132,11 @@ class ConfigTest(ExtendedTestCase):
         self.assertEqual(len(content_item), 5)
         with self.assertRaises(IOError):
             conf.parse("DoesNotExits")
-            
+
 
     def test_parse_invalid(self):
         conf = ConfigParser()
-        conf.add("INT", value_type = ContentTypeEnum.CONFIG_INT )
+        conf.add("INT", value_type=ContentTypeEnum.CONFIG_INT)
         with TestAreaContext("config/parse2"):
             with open("config","w") as fileH:
                 fileH.write("INT xx\n")
@@ -141,38 +144,38 @@ class ConfigTest(ExtendedTestCase):
             with self.assertRaises(ValueError):
                 conf.parse("config")
 
-            content = conf.parse("config" , validate = False )
-            self.assertFalse( content.isValid() )
-            self.assertEqual( len(content.getErrors()) , 1 )
+            content = conf.parse("config", validate=False)
+            self.assertFalse(content.isValid())
+            self.assertEqual(len(content.getErrors()), 1)
 
 
     def test_parse_deprecated(self):
         conf = ConfigParser()
-        item = conf.add("INT", value_type = ContentTypeEnum.CONFIG_INT )
+        item = conf.add("INT", value_type=ContentTypeEnum.CONFIG_INT)
         msg = "ITEM INT IS DEPRECATED"
-        item.setDeprecated( msg )
+        item.setDeprecated(msg)
         with TestAreaContext("config/parse2"):
             with open("config","w") as fileH:
                 fileH.write("INT 100\n")
 
-            content = conf.parse("config"  )
-            self.assertTrue( content.isValid() )
+            content = conf.parse("config" )
+            self.assertTrue(content.isValid())
 
             warnings = content.getWarnings()
-            self.assertEqual( len(warnings) , 1 )
-            self.assertEqual( warnings[0] , msg )
+            self.assertEqual(len(warnings), 1)
+            self.assertEqual(warnings[0], msg)
 
 
     def test_parse_dotdot_relative(self):
         conf = ConfigParser()
         schema_item = conf.add("EXECUTABLE", False)
-        schema_item.iset_type(0 , ContentTypeEnum.CONFIG_PATH )
-        
-        
+        schema_item.iset_type(0, ContentTypeEnum.CONFIG_PATH)
+
+
         with TestAreaContext("config/parse_dotdot"):
             os.makedirs("cwd/jobs")
             os.makedirs("eclipse/bin")
-            script_path = os.path.join( os.getcwd() , "eclipse/bin/script.sh")
+            script_path = os.path.join(os.getcwd(), "eclipse/bin/script.sh")
             with open(script_path,"w") as f:
                 f.write("This is a test script")
 
@@ -184,44 +187,44 @@ class ConfigTest(ExtendedTestCase):
             content = conf.parse("../jobs/JOB")
             item = content["EXECUTABLE"]
             node = item[0]
-            self.assertEqual( script_path , node.getPath( ))
-            
+            self.assertEqual(script_path, node.getPath())
 
 
-            
-            
+
+
+
     def test_parser_content(self):
         conf = ConfigParser()
         conf.add("KEY2", False)
         schema_item = conf.add("KEY", False)
-        schema_item.iset_type(2 , ContentTypeEnum.CONFIG_INT )
-        schema_item.iset_type(3 , ContentTypeEnum.CONFIG_BOOL )
-        schema_item.iset_type(4 , ContentTypeEnum.CONFIG_FLOAT )
-        schema_item.iset_type(5 , ContentTypeEnum.CONFIG_PATH )
+        schema_item.iset_type(2, ContentTypeEnum.CONFIG_INT)
+        schema_item.iset_type(3, ContentTypeEnum.CONFIG_BOOL)
+        schema_item.iset_type(4, ContentTypeEnum.CONFIG_FLOAT)
+        schema_item.iset_type(5, ContentTypeEnum.CONFIG_PATH)
         schema_item = conf.add("NOT_IN_CONTENT", False)
-        
-        
+
+
         with TestAreaContext("config/parse2"):
             with open("config","w") as fileH:
                 fileH.write("KEY VALUE1 VALUE2 100  True  3.14  path/file.txt\n")
 
-            cwd0 = os.getcwd( )
+            cwd0 = os.getcwd()
             os.makedirs("tmp")
             os.chdir("tmp")
             content = conf.parse("../config")
-            self.assertTrue( content.isValid() )
-            self.assertTrue( "KEY" in content )
-            self.assertFalse( "NOKEY" in content )
+            self.assertTrue(content.isValid())
+            self.assertTrue("KEY" in content)
+            self.assertFalse("NOKEY" in content)
 
-            self.assertFalse( "NOT_IN_CONTENT" in content )
+            self.assertFalse("NOT_IN_CONTENT" in content)
             item = content["NOT_IN_CONTENT"]
-            self.assertEqual( len(item) , 0 )
-            
+            self.assertEqual(len(item), 0)
+
             with self.assertRaises(KeyError):
                 content["Nokey"]
-                
+
             item = content["KEY"]
-            self.assertEqual(len(item) , 1)
+            self.assertEqual(len(item), 1)
 
             line = item[0]
             with self.assertRaises(TypeError):
@@ -230,51 +233,51 @@ class ConfigTest(ExtendedTestCase):
             with self.assertRaises(TypeError):
                 line.getPath()
 
-                
-            rel_path = line.getPath(index = 5, absolute = False)
-            self.assertEqual( rel_path , "../path/file.txt" )
-            get = line[5]
-            self.assertEqual( get , "../path/file.txt")
-            abs_path = line.getPath(index = 5)
-            self.assertEqual( abs_path , os.path.join(cwd0 , "path/file.txt"))
-            
-            rel_path = line.getPath(index = 5, absolute = False , relative_start = "../")
-            self.assertEqual( rel_path , "path/file.txt" )
 
-            
+            rel_path = line.getPath(index=5, absolute=False)
+            self.assertEqual(rel_path, "../path/file.txt")
+            get = line[5]
+            self.assertEqual(get, "../path/file.txt")
+            abs_path = line.getPath(index=5)
+            self.assertEqual(abs_path, os.path.join(cwd0, "path/file.txt"))
+
+            rel_path = line.getPath(index=5, absolute=False, relative_start="../")
+            self.assertEqual(rel_path, "path/file.txt")
+
+
             with self.assertRaises(IndexError):
                 item[10]
 
             node = item[0]
-            self.assertEqual(len(node) , 6)
+            self.assertEqual(len(node), 6)
             with self.assertRaises(IndexError):
                 node[6]
-            
-            self.assertEqual( node[0] , "VALUE1" )
-            self.assertEqual( node[1] , "VALUE2" )
-            self.assertEqual( node[2] , 100 )
-            self.assertEqual( node[3] , True )
-            self.assertEqual( node[4] , 3.14)
 
-            self.assertEqual( content.getValue( "KEY" , 0 , 1 ) , "VALUE2" )
-            self.assertEqual( _iget( content , "KEY" , 0 , 1) , "VALUE2")
+            self.assertEqual(node[0], "VALUE1")
+            self.assertEqual(node[1], "VALUE2")
+            self.assertEqual(node[2], 100)
+            self.assertEqual(node[3], True)
+            self.assertEqual(node[4], 3.14)
 
-            self.assertEqual( content.getValue( "KEY" , 0 , 2 ) , 100 )
-            self.assertEqual( _iget_as_int( content , "KEY" , 0 , 2) , 100)
+            self.assertEqual(content.getValue("KEY", 0, 1), "VALUE2")
+            self.assertEqual(_iget(content, "KEY", 0, 1), "VALUE2")
 
-            self.assertEqual( content.getValue( "KEY" , 0 , 3 ) , True )
-            self.assertEqual( _iget_as_bool( content , "KEY" , 0 , 3) , True)
+            self.assertEqual(content.getValue("KEY", 0, 2), 100)
+            self.assertEqual(_iget_as_int(content, "KEY", 0, 2), 100)
 
-            self.assertEqual( content.getValue( "KEY" , 0 , 4 ) , 3.14 )
-            self.assertEqual( _iget_as_double( content , "KEY" , 0 , 4) , 3.14)
+            self.assertEqual(content.getValue("KEY", 0, 3), True)
+            self.assertEqual(_iget_as_bool(content, "KEY", 0, 3), True)
 
-            self.assertIsNone( _safe_iget( content , "KEY2" , 0 , 0))
+            self.assertEqual(content.getValue("KEY", 0, 4), 3.14)
+            self.assertEqual(_iget_as_double(content, "KEY", 0, 4), 3.14)
 
-            self.assertEqual(  _get_occurences( content , "KEY2" ) , 0)
-            self.assertEqual(  _get_occurences( content , "KEY" ) , 1)
-            self.assertEqual(  _get_occurences( content , "MISSING-KEY" ) , 0)
-            
-            
+            self.assertIsNone(_safe_iget(content, "KEY2", 0, 0))
+
+            self.assertEqual( _get_occurences(content, "KEY2"), 0)
+            self.assertEqual( _get_occurences(content, "KEY"), 1)
+            self.assertEqual( _get_occurences(content, "MISSING-KEY"), 0)
+
+
 
     def test_schema(self):
         schema_item = SchemaItem("TestItem")
@@ -284,33 +287,33 @@ class ConfigTest(ExtendedTestCase):
         self.assertEqual(schema_item.iget_type(0), ContentTypeEnum.CONFIG_INT)
         schema_item.set_argc_minmax(3, 6)
 
-        self.assertTrue( SchemaItem.validString( ContentTypeEnum.CONFIG_INT , "100") )
-        self.assertFalse( SchemaItem.validString( ContentTypeEnum.CONFIG_INT , "100.99") )
-        self.assertTrue( SchemaItem.validString( ContentTypeEnum.CONFIG_FLOAT , "100.99") )
-        self.assertFalse( SchemaItem.validString( ContentTypeEnum.CONFIG_FLOAT , "100.99X") )
-        self.assertTrue( SchemaItem.validString( ContentTypeEnum.CONFIG_STRING , "100.99XX") )
-        self.assertTrue( SchemaItem.validString( ContentTypeEnum.CONFIG_PATH , "100.99XX") )
-        
-        
+        self.assertTrue(SchemaItem.validString(ContentTypeEnum.CONFIG_INT, "100"))
+        self.assertFalse(SchemaItem.validString(ContentTypeEnum.CONFIG_INT, "100.99"))
+        self.assertTrue(SchemaItem.validString(ContentTypeEnum.CONFIG_FLOAT, "100.99"))
+        self.assertFalse(SchemaItem.validString(ContentTypeEnum.CONFIG_FLOAT, "100.99X"))
+        self.assertTrue(SchemaItem.validString(ContentTypeEnum.CONFIG_STRING, "100.99XX"))
+        self.assertTrue(SchemaItem.validString(ContentTypeEnum.CONFIG_PATH, "100.99XX"))
+
+
         del schema_item
 
 
-    
+
 
     def test_settings(self):
         cs = ConfigSettings("SETTINGS")
-        
+
         with self.assertRaises(TypeError):
-            cs.addSetting("SETTING1" , ContentTypeEnum.CONFIG_INT , 100.67)
-            
-        self.assertFalse( "SETTING1" in cs )
-        cs.addSetting("SETTING2" , ContentTypeEnum.CONFIG_INT , 100)
-        self.assertTrue( "SETTING2" in cs )
+            cs.addSetting("SETTING1", ContentTypeEnum.CONFIG_INT, 100.67)
+
+        self.assertFalse("SETTING1" in cs)
+        cs.addSetting("SETTING2", ContentTypeEnum.CONFIG_INT, 100)
+        self.assertTrue("SETTING2" in cs)
 
         with self.assertRaises(KeyError):
             value = cs["NO_SUCH_KEY"]
 
-        self.assertEqual( cs["SETTING2"] , 100 )
+        self.assertEqual(cs["SETTING2"], 100)
 
         with self.assertRaises(KeyError):
             cs["NO_SUCH_KEY"] = 100
@@ -318,40 +321,40 @@ class ConfigTest(ExtendedTestCase):
 
         parser = ConfigParser()
         cs = ConfigSettings("SETTINGS")
-        cs.addSetting("A" , ContentTypeEnum.CONFIG_INT , 1)
-        cs.addSetting("B" , ContentTypeEnum.CONFIG_INT , 1)
-        cs.addSetting("C" , ContentTypeEnum.CONFIG_INT , 1)
-        cs.initParser( parser )
+        cs.addSetting("A", ContentTypeEnum.CONFIG_INT, 1)
+        cs.addSetting("B", ContentTypeEnum.CONFIG_INT, 1)
+        cs.addSetting("C", ContentTypeEnum.CONFIG_INT, 1)
+        cs.initParser(parser)
 
-        
+
         with TestAreaContext("config/parse3"):
             with open("config","w") as fileH:
                 fileH.write("SETTINGS A 100\n")
                 fileH.write("SETTINGS B 200\n")
                 fileH.write("SETTINGS C 300\n")
 
-            content = parser.parse( "config" )
-        cs.apply( content )
-        self.assertEqual( cs["A"] , 100)
-        self.assertEqual( cs["B"] , 200)
-        self.assertEqual( cs["C"] , 300)
-            
+            content = parser.parse("config")
+        cs.apply(content)
+        self.assertEqual(cs["A"], 100)
+        self.assertEqual(cs["B"], 200)
+        self.assertEqual(cs["C"], 300)
+
         keys = cs.keys()
-        self.assertTrue("A" in keys )
-        self.assertTrue("B" in keys )
-        self.assertTrue("C" in keys )
-        self.assertEqual( len(keys) , 3 )
+        self.assertTrue("A" in keys)
+        self.assertTrue("B" in keys)
+        self.assertTrue("C" in keys)
+        self.assertEqual(len(keys), 3)
 
         cs = ConfigSettings("SETTINGS")
-        cs.addDoubleSetting("A" , 1.0)
-        self.assertEqual( ContentTypeEnum.CONFIG_FLOAT , cs.getType("A"))
-        
+        cs.addDoubleSetting("A", 1.0)
+        self.assertEqual(ContentTypeEnum.CONFIG_FLOAT, cs.getType("A"))
+
         cs = ConfigSettings("SETTINGS")
-        cs.addDoubleSetting("A" , 1.0)
-        cs.addIntSetting("B" , 1)
-        cs.addStringSetting("C" , "1")
-        cs.addBoolSetting("D" ,  True)
-        cs.initParser( parser )
+        cs.addDoubleSetting("A", 1.0)
+        cs.addIntSetting("B", 1)
+        cs.addStringSetting("C", "1")
+        cs.addBoolSetting("D",  True)
+        cs.initParser(parser)
 
         with TestAreaContext("config/parse4"):
             with open("config","w") as fileH:
@@ -360,15 +363,13 @@ class ConfigTest(ExtendedTestCase):
                 fileH.write("SETTINGS C 300\n")
                 fileH.write("SETTINGS D False\n")
 
-            content = parser.parse( "config" )
+            content = parser.parse("config")
 
-        cs.apply( content )
-        self.assertEqual( cs["A"] , 100.1)
-        self.assertEqual( cs["B"] , 200)
-        self.assertEqual( cs["C"] , "300")
-        self.assertEqual( cs["D"] , False)
+        cs.apply(content)
+        self.assertEqual(cs["A"], 100.1)
+        self.assertEqual(cs["B"], 200)
+        self.assertEqual(cs["C"], "300")
+        self.assertEqual(cs["D"], False)
 
         with self.assertRaises(Exception):
             cs["A"] = "Hei"
-
-

--- a/python/tests/res/config/test_config.py
+++ b/python/tests/res/config/test_config.py
@@ -66,8 +66,8 @@ class ConfigTest(ExtendedTestCase):
             schema_item.iset_type(2 , ContentTypeEnum.CONFIG_BOOL )
             schema_item.iset_type(3 , ContentTypeEnum.CONFIG_STRING )
             schema_item.iset_type(4 , ContentTypeEnum.CONFIG_PATH )
-            self.assertFalse( "TYPE_XX" in conf )
-            self.assertTrue( "TYPE_ITEM" in conf )
+            self.assertNotIn( "TYPE_XX", conf )
+            self.assertIn( "TYPE_ITEM", conf )
             
             content = conf.parse("config")
             type_item = content["TYPE_ITEM"][0]
@@ -91,7 +91,10 @@ class ConfigTest(ExtendedTestCase):
             self.assertEqual( path_value , "file")
             self.assertEqual( type_item.igetString(4) , "file")
 
-
+            # test __getitem__
+            self.assertTrue(conf['TYPE_ITEM'])
+            with self.assertRaises(KeyError):
+                _ = conf['TYPE_XX']
             
 
 


### PR DESCRIPTION
**Task**
Give `config_parser.py` some Pythonic love.


**Approach**
Add `__getitem__` and `__len__` and tests.   Fixes a broken (probably unused?) method `getSchemaItem` (it never returned anything).  Fixes whitespace.


**Pre un-WIP checklist**
- [X] Statoil tests pass locally
- [X] Have completed graphical integration test steps
