### PR TITLE
Ppu code

### DIFF
--- a/libjob_queue/CMakeLists.txt
+++ b/libjob_queue/CMakeLists.txt
@@ -141,6 +141,10 @@ target_link_libraries(job_queue_timeout_test job_queue)
 add_test(NAME job_queue_timeout_test
          COMMAND job_queue_timeout_test $<TARGET_FILE:job_queue_stress_task>)
 
+add_executable(job_lsf_test tests/job_lsf_test.c)
+target_link_libraries(job_lsf_test job_queue)
+add_test(NAME job_lsf_test COMMAND job_lsf_test)
+
 add_executable(job_queue_driver_test tests/job_queue_driver_test.c)
 target_link_libraries(job_queue_driver_test job_queue)
 add_test(NAME job_queue_driver_test COMMAND job_queue_driver_test)
@@ -198,9 +202,9 @@ endif()
 set(LSF_SERVER "" CACHE STRING  "List of LSF servers for testing")
 
 if (LSF_LIBRARY)
-   add_executable(job_lsf_test tests/job_lsf_test.c)
-   target_link_libraries(job_lsf_test job_queue util test_util)
-   add_test(NAME job_lsf_test COMMAND job_lsf_test)
+   add_executable(job_lsb_test tests/job_lsb_test.c)
+   target_link_libraries(job_lsb_test job_queue util test_util)
+   add_test(NAME job_lsb_test COMMAND job_lsb_test)
 
    add_executable(job_lsb tests/job_lsb.c)
    target_link_libraries(job_lsb job_queue util test_util)

--- a/libjob_queue/include/ert/job_queue/lsf_driver.h
+++ b/libjob_queue/include/ert/job_queue/lsf_driver.h
@@ -42,6 +42,7 @@ extern "C" {
 #define LSF_DEBUG_OUTPUT  "DEBUG_OUTPUT"
 #define LSF_SUBMIT_SLEEP  "SUBMIT_SLEEP"
 #define LSF_EXCLUDE_HOST  "EXCLUDE_HOST"
+#define LSF_PROJECT_CODE  "PROJECT_CODE"
 
 #define LOCAL_LSF_SERVER "LOCAL"
 #define NULL_LSF_SERVER  "NULL"
@@ -95,6 +96,7 @@ typedef struct lsf_job_struct    lsf_job_type;
   bool            lsf_driver_has_option( const void * __driver , const char * option_key);
   const  void   * lsf_driver_get_option( const void * __driver , const char * option_key);
   bool            lsf_driver_set_option( void * __driver , const char * option_key , const void * value);
+  bool            lsf_driver_has_project_code( const lsf_driver_type * driver );
   void            lsf_driver_init_option_list(stringlist_type * option_list);
   int             lsf_job_parse_bsub_stdout(const char * bsub_cmd, const char * stdout_file);
   char          * lsf_job_write_bjobs_to_file(const char * bjobs_cmd, lsf_driver_type * driver, const long jobid);

--- a/libjob_queue/tests/job_lsb_test.c
+++ b/libjob_queue/tests/job_lsb_test.c
@@ -1,0 +1,60 @@
+/*
+   Copyright (C) 2012  Statoil ASA, Norway.
+
+   The file 'job_lsb_test.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <ert/util/test_util.h>
+
+#include <ert/job_queue/lsf_job_stat.h>
+#include <ert/job_queue/lsf_driver.h>
+#include <ert/job_queue/lsb.h>
+
+
+void test_server(lsf_driver_type * driver , const char * server, lsf_submit_method_enum submit_method) {
+  lsf_driver_set_option(driver , LSF_SERVER , server );
+  test_assert_true( lsf_driver_get_submit_method( driver ) == submit_method );
+}
+
+
+
+/*
+  This test should ideally be run twice in two different environments;
+  with and without dlopen() access to the lsf libraries.
+*/
+
+int main( int argc , char ** argv) {
+  lsf_submit_method_enum submit_NULL;
+  lsb_type * lsb = lsb_alloc();
+  if (lsb_ready(lsb))
+    submit_NULL = LSF_SUBMIT_INTERNAL;
+  else
+    submit_NULL = LSF_SUBMIT_LOCAL_SHELL;
+
+
+  test_server( driver , NULL        , submit_NULL );
+  test_server( driver , "LoCaL"     , LSF_SUBMIT_LOCAL_SHELL );
+  test_server( driver , "LOCAL"     , LSF_SUBMIT_LOCAL_SHELL );
+  test_server( driver , "XLOCAL"    , LSF_SUBMIT_REMOTE_SHELL );
+  test_server( driver , NULL        , submit_NULL );
+  test_server( driver , "NULL"      , submit_NULL );
+  test_server( driver , "be-grid01" , LSF_SUBMIT_REMOTE_SHELL );
+  printf("Servers OK\n");
+
+  lsb_free( lsb );
+  exit(0);
+}

--- a/libjob_queue/tests/job_lsf_exclude_hosts_test.c
+++ b/libjob_queue/tests/job_lsf_exclude_hosts_test.c
@@ -82,9 +82,11 @@ void test_bjobs_parse_hosts() {
 }
 
 int main(int argc, char ** argv) {
-  lsf_driver_type * driver = lsf_driver_alloc();
-  test_submit(driver, argv[1]);
-  lsf_driver_free(driver);
+  {
+    lsf_driver_type * driver = lsf_driver_alloc();
+    test_submit(driver, argv[1]);
+    lsf_driver_free(driver);
+  }
   test_bjobs_parse_hosts();
   exit(0);
 }

--- a/libjob_queue/tests/job_lsf_remote_submit_test.c
+++ b/libjob_queue/tests/job_lsf_remote_submit_test.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2012  Statoil ASA, Norway. 
-    
-   The file 'job_lsf_submit_test.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2012  Statoil ASA, Norway.
+
+   The file 'job_lsf_submit_test.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -27,10 +27,10 @@
 
 
 void test_submit(lsf_driver_type * driver , const char * server , const char * bsub_cmd , const char * bjobs_cmd , const char * bkill_cmd , const char * cmd) {
-  
+
   test_assert_true( lsf_driver_set_option(driver , LSF_DEBUG_OUTPUT , "TRUE" ) );
   test_assert_true( lsf_driver_set_option(driver , LSF_SERVER , server ) );
-  
+
   if (bsub_cmd != NULL)
     test_assert_true( lsf_driver_set_option(driver , LSF_BSUB_CMD , server ));
 
@@ -39,17 +39,17 @@ void test_submit(lsf_driver_type * driver , const char * server , const char * b
 
   if (bkill_cmd != NULL)
     test_assert_true( lsf_driver_set_option(driver , LSF_BKILL_CMD , server ));
-  
+
   {
     char * run_path = util_alloc_cwd();
     lsf_job_type * job = lsf_driver_submit_job( driver , cmd , 1 , run_path , "NAME" , 0 , NULL );
     if (job) {
       {
         int lsf_status = lsf_driver_get_job_status_lsf( driver , job );
-        if (!((lsf_status == JOB_STAT_RUN) || (lsf_status == JOB_STAT_PEND))) 
+        if (!((lsf_status == JOB_STAT_RUN) || (lsf_status == JOB_STAT_PEND)))
           test_error_exit("Got lsf_status:%d expected: %d or %d \n",lsf_status , JOB_STAT_RUN , JOB_STAT_PEND);
       }
-      
+
       lsf_driver_kill_job( driver , job );
       lsf_driver_set_bjobs_refresh_interval( driver , 0 );
       sleep(2);
@@ -67,10 +67,10 @@ void test_submit(lsf_driver_type * driver , const char * server , const char * b
         if (lsf_status != JOB_STAT_EXIT)
           test_error_exit("Got lsf_status:%d expected: %d \n",lsf_status , JOB_STAT_EXIT );
       }
-    } else 
+    } else
       test_error_exit("lsf_driver_submit_job() returned NULL \n");
-    
-    
+
+
     free( run_path );
   }
 }
@@ -81,13 +81,13 @@ int main( int argc , char ** argv) {
   {
     int iarg;
     lsf_driver_type * driver = lsf_driver_alloc();
-    
+
     for (iarg = 2; iarg < argc; iarg++) {
       const char * server = argv[iarg];
       printf("Testing lsf server:%s \n",server);
       test_submit(driver , server , NULL , NULL , NULL , argv[1]);
     }
-    
+
     lsf_driver_free( driver );
   }
   exit(0);

--- a/libjob_queue/tests/job_lsf_test.c
+++ b/libjob_queue/tests/job_lsf_test.c
@@ -35,18 +35,21 @@ void test_status(int lsf_status , job_status_type job_status) {
   test_assert_true( lsf_driver_convert_status( lsf_status ) == job_status);
 }
 
-
-int main( int argc , char ** argv) {
+void test_options(void) {
   lsf_driver_type * driver = lsf_driver_alloc();
-
+  test_assert_false( lsf_driver_has_project_code( driver ));
   test_option( driver , LSF_BSUB_CMD    , "Xbsub");
   test_option( driver , LSF_BJOBS_CMD   , "Xbsub");
   test_option( driver , LSF_BKILL_CMD   , "Xbsub");
   test_option( driver , LSF_RSH_CMD     , "RSH");
   test_option( driver , LSF_LOGIN_SHELL , "shell");
   test_option( driver , LSF_BSUB_CMD    , "bsub");
+  test_option( driver , LSF_PROJECT_CODE    , "my-ppu");
+  test_assert_true( lsf_driver_has_project_code( driver ));
+  lsf_driver_free( driver );
+}
 
-
+void test_status_tr() {
   test_status( JOB_STAT_PEND   , JOB_QUEUE_PENDING );
   test_status( JOB_STAT_PSUSP  , JOB_QUEUE_RUNNING );
   test_status( JOB_STAT_USUSP  , JOB_QUEUE_RUNNING );
@@ -57,6 +60,13 @@ int main( int argc , char ** argv) {
   test_status( JOB_STAT_EXIT   , JOB_QUEUE_EXIT );
   test_status( JOB_STAT_UNKWN  , JOB_QUEUE_EXIT );
   test_status( 192             , JOB_QUEUE_DONE );
+}
+
+
+int main( int argc , char ** argv) {
+
+  test_options();
+  test_status_tr( );
 
   exit(0);
 }

--- a/libjob_queue/tests/job_lsf_test.c
+++ b/libjob_queue/tests/job_lsf_test.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2012  Statoil ASA, Norway. 
-    
-   The file 'job_lsf_test.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2012  Statoil ASA, Norway.
+
+   The file 'job_lsf_test.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -59,21 +59,21 @@ int main( int argc , char ** argv) {
   printf("Options OK\n");
 
   {
-    
+
     lsf_submit_method_enum submit_NULL;
     lsb_type * lsb = lsb_alloc();
     if (lsb_ready(lsb))
       submit_NULL = LSF_SUBMIT_INTERNAL;
     else
       submit_NULL = LSF_SUBMIT_LOCAL_SHELL;
-    
 
-    test_server( driver , NULL        , submit_NULL ); 
-    test_server( driver , "LoCaL"     , LSF_SUBMIT_LOCAL_SHELL ); 
-    test_server( driver , "LOCAL"     , LSF_SUBMIT_LOCAL_SHELL ); 
+
+    test_server( driver , NULL        , submit_NULL );
+    test_server( driver , "LoCaL"     , LSF_SUBMIT_LOCAL_SHELL );
+    test_server( driver , "LOCAL"     , LSF_SUBMIT_LOCAL_SHELL );
     test_server( driver , "XLOCAL"    , LSF_SUBMIT_REMOTE_SHELL );
-    test_server( driver , NULL        , submit_NULL ); 
-    test_server( driver , "NULL"      , submit_NULL ); 
+    test_server( driver , NULL        , submit_NULL );
+    test_server( driver , "NULL"      , submit_NULL );
     test_server( driver , "be-grid01" , LSF_SUBMIT_REMOTE_SHELL );
     printf("Servers OK\n");
 
@@ -88,7 +88,7 @@ int main( int argc , char ** argv) {
   test_status( JOB_STAT_DONE   , JOB_QUEUE_DONE );
   test_status( JOB_STAT_EXIT   , JOB_QUEUE_EXIT );
   test_status( JOB_STAT_UNKWN  , JOB_QUEUE_EXIT );
-  test_status( 192             , JOB_QUEUE_DONE ); 
+  test_status( 192             , JOB_QUEUE_DONE );
   printf("Status OK \n");
 
   exit(0);

--- a/libjob_queue/tests/job_lsf_test.c
+++ b/libjob_queue/tests/job_lsf_test.c
@@ -22,7 +22,6 @@
 
 #include <ert/job_queue/lsf_job_stat.h>
 #include <ert/job_queue/lsf_driver.h>
-#include <ert/job_queue/lsb.h>
 
 
 void test_option(lsf_driver_type * driver , const char * option , const char * value) {
@@ -31,21 +30,11 @@ void test_option(lsf_driver_type * driver , const char * option , const char * v
 }
 
 
-void test_server(lsf_driver_type * driver , const char * server, lsf_submit_method_enum submit_method) {
-  lsf_driver_set_option(driver , LSF_SERVER , server );
-  test_assert_true( lsf_driver_get_submit_method( driver ) == submit_method );
-}
-
 
 void test_status(int lsf_status , job_status_type job_status) {
   test_assert_true( lsf_driver_convert_status( lsf_status ) == job_status);
 }
 
-
-/*
-  This test should ideally be run twice in two different environments;
-  with and without dlopen() access to the lsf libraries.
-*/
 
 int main( int argc , char ** argv) {
   lsf_driver_type * driver = lsf_driver_alloc();
@@ -56,29 +45,8 @@ int main( int argc , char ** argv) {
   test_option( driver , LSF_RSH_CMD     , "RSH");
   test_option( driver , LSF_LOGIN_SHELL , "shell");
   test_option( driver , LSF_BSUB_CMD    , "bsub");
-  printf("Options OK\n");
-
-  {
-
-    lsf_submit_method_enum submit_NULL;
-    lsb_type * lsb = lsb_alloc();
-    if (lsb_ready(lsb))
-      submit_NULL = LSF_SUBMIT_INTERNAL;
-    else
-      submit_NULL = LSF_SUBMIT_LOCAL_SHELL;
 
 
-    test_server( driver , NULL        , submit_NULL );
-    test_server( driver , "LoCaL"     , LSF_SUBMIT_LOCAL_SHELL );
-    test_server( driver , "LOCAL"     , LSF_SUBMIT_LOCAL_SHELL );
-    test_server( driver , "XLOCAL"    , LSF_SUBMIT_REMOTE_SHELL );
-    test_server( driver , NULL        , submit_NULL );
-    test_server( driver , "NULL"      , submit_NULL );
-    test_server( driver , "be-grid01" , LSF_SUBMIT_REMOTE_SHELL );
-    printf("Servers OK\n");
-
-    lsb_free( lsb );
-  }
   test_status( JOB_STAT_PEND   , JOB_QUEUE_PENDING );
   test_status( JOB_STAT_PSUSP  , JOB_QUEUE_RUNNING );
   test_status( JOB_STAT_USUSP  , JOB_QUEUE_RUNNING );
@@ -89,7 +57,6 @@ int main( int argc , char ** argv) {
   test_status( JOB_STAT_EXIT   , JOB_QUEUE_EXIT );
   test_status( JOB_STAT_UNKWN  , JOB_QUEUE_EXIT );
   test_status( 192             , JOB_QUEUE_DONE );
-  printf("Status OK \n");
 
   exit(0);
 }

--- a/libjob_queue/tests/job_lsf_test.c
+++ b/libjob_queue/tests/job_lsf_test.c
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 
 #include <ert/util/test_util.h>
+#include <ert/util/util.h>
 
 #include <ert/job_queue/lsf_job_stat.h>
 #include <ert/job_queue/lsf_driver.h>
@@ -63,10 +64,36 @@ void test_status_tr() {
 }
 
 
+void test_cmd(void) {
+  const char * project_code = "XXX_PROJECT";
+  lsf_driver_type * driver = lsf_driver_alloc();
+  {
+    stringlist_type * cmd = lsf_driver_alloc_cmd( driver , "out" , "job", "/bin/echo" , 1 , 0 , NULL );
+    test_assert_false( lsf_driver_has_project_code( driver ));
+    test_assert_false( stringlist_contains( cmd , "-P" ));
+    stringlist_free( cmd );
+  }
+
+  lsf_driver_set_option( driver , LSF_PROJECT_CODE , project_code);
+  {
+    stringlist_type * cmd = lsf_driver_alloc_cmd( driver , "out" , "job", "/bin/echo" , 1 , 0 , NULL );
+    int P_index = stringlist_find_first( cmd , "-P" );
+    test_assert_true( lsf_driver_has_project_code( driver ));
+    test_assert_true( P_index >= 0 );
+    test_assert_string_equal( stringlist_iget( cmd , P_index + 1) , project_code );
+    stringlist_free( cmd );
+  }
+
+  lsf_driver_free(driver);
+}
+
+
 int main( int argc , char ** argv) {
+  util_install_signals();
 
   test_options();
   test_status_tr( );
+  test_cmd();
 
   exit(0);
 }


### PR DESCRIPTION
**Task**
We have been requested by GBS SUB to facilitate pay per use information. As a first step to support this we support passing the `-P $project_code` when submitting with lsf `bsub` command. When this PR is merged the user can add to her config file:
```
QUEUE_OPTION LSF PROJECT_CODE   xxx123
```
and then the lsf driver will add `-P xxx123` to the `bsub` argument list.



**Approach**
Fiddle with the lsf_driver.

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

