### PR TITLE
Res config from config_content

### DIFF
--- a/libconfig/include/ert/config/config_content.h
+++ b/libconfig/include/ert/config/config_content.h
@@ -67,6 +67,7 @@ typedef struct config_content_struct config_content_type;
   config_content_node_type * config_content_get_value_node( const config_content_type * content , const char * kw);
   void config_content_add_define( config_content_type * content , const char * key , const char * value );
   subst_list_type * config_content_get_define_list( config_content_type * content );
+  const subst_list_type * config_content_get_const_define_list(const config_content_type * content);
   const char * config_content_get_config_file( const config_content_type * content , bool abs_path );
   int config_content_get_size(const config_content_type * content);
   const config_content_node_type * config_content_iget_node( const config_content_type * content , int index);

--- a/libconfig/src/config_content.c
+++ b/libconfig/src/config_content.c
@@ -126,6 +126,9 @@ const stringlist_type * config_content_get_warnings( const config_content_type *
 
 
 void config_content_free( config_content_type * content ) {
+  if(!content)
+    return;
+
   stringlist_free( content->warnings );
   vector_free( content->nodes );
   vector_free( content->path_elm_stack );
@@ -376,6 +379,9 @@ subst_list_type * config_content_get_define_list( config_content_type * content 
   return content->define_list;
 }
 
+const subst_list_type * config_content_get_const_define_list(const config_content_type * content) {
+  return content->define_list;
+}
 
 /*****************************************************************/
 

--- a/libenkf/include/ert/enkf/analysis_config.h
+++ b/libenkf/include/ert/enkf/analysis_config.h
@@ -54,8 +54,9 @@ void                   analysis_config_load_all_external_modules_from_config ( a
 stringlist_type      * analysis_config_alloc_module_names( const analysis_config_type * config );
 const char           * analysis_config_get_log_path( const analysis_config_type * config );
 void                   analysis_config_init( analysis_config_type * analysis , const config_content_type * config);
-analysis_config_type * analysis_config_alloc(void);
+analysis_config_type * analysis_config_alloc_default(void);
 analysis_config_type * analysis_config_alloc_load(const char * user_config_file);
+analysis_config_type * analysis_config_alloc(const config_content_type * config_content);
 void                   analysis_config_free( analysis_config_type * );
 bool                   analysis_config_get_merge_observations(const analysis_config_type * );
 double                 analysis_config_get_alpha(const analysis_config_type * config);

--- a/libenkf/include/ert/enkf/config_keys.h
+++ b/libenkf/include/ert/enkf/config_keys.h
@@ -153,6 +153,8 @@ extern "C" {
 #define  PLOT_SETTING_KEY                  "PLOT_SETTINGS"
 #define  UPDATE_SETTING_KEY                "UPDATE_SETTINGS"
 
+#define  WORKING_DIRECTORY_KEY             "WORKING_DIRECTORY"
+
 #define CONFIG_BOOL_STRING( var ) (var) ? "TRUE" : "FALSE"
 
 

--- a/libenkf/include/ert/enkf/ecl_config.h
+++ b/libenkf/include/ert/enkf/ecl_config.h
@@ -102,8 +102,9 @@ extern "C" {
   void                  ecl_config_clear_static_kw( ecl_config_type * ecl_config );
   stringlist_type     * ecl_config_get_static_kw_list( const ecl_config_type * ecl_config );
   void                  ecl_config_fprintf_config( const ecl_config_type * ecl_config , FILE * stream );
-  ecl_config_type     * ecl_config_alloc( );
   ecl_config_type     * ecl_config_alloc_load(const char * user_config_file);
+  ecl_config_type     * ecl_config_alloc(const config_content_type * config_content);
+
   void                  ecl_config_add_config_items( config_parser_type * config );
   const char          * ecl_config_get_depth_unit( const ecl_config_type * ecl_config );
   const char          * ecl_config_get_pressure_unit( const ecl_config_type * ecl_config );

--- a/libenkf/include/ert/enkf/ensemble_config.h
+++ b/libenkf/include/ert/enkf/ensemble_config.h
@@ -80,8 +80,9 @@ typedef struct ensemble_config_struct ensemble_config_type;
   stringlist_type                * ensemble_config_alloc_keylist(const ensemble_config_type *);
   stringlist_type                * ensemble_config_alloc_keylist_from_var_type(const ensemble_config_type *  , int var_mask);
   stringlist_type                * ensemble_config_alloc_keylist_from_impl_type(const ensemble_config_type *, ert_impl_type);
-  ensemble_config_type           * ensemble_config_alloc( );
-  ensemble_config_type           * ensemble_config_alloc_load(const char * user_config_file, ecl_grid_type * grid, const ecl_sum_type * refcase);
+  ensemble_config_type           * ensemble_config_alloc_load(const char *, ecl_grid_type *, const ecl_sum_type *);
+  ensemble_config_type           * ensemble_config_alloc(const config_content_type *, ecl_grid_type *, const ecl_sum_type *);
+
   void                             ensemble_config_fprintf_config( ensemble_config_type * ensemble_config , FILE * stream );
   const summary_key_matcher_type * ensemble_config_get_summary_key_matcher(const ensemble_config_type * ensemble_config);
   int                      ensemble_config_get_size(const ensemble_config_type * ensemble_config );

--- a/libenkf/include/ert/enkf/ert_template.h
+++ b/libenkf/include/ert/enkf/ert_template.h
@@ -43,8 +43,8 @@ void                ert_template_free__(void * arg);
 void                ert_templates_clear( ert_templates_type * ert_templates );
 ert_template_type * ert_templates_get_template( ert_templates_type * ert_templates , const char * key);
 
-ert_templates_type * ert_templates_alloc(subst_list_type * parent_subst);
 ert_templates_type * ert_templates_alloc_load(subst_list_type * parent_subst, const char * config_file);
+ert_templates_type * ert_templates_alloc(subst_list_type *, const config_content_type *);
 void                 ert_templates_free( ert_templates_type * ert_templates );
 ert_template_type  * ert_templates_add_template( ert_templates_type * ert_templates , const char * key , const char * template_file , const char * target_file , const char * arg_string);
 void                 ert_templates_instansiate( ert_templates_type * ert_templates , const char * path , const subst_list_type * arg_list);

--- a/libenkf/include/ert/enkf/ert_workflow_list.h
+++ b/libenkf/include/ert/enkf/ert_workflow_list.h
@@ -40,9 +40,11 @@ extern "C" {
   workflow_type           *  ert_workflow_list_get_workflow(ert_workflow_list_type * workflow_list , const char * workflow_name );
   workflow_type           *  ert_workflow_list_add_workflow( ert_workflow_list_type * workflow_list , const char * workflow_file , const char * workflow_name);
   void                       ert_workflow_list_free( ert_workflow_list_type * workflow_list );
-  ert_workflow_list_type  *  ert_workflow_list_alloc( const subst_list_type * subst_list );
+  ert_workflow_list_type  *  ert_workflow_list_alloc_empty( const subst_list_type * subst_list );
   ert_workflow_list_type  *  ert_workflow_list_alloc_load_site_config(const subst_list_type *);
   ert_workflow_list_type  *  ert_workflow_list_alloc_load(const subst_list_type * context, const char * user_config_file);
+  ert_workflow_list_type  *  ert_workflow_list_alloc(const subst_list_type * context, const config_content_type * config_content);
+
   void                       ert_workflow_list_add_jobs_in_directory( ert_workflow_list_type * workflow_list , const char * path );
   void                       ert_workflow_list_add_job( ert_workflow_list_type * workflow_list , const char * job_name , const char * config_file );
   bool                       ert_workflow_list_has_job( const ert_workflow_list_type * workflow_list , const char * job_name);

--- a/libenkf/include/ert/enkf/hook_manager.h
+++ b/libenkf/include/ert/enkf/hook_manager.h
@@ -31,10 +31,9 @@ extern "C" {
 
   typedef struct hook_manager_struct hook_manager_type;
 
-  hook_manager_type   * hook_manager_alloc(ert_workflow_list_type * workflow_list);
-  hook_manager_type * hook_manager_alloc_load(
-        ert_workflow_list_type * workflow_list,
-        const char * user_config_file);
+  hook_manager_type   * hook_manager_alloc_default(ert_workflow_list_type * workflow_list);
+  hook_manager_type   * hook_manager_alloc_load(ert_workflow_list_type *, const char *);
+  hook_manager_type   * hook_manager_alloc(ert_workflow_list_type *, const config_content_type *);
 
   void                  hook_manager_free();
 

--- a/libenkf/include/ert/enkf/log_config.h
+++ b/libenkf/include/ert/enkf/log_config.h
@@ -19,6 +19,7 @@
 #ifndef ERT_LOG_CONFIG_H
 #define ERT_LOG_CONFIG_H
 
+#include <ert/config/config_content.h>
 #include <ert/util/log.h>
 
 
@@ -41,6 +42,7 @@
 typedef struct log_config_struct log_config_type;
 
 log_config_type * log_config_alloc_load(const char *);
+log_config_type * log_config_alloc(const config_content_type *);
 void              log_config_free(log_config_type *);
 
 const char *             log_config_get_log_file(const log_config_type *);

--- a/libenkf/include/ert/enkf/model_config.h
+++ b/libenkf/include/ert/enkf/model_config.h
@@ -86,8 +86,10 @@ extern "C" {
   history_source_type    model_config_get_history_source( const model_config_type * model_config );
   void                   model_config_set_refcase( model_config_type * model_config , const ecl_sum_type * refcase );
   void                   model_config_fprintf_config( const model_config_type * model_config , int ens_size ,FILE * stream );
-  model_config_type    * model_config_alloc();
-  model_config_type    * model_config_alloc_load(const char * user_config_file, const ext_joblist_type * joblist, int last_history_restart, const sched_file_type * sched_file, const ecl_sum_type * refcase);
+  model_config_type    * model_config_alloc_empty();
+  model_config_type    * model_config_alloc_load(const char*, const ext_joblist_type*, int, const sched_file_type*, const ecl_sum_type*);
+  model_config_type    * model_config_alloc(const config_content_type*, const ext_joblist_type *, int, const sched_file_type *, const ecl_sum_type*);
+
   bool                   model_config_select_history( model_config_type * model_config , history_source_type source_type, const sched_file_type * schede_file , const ecl_sum_type * refcase);
   void                   model_config_set_runpath(model_config_type * model_config , const char * fmt);
   void                   model_config_set_gen_kw_export_file( model_config_type * model_config, const char * file_name);

--- a/libenkf/include/ert/enkf/plot_settings.h
+++ b/libenkf/include/ert/enkf/plot_settings.h
@@ -23,6 +23,7 @@
 #include <ert/config/config_settings.h>
 
 config_settings_type * plot_settings_alloc_load(const char * config_file);
+config_settings_type * plot_settings_alloc(const config_content_type * config_content);
 
 void               plot_settings_init(config_settings_type * setting);
 void               plot_settings_add_config_items( config_parser_type * config );

--- a/libenkf/include/ert/enkf/queue_config.h
+++ b/libenkf/include/ert/enkf/queue_config.h
@@ -39,6 +39,7 @@ extern "C" {
 typedef struct queue_config_struct queue_config_type;
 
     queue_config_type * queue_config_alloc_load(const char * user_config_file);
+    queue_config_type * queue_config_alloc(const config_content_type * config_content);
     queue_config_type * queue_config_alloc_local_copy( queue_config_type * queue_config);
     void queue_config_free(queue_config_type * queue_config);
 

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -39,6 +39,7 @@
 typedef struct res_config_struct res_config_type;
 
 res_config_type * res_config_alloc_load(const char *);
+res_config_type * res_config_alloc(const config_content_type *);
 void              res_config_free(res_config_type *);
 
 const site_config_type       * res_config_get_site_config(const res_config_type *);

--- a/libenkf/include/ert/enkf/rng_config.h
+++ b/libenkf/include/ert/enkf/rng_config.h
@@ -31,15 +31,15 @@ extern "C" {
 typedef struct rng_config_struct rng_config_type;
 
   void              rng_config_fprintf_config( rng_config_type * rng_config , FILE * stream );
-  void              rng_config_init( rng_config_type * rng_config , config_content_type * config );
+  void              rng_config_init(rng_config_type * rng_config, const config_content_type * config);
   void              rng_config_set_type( rng_config_type * rng_config , rng_alg_type type);
   rng_alg_type      rng_config_get_type(const rng_config_type * rng_config );
   const char      * rng_config_get_seed_load_file( const rng_config_type * rng_config );
   void              rng_config_set_seed_load_file( rng_config_type * rng_config , const char * seed_load_file);
   const char      * rng_config_get_seed_store_file( const rng_config_type * rng_config );
   void              rng_config_set_seed_store_file( rng_config_type * rng_config , const char * seed_store_file);
-  rng_config_type * rng_config_alloc( );
   rng_config_type * rng_config_alloc_load_user_config(const char * user_config_file);
+  rng_config_type * rng_config_alloc(const config_content_type * config_content);
   void              rng_config_free( rng_config_type * rng);
   void              rng_config_add_config_items( config_parser_type * config );
   rng_type *        rng_config_alloc_init_rng( const rng_config_type * rng_config);

--- a/libenkf/include/ert/enkf/site_config.h
+++ b/libenkf/include/ert/enkf/site_config.h
@@ -99,6 +99,7 @@ typedef struct site_config_struct site_config_type;
   mode_t                   site_config_get_umask( const site_config_type * site_config );
 
   site_config_type       * site_config_alloc_load_user_config(const char *);
+  site_config_type       * site_config_alloc(const config_content_type * config_content);
 
   config_content_type    * site_config_alloc_content(config_parser_type*);
 

--- a/libenkf/include/ert/enkf/subst_config.h
+++ b/libenkf/include/ert/enkf/subst_config.h
@@ -22,6 +22,7 @@
 typedef struct subst_config_struct subst_config_type;
 
 subst_config_type * subst_config_alloc_load(const char * user_config_file, const char * working_dir);
+subst_config_type * subst_config_alloc(const config_content_type * user_config);
 void                subst_config_free(subst_config_type * subst_config);
 
 subst_func_pool_type * subst_config_get_subst_func_pool(subst_config_type * subst_type);

--- a/libenkf/src/analysis_config.c
+++ b/libenkf/src/analysis_config.c
@@ -589,7 +589,7 @@ void analysis_config_free(analysis_config_type * config) {
 
 
 
-analysis_config_type * analysis_config_alloc(void) {
+analysis_config_type * analysis_config_alloc_default(void) {
   analysis_config_type * config = util_malloc( sizeof * config );
   UTIL_TYPE_ID_INIT( config , ANALYSIS_CONFIG_TYPE_ID );
 
@@ -622,7 +622,7 @@ analysis_config_type * analysis_config_alloc(void) {
 }
 
 static analysis_config_type * analysis_config_alloc_load_site_config() {
-  analysis_config_type * analysis_config = analysis_config_alloc();
+  analysis_config_type * analysis_config = analysis_config_alloc_default();
 
   config_parser_type * config = config_alloc();
   config_content_type * content = site_config_alloc_content(config);
@@ -636,20 +636,29 @@ static analysis_config_type * analysis_config_alloc_load_site_config() {
 }
 
 analysis_config_type * analysis_config_alloc_load(const char * user_config_file) {
+  config_parser_type * config_parser = config_alloc();
+  config_content_type * config_content = NULL;
+  if(user_config_file)
+    config_content = model_config_alloc_content(user_config_file, config_parser);
+
+  analysis_config_type * analysis_config = analysis_config_alloc(config_content);
+
+  config_content_free(config_content);
+  config_free(config_parser);
+
+  return analysis_config;
+}
+
+analysis_config_type * analysis_config_alloc(const config_content_type * config_content) {
   analysis_config_type * analysis_config = analysis_config_alloc_load_site_config();
 
-  if(user_config_file) {
-    config_parser_type * config = config_alloc();
-    config_content_type * content = model_config_alloc_content(user_config_file, config);
-
+  if(config_content) {
     analysis_config_load_internal_modules(analysis_config);
-    analysis_config_init(analysis_config, content);
-
-    config_content_free(content);
-    config_free(config);
+    analysis_config_init(analysis_config, config_content);
   }
 
   return analysis_config;
+
 }
 /*****************************************************************/
 /*

--- a/libenkf/src/ecl_config.c
+++ b/libenkf/src/ecl_config.c
@@ -511,7 +511,7 @@ static void ecl_config_init_static_kw(ecl_config_type * ecl_config)
     [i]);
 }
 
-ecl_config_type * ecl_config_alloc()
+static ecl_config_type * ecl_config_alloc_empty(void)
 {
   ecl_config_type * ecl_config = util_malloc(sizeof *ecl_config);
 
@@ -541,17 +541,24 @@ ecl_config_type * ecl_config_alloc()
 }
 
 ecl_config_type * ecl_config_alloc_load(const char * user_config_file) {
-  ecl_config_type * ecl_config = ecl_config_alloc();
+  config_parser_type * config_parser = config_alloc();
+  config_content_type * config_content = NULL;
+  if(user_config_file)
+    config_content = model_config_alloc_content(user_config_file, config_parser);
 
-  if(user_config_file) {
-    config_parser_type * config = config_alloc();
-    config_content_type * content = model_config_alloc_content(user_config_file, config);
+  ecl_config_type * ecl_config = ecl_config_alloc(config_content);
 
-    ecl_config_init(ecl_config, content);
+  config_content_free(config_content);
+  config_free(config_parser);
 
-    config_content_free(content);
-    config_free(config);
-  }
+  return ecl_config;
+}
+
+ecl_config_type * ecl_config_alloc(const config_content_type * config_content) {
+  ecl_config_type * ecl_config = ecl_config_alloc_empty();
+
+  if(config_content)
+    ecl_config_init(ecl_config, config_content);
 
   return ecl_config;
 }

--- a/libenkf/src/ensemble_config.c
+++ b/libenkf/src/ensemble_config.c
@@ -137,7 +137,7 @@ const char * ensemble_config_get_gen_kw_format( const ensemble_config_type * ens
 }
 
 
-ensemble_config_type * ensemble_config_alloc( ) {
+static ensemble_config_type * ensemble_config_alloc_empty(void) {
   ensemble_config_type * ensemble_config = util_malloc(sizeof * ensemble_config );
 
   UTIL_TYPE_ID_INIT( ensemble_config , ENSEMBLE_CONFIG_TYPE_ID );
@@ -152,17 +152,28 @@ ensemble_config_type * ensemble_config_alloc( ) {
 }
 
 ensemble_config_type * ensemble_config_alloc_load(const char * user_config_file, ecl_grid_type * grid, const ecl_sum_type * refcase) {
-  ensemble_config_type * ensemble_config = ensemble_config_alloc();
+  config_parser_type * config_parser = config_alloc();
+  config_content_type * config_content = NULL;
+  if(user_config_file)
+    config_content = model_config_alloc_content(user_config_file, config_parser);
 
-  if(user_config_file) {
-    config_parser_type * config = config_alloc();
-    config_content_type * content = model_config_alloc_content(user_config_file, config);
+  ensemble_config_type * ensemble_config = ensemble_config_alloc(config_content, grid, refcase);
 
-    ensemble_config_init(ensemble_config, content, grid, refcase);
+  config_content_free(config_content);
+  config_free(config_parser);
 
-    config_content_free(content);
-    config_free(config);
-  }
+  return ensemble_config;
+}
+
+ensemble_config_type * ensemble_config_alloc(
+                            const config_content_type * config_content,
+                            ecl_grid_type * grid,
+                            const ecl_sum_type * refcase) {
+
+  ensemble_config_type * ensemble_config = ensemble_config_alloc_empty();
+
+  if(config_content)
+    ensemble_config_init(ensemble_config, config_content, grid, refcase);
 
   return ensemble_config;
 }

--- a/libenkf/src/ert_template.c
+++ b/libenkf/src/ert_template.c
@@ -135,7 +135,7 @@ static void ert_template_fprintf_config( const ert_template_type * template , FI
 /*****************************************************************/
 
 
-ert_templates_type * ert_templates_alloc( subst_list_type * parent_subst  ) {
+static ert_templates_type * ert_templates_alloc_default(subst_list_type * parent_subst) {
   ert_templates_type * templates = util_malloc( sizeof * templates );
   UTIL_TYPE_ID_INIT( templates , ERT_TEMPLATES_TYPE_ID );
   templates->templates       = hash_alloc();
@@ -146,17 +146,27 @@ ert_templates_type * ert_templates_alloc( subst_list_type * parent_subst  ) {
 ert_templates_type * ert_templates_alloc_load(subst_list_type * parent_subst,
         const char * config_file)
 {
-  ert_templates_type * templates = ert_templates_alloc(parent_subst);
+  config_parser_type * config_parser = config_alloc();
+  config_content_type * config_content = NULL;
 
-  if(config_file) {
-    config_parser_type * config = config_alloc();
-    config_content_type * content = model_config_alloc_content(config_file, config);
+  if(config_file)
+    config_content = model_config_alloc_content(config_file, config_parser);
 
-    ert_templates_init(templates, content);
+  ert_templates_type * templates = ert_templates_alloc(parent_subst, config_content);
 
-    config_content_free(content);
-    config_free(config);
-  }
+  config_content_free(config_content);
+  config_free(config_parser);
+
+  return templates;
+}
+
+ert_templates_type * ert_templates_alloc(subst_list_type * parent_subst,
+                                         const config_content_type * config_content) {
+
+  ert_templates_type * templates = ert_templates_alloc_default(parent_subst);
+
+  if(config_content)
+    ert_templates_init(templates, config_content);
 
   return templates;
 }

--- a/libenkf/src/hook_manager.c
+++ b/libenkf/src/hook_manager.c
@@ -53,7 +53,7 @@ struct hook_manager_struct {
 
 void hook_manager_set_runpath_list_file(hook_manager_type *, const char *, const char *);
 
-hook_manager_type * hook_manager_alloc( ert_workflow_list_type * workflow_list ) {
+hook_manager_type * hook_manager_alloc_default(ert_workflow_list_type * workflow_list) {
   hook_manager_type * hook_manager = util_malloc( sizeof * hook_manager );
   hook_manager->hook_workflow_list = vector_alloc_new();
 
@@ -71,17 +71,27 @@ hook_manager_type * hook_manager_alloc_load(
         ert_workflow_list_type * workflow_list,
         const char * user_config_file)
 {
-  hook_manager_type * hook_manager = hook_manager_alloc(workflow_list);
+  config_parser_type * config_parser = config_alloc();
+  config_content_type * config_content = NULL;
+  if(user_config_file)
+    config_content = model_config_alloc_content(user_config_file, config_parser);
 
-  if(user_config_file) {
-    config_parser_type * config = config_alloc();
-    config_content_type * content = model_config_alloc_content(user_config_file, config);
+  hook_manager_type * hook_manager = hook_manager_alloc(workflow_list, config_content);
 
-    hook_manager_init(hook_manager, content);
+  config_content_free(config_content);
+  config_free(config_parser);
 
-    config_content_free(content);
-    config_free(config);
-  }
+  return hook_manager;
+}
+
+hook_manager_type * hook_manager_alloc(
+                    ert_workflow_list_type * workflow_list,
+                    const config_content_type * config_content) {
+
+  hook_manager_type * hook_manager = hook_manager_alloc_default(workflow_list);
+
+  if(config_content)
+    hook_manager_init(hook_manager, config_content);
 
   return hook_manager;
 }

--- a/libenkf/src/log_config.c
+++ b/libenkf/src/log_config.c
@@ -45,17 +45,25 @@ static log_config_type * log_config_alloc_default() {
 
 
 log_config_type * log_config_alloc_load(const char * config_file) {
+  config_parser_type * config_parser = config_alloc();
+  config_content_type * config_content = NULL;
+  if(config_file)
+    config_content = model_config_alloc_content(config_file, config_parser);
+
+  log_config_type * log_config = log_config_alloc(config_content);
+
+  config_content_free(config_content);
+  config_free(config_parser);
+
+  return log_config;
+}
+
+
+log_config_type * log_config_alloc(const config_content_type * config_content) {
   log_config_type * log_config = log_config_alloc_default();
 
-  if(config_file) {
-    config_parser_type * config = config_alloc();
-    config_content_type * content = model_config_alloc_content(config_file, config);
-
-    log_config_init(log_config, content);
-
-    config_content_free(content);
-    config_free(config);
-  }
+  if(config_content)
+    log_config_init(log_config, config_content);
 
   return log_config;
 }

--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -308,7 +308,7 @@ void model_config_set_max_internal_submit( model_config_type * model_config , in
 
 UTIL_IS_INSTANCE_FUNCTION( model_config , MODEL_CONFIG_TYPE_ID)
 
-model_config_type * model_config_alloc() {
+model_config_type * model_config_alloc_empty() {
   model_config_type * model_config  = util_malloc(sizeof * model_config );
   /**
      There are essentially three levels of initialisation:
@@ -355,24 +355,43 @@ model_config_type * model_config_alloc_load(const char * user_config_file,
         const sched_file_type * sched_file,
         const ecl_sum_type * refcase)
 {
-  model_config_type * model_config = model_config_alloc();
+  config_parser_type * config_parser = config_alloc();
+  config_content_type * config_content = NULL;
+  if(user_config_file)
+    config_content = model_config_alloc_content(user_config_file, config_parser);
 
-  if(user_config_file) {
-    config_parser_type * config = config_alloc();
-    config_content_type * content = model_config_alloc_content(user_config_file, config);
+  model_config_type * model_config = model_config_alloc(
+                                            config_content,
+                                            joblist,
+                                            last_history_restart,
+                                            sched_file,
+                                            refcase
+                                            );
 
+  config_content_free(config_content);
+  config_free(config_parser);
+
+  return model_config;
+}
+
+model_config_type * model_config_alloc(
+        const config_content_type * config_content,
+        const ext_joblist_type * joblist,
+        int last_history_restart,
+        const sched_file_type * sched_file,
+        const ecl_sum_type * refcase)
+{
+  model_config_type * model_config = model_config_alloc_empty();
+
+  if(config_content)
     model_config_init(model_config,
-                      content,
+                      config_content,
                       0,
                       joblist,
                       last_history_restart,
                       sched_file,
                       refcase
                       );
-
-    config_content_free(content);
-    config_free(config);
-  }
 
   return model_config;
 }

--- a/libenkf/src/plot_settings.c
+++ b/libenkf/src/plot_settings.c
@@ -42,40 +42,49 @@
 #define DEFAULT_SHOW_HISTORY     FALSE_STRING
 
 config_settings_type * plot_settings_alloc_load(const char * config_file) {
+  config_parser_type * config_parser = config_alloc();
+  config_content_type * config_content = NULL;
+  if(config_file)
+    config_content = model_config_alloc_content(config_file, config_parser);
+
+  config_settings_type * plot_config = plot_settings_alloc(config_content);
+
+  config_content_free(config_content);
+  config_free(config_parser);
+
+  return plot_config;
+}
+
+config_settings_type * plot_settings_alloc(const config_content_type * config_content) {
   config_settings_type * plot_config = config_settings_alloc(PLOT_SETTING_KEY);
   plot_settings_init(plot_config);
 
-  if(config_file) {
-    config_parser_type * config = config_alloc();
-    config_content_type * content = model_config_alloc_content(config_file, config);
-
-    config_settings_apply(plot_config, content);
-
-    config_content_free(content);
-    config_free(config);
-  }
+  if(config_content)
+    config_settings_apply(plot_config, config_content);
 
   return plot_config;
 }
 
 void plot_settings_init(config_settings_type * settings) {
 
-  config_settings_add_setting(settings , PATH_KEY , CONFIG_STRING , DEFAULT_PLOT_PATH );
-  config_settings_add_setting(settings , SHOW_REFCASE_KEY , CONFIG_BOOL , DEFAULT_SHOW_REFCASE );
-  config_settings_add_setting(settings , SHOW_HISTORY_KEY , CONFIG_BOOL , DEFAULT_SHOW_HISTORY );
+  config_settings_add_setting(settings, PATH_KEY,         CONFIG_STRING, DEFAULT_PLOT_PATH);
+  config_settings_add_setting(settings, SHOW_REFCASE_KEY, CONFIG_BOOL,   DEFAULT_SHOW_REFCASE);
+  config_settings_add_setting(settings, SHOW_HISTORY_KEY, CONFIG_BOOL,   DEFAULT_SHOW_HISTORY);
 
 }
 
 
 void plot_settings_add_config_items( config_parser_type * config ) {
-  config_settings_init_parser__( PLOT_SETTING_KEY , config , false );
+  config_settings_init_parser__(PLOT_SETTING_KEY, config, false);
+  config_add_key_value(config, PLOT_PATH_KEY, false, CONFIG_STRING);
 
-  config_add_key_value(config , PLOT_PATH_KEY         , false , CONFIG_STRING);
-  {
-    char * msg = util_alloc_sprintf( "The keyword %s has been deprecated - use %s %s <PATH>", PLOT_PATH_KEY , PLOT_SETTING_KEY , PATH_KEY );
-    config_parser_deprecate( config , PLOT_PATH_KEY , msg);
-    free( msg );
-  }
+  char * msg = util_alloc_sprintf(
+                   "The keyword %s has been deprecated - use %s %s <PATH>",
+                   PLOT_PATH_KEY,
+                   PLOT_SETTING_KEY,
+                   PATH_KEY
+                   );
+
+  config_parser_deprecate(config, PLOT_PATH_KEY, msg);
+  free(msg);
 }
-
-

--- a/libenkf/src/queue_config.c
+++ b/libenkf/src/queue_config.c
@@ -62,7 +62,7 @@ static queue_config_type * queue_config_alloc_empty() {
     return queue_config;
 }
 
-static queue_config_type * queue_config_alloc() {
+static queue_config_type * queue_config_alloc_default() {
   queue_config_type * queue_config = queue_config_alloc_empty();
 
   config_parser_type * config = config_alloc();
@@ -77,21 +77,25 @@ static queue_config_type * queue_config_alloc() {
 }
 
 queue_config_type * queue_config_alloc_load(const char * user_config_file) {
-  queue_config_type * queue_config = queue_config_alloc();
+  config_parser_type * config = config_alloc();
+  config_content_type * content = NULL;
+  if(user_config_file)
+    content = model_config_alloc_content(user_config_file, config);
 
-  if(user_config_file) {
+  queue_config_type * queue_config = queue_config_alloc(content);
+
+  config_free(config);
+  config_content_free(content);
+
+  return queue_config;
+}
+
+queue_config_type * queue_config_alloc(const config_content_type * config_content) {
+  queue_config_type * queue_config = queue_config_alloc_default();
+
+  if(config_content) {
     queue_config->user_mode = true;
-
-    config_parser_type * config = config_alloc();
-    config_content_type * content = model_config_alloc_content(
-                                                    user_config_file,
-                                                    config
-                                                    );
-
-    queue_config_init(queue_config, content);
-
-    config_free(config);
-    config_content_free(content);
+    queue_config_init(queue_config, config_content);
   }
 
   return queue_config;

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -173,7 +173,7 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                     );
 
   res_config->plot_config     = plot_settings_alloc(config_content);
-  res_config->ecl_config      = ecl_config_alloc_load(res_config->user_config_file);
+  res_config->ecl_config      = ecl_config_alloc(config_content);
 
   res_config->ensemble_config = ensemble_config_alloc_load(res_config->user_config_file,
                                             ecl_config_get_grid(res_config->ecl_config),

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -154,8 +154,8 @@ res_config_type * res_config_alloc_load(const char * config_file) {
 
   res_config->subst_config    = subst_config_alloc(config_content);
   res_config->site_config     = site_config_alloc(config_content);
+  res_config->rng_config      = rng_config_alloc(config_content);
 
-  res_config->rng_config      = rng_config_alloc_load_user_config(res_config->user_config_file);
   res_config->analysis_config = analysis_config_alloc_load(res_config->user_config_file);
   res_config->workflow_list   = ert_workflow_list_alloc_load(
                                     subst_config_get_subst_list(res_config->subst_config),

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -175,7 +175,7 @@ res_config_type * res_config_alloc_load(const char * config_file) {
   res_config->plot_config     = plot_settings_alloc(config_content);
   res_config->ecl_config      = ecl_config_alloc(config_content);
 
-  res_config->ensemble_config = ensemble_config_alloc_load(res_config->user_config_file,
+  res_config->ensemble_config = ensemble_config_alloc(config_content,
                                             ecl_config_get_grid(res_config->ecl_config),
                                             ecl_config_get_refcase(res_config->ecl_config)
                                     );

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -155,8 +155,8 @@ res_config_type * res_config_alloc_load(const char * config_file) {
   res_config->subst_config    = subst_config_alloc(config_content);
   res_config->site_config     = site_config_alloc(config_content);
   res_config->rng_config      = rng_config_alloc(config_content);
+  res_config->analysis_config = analysis_config_alloc(config_content);
 
-  res_config->analysis_config = analysis_config_alloc_load(res_config->user_config_file);
   res_config->workflow_list   = ert_workflow_list_alloc_load(
                                     subst_config_get_subst_list(res_config->subst_config),
                                     res_config->user_config_file

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -157,9 +157,9 @@ res_config_type * res_config_alloc_load(const char * config_file) {
   res_config->rng_config      = rng_config_alloc(config_content);
   res_config->analysis_config = analysis_config_alloc(config_content);
 
-  res_config->workflow_list   = ert_workflow_list_alloc_load(
+  res_config->workflow_list   = ert_workflow_list_alloc(
                                     subst_config_get_subst_list(res_config->subst_config),
-                                    res_config->user_config_file
+                                    config_content
                                     );
 
   res_config->hook_manager    = hook_manager_alloc_load(

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -153,8 +153,8 @@ res_config_type * res_config_alloc_load(const char * config_file) {
   const config_content_type * config_content = content;
 
   res_config->subst_config    = subst_config_alloc(config_content);
+  res_config->site_config     = site_config_alloc(config_content);
 
-  res_config->site_config     = site_config_alloc_load_user_config(res_config->user_config_file);
   res_config->rng_config      = rng_config_alloc_load_user_config(res_config->user_config_file);
   res_config->analysis_config = analysis_config_alloc_load(res_config->user_config_file);
   res_config->workflow_list   = ert_workflow_list_alloc_load(

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -172,7 +172,7 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                     config_content
                                     );
 
-  res_config->plot_config     = plot_settings_alloc_load(res_config->user_config_file);
+  res_config->plot_config     = plot_settings_alloc(config_content);
   res_config->ecl_config      = ecl_config_alloc_load(res_config->user_config_file);
 
   res_config->ensemble_config = ensemble_config_alloc_load(res_config->user_config_file,

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -167,9 +167,9 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                     config_content
                                     );
 
-  res_config->templates       = ert_templates_alloc_load(
+  res_config->templates       = ert_templates_alloc(
                                     subst_config_get_subst_list(res_config->subst_config),
-                                    res_config->user_config_file
+                                    config_content
                                     );
 
   res_config->plot_config     = plot_settings_alloc_load(res_config->user_config_file);

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -180,7 +180,7 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                             ecl_config_get_refcase(res_config->ecl_config)
                                     );
 
-  res_config->model_config    = model_config_alloc_load(res_config->user_config_file,
+  res_config->model_config    = model_config_alloc(config_content,
                                         site_config_get_installed_jobs(res_config->site_config),
                                         ecl_config_get_last_history_restart(res_config->ecl_config),
                                         ecl_config_get_sched_file(res_config->ecl_config),

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -187,7 +187,7 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                         ecl_config_get_refcase(res_config->ecl_config)
                                    );
 
-  res_config->log_config      = log_config_alloc_load(res_config->user_config_file);
+  res_config->log_config      = log_config_alloc(config_content);
 
 
   config_free(config);

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -162,9 +162,9 @@ res_config_type * res_config_alloc_load(const char * config_file) {
                                     config_content
                                     );
 
-  res_config->hook_manager    = hook_manager_alloc_load(
+  res_config->hook_manager    = hook_manager_alloc(
                                     res_config->workflow_list,
-                                    res_config->user_config_file
+                                    config_content
                                     );
 
   res_config->templates       = ert_templates_alloc_load(

--- a/libenkf/src/rng_config.c
+++ b/libenkf/src/rng_config.c
@@ -65,7 +65,7 @@ void rng_config_set_seed_store_file( rng_config_type * rng_config , const char *
 }
 
 
-rng_config_type * rng_config_alloc( ) {
+static rng_config_type * rng_config_alloc_default(void) {
   rng_config_type * rng_config = util_malloc( sizeof * rng_config);
 
   rng_config_set_type( rng_config , MZRAN );  /* Only type ... */
@@ -76,17 +76,24 @@ rng_config_type * rng_config_alloc( ) {
 }
 
 rng_config_type * rng_config_alloc_load_user_config(const char * user_config_file) {
-  rng_config_type * rng_config = rng_config_alloc();
+  config_parser_type * config_parser = config_alloc();
+  config_content_type * config_content = NULL;
+  if(user_config_file)
+    config_content = model_config_alloc_content(user_config_file, config_parser);
 
-  if(user_config_file != NULL) {
-    config_parser_type * config = config_alloc();
-    config_content_type * content = model_config_alloc_content(user_config_file, config);
+  rng_config_type * rng_config = rng_config_alloc(config_content);
 
-    rng_config_init(rng_config, content);
+  config_content_free(config_content);
+  config_free(config_parser);
 
-    config_content_free(content);
-    config_free(config);
-  }
+  return rng_config;
+}
+
+rng_config_type * rng_config_alloc(const config_content_type * config_content) {
+  rng_config_type * rng_config = rng_config_alloc_default();
+
+  if(config_content)
+    rng_config_init(rng_config, config_content);
 
   return rng_config;
 }
@@ -153,12 +160,12 @@ void rng_config_add_config_items( config_parser_type * config ) {
 }
 
 
-void rng_config_init( rng_config_type * rng_config , config_content_type * config ) {
-  if (config_content_has_item( config , STORE_SEED_KEY ))
-    rng_config_set_seed_store_file( rng_config , config_content_iget(config , STORE_SEED_KEY ,0,0));
+void rng_config_init(rng_config_type * rng_config, const config_content_type * config_content) {
+  if(config_content_has_item(config_content, STORE_SEED_KEY))
+    rng_config_set_seed_store_file(rng_config, config_content_iget(config_content, STORE_SEED_KEY, 0, 0));
 
-  if (config_content_has_item( config , LOAD_SEED_KEY ))
-    rng_config_set_seed_load_file( rng_config , config_content_iget(config , LOAD_SEED_KEY ,0,0));
+  if(config_content_has_item(config_content, LOAD_SEED_KEY))
+    rng_config_set_seed_load_file(rng_config, config_content_iget(config_content, LOAD_SEED_KEY,0 ,0));
 }
 
 

--- a/libenkf/src/site_config.c
+++ b/libenkf/src/site_config.c
@@ -195,7 +195,7 @@ static void site_config_load_config(site_config_type * site_config) {
 /*
  * NOTE: The queue config is not loaded until the site_config_alloc_load_user.
  */
-static site_config_type * site_config_alloc() {
+static site_config_type * site_config_alloc_default() {
   site_config_type * site_config = site_config_alloc_empty();
   site_config_set_config_file(site_config, site_config_get_location());
   site_config_load_config(site_config);
@@ -204,22 +204,27 @@ static site_config_type * site_config_alloc() {
 }
 
 site_config_type * site_config_alloc_load_user_config(const char * user_config_file) {
-  site_config_type * site_config = site_config_alloc();
-  site_config->queue_config = queue_config_alloc_load(user_config_file);
+  config_parser_type * config_parser = config_alloc();
+  config_content_type * config_content = NULL;
 
-  if(user_config_file) {
+  if(user_config_file)
+    config_content = model_config_alloc_content(user_config_file, config_parser);
+
+  site_config_type * site_config = site_config_alloc(config_content);
+
+  config_free(config_parser);
+  config_content_free(config_content);
+
+  return site_config;
+}
+
+site_config_type * site_config_alloc(const config_content_type * config_content) {
+  site_config_type * site_config = site_config_alloc_default();
+  site_config->queue_config = queue_config_alloc(config_content);
+
+  if(config_content) {
     site_config->user_mode = true;
-
-    config_parser_type * config = config_alloc();
-    config_content_type * content = model_config_alloc_content(
-                                                    user_config_file,
-                                                    config
-                                                    );
-
-    site_config_init(site_config, content);
-
-    config_content_free(content);
-    config_free(config);
+    site_config_init(site_config, config_content);
   }
 
   return site_config;

--- a/libenkf/tests/enkf_analysis_config.c
+++ b/libenkf/tests/enkf_analysis_config.c
@@ -33,7 +33,7 @@
 
 
 analysis_config_type * create_analysis_config() {
-  analysis_config_type * ac = analysis_config_alloc();
+  analysis_config_type * ac = analysis_config_alloc_default();
   return ac;
 }
 

--- a/libenkf/tests/enkf_analysis_config_ext_module.c
+++ b/libenkf/tests/enkf_analysis_config_ext_module.c
@@ -47,7 +47,7 @@ void test_load_external_module( analysis_config_type * ac , const char * user_na
 
 
 int main(int argc , char ** argv) {
-  analysis_config_type * analysis_config = analysis_config_alloc();
+  analysis_config_type * analysis_config = analysis_config_alloc_default();
 
   for (int i = 1; i < argc; i+= 2) {
     const char * user_name = argv[i];

--- a/libenkf/tests/enkf_ecl_config.c
+++ b/libenkf/tests/enkf_ecl_config.c
@@ -26,7 +26,7 @@
 #include <ert/enkf/ecl_refcase_list.h>
 
 int main(int argc , char ** argv) {
-  ecl_config_type * ecl_config = ecl_config_alloc();
+  ecl_config_type * ecl_config = ecl_config_alloc(NULL);
 
   if (argc == 2) {
     test_assert_true(ecl_config_load_refcase( ecl_config , argv[1]));

--- a/libenkf/tests/enkf_ecl_config_config.c
+++ b/libenkf/tests/enkf_ecl_config_config.c
@@ -35,7 +35,7 @@ int main(int argc , char ** argv) {
   {
     char * config_file = util_alloc_abs_path(argv[1]);
 
-    ecl_config_type * ecl_config = ecl_config_alloc();
+    ecl_config_type * ecl_config = ecl_config_alloc(NULL);
     ecl_refcase_list_type * refcase_list = ecl_config_get_refcase_list( ecl_config );
     {
       config_parser_type * config = config_alloc();

--- a/libenkf/tests/enkf_ensemble.c
+++ b/libenkf/tests/enkf_ensemble.c
@@ -39,7 +39,7 @@
 
 
 int main(int argc , char ** argv) {
-  ensemble_config_type * ensemble = ensemble_config_alloc();
+  ensemble_config_type * ensemble = ensemble_config_alloc(NULL, NULL, NULL);
   ensemble_config_free( ensemble );
   exit(0);
 }

--- a/libenkf/tests/enkf_ensemble_GEN_PARAM.c
+++ b/libenkf/tests/enkf_ensemble_GEN_PARAM.c
@@ -43,7 +43,7 @@ int main(int argc , char ** argv) {
   const char * config_file = argv[1];
   config_parser_type * config = config_alloc();
   config_content_type * content;
-  ensemble_config_type * ensemble = ensemble_config_alloc();
+  ensemble_config_type * ensemble = ensemble_config_alloc(NULL, NULL, NULL);
 
   enkf_config_node_add_GEN_PARAM_config_schema( config );
 

--- a/libenkf/tests/enkf_ensemble_config.c
+++ b/libenkf/tests/enkf_ensemble_config.c
@@ -35,7 +35,7 @@ void add_NULL_node( void * arg) {
 
 
 void test_abort_on_add_NULL() {
-  ensemble_config_type * ensemble_config = ensemble_config_alloc();
+  ensemble_config_type * ensemble_config = ensemble_config_alloc(NULL, NULL, NULL);
 
   test_assert_true( ensemble_config_is_instance( ensemble_config ));
   test_assert_util_abort("ensemble_config_add_node" , add_NULL_node , ensemble_config );

--- a/libenkf/tests/enkf_ert_workflow_list.c
+++ b/libenkf/tests/enkf_ert_workflow_list.c
@@ -29,7 +29,7 @@
 
 
 void test_create_workflow_list() {
-   ert_workflow_list_type * wf_list = ert_workflow_list_alloc( NULL );
+   ert_workflow_list_type * wf_list = ert_workflow_list_alloc_empty(NULL);
    test_assert_true( ert_workflow_list_is_instance( wf_list ));
    ert_workflow_list_free( wf_list );
 }
@@ -38,7 +38,7 @@ void test_create_workflow_list() {
 
 void test_add_alias( const char * job) {
   test_work_area_type * work_area = test_work_area_alloc( "workflow_list/alias" );
-  ert_workflow_list_type * wf_list = ert_workflow_list_alloc( NULL );
+  ert_workflow_list_type * wf_list = ert_workflow_list_alloc_empty(NULL);
   ert_workflow_list_add_job( wf_list , "JOB" , job );
 
   {

--- a/libenkf/tests/enkf_forward_load_context.c
+++ b/libenkf/tests/enkf_forward_load_context.c
@@ -49,7 +49,8 @@ void test_create() {
 
 void test_load_restart1() {
   run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", NULL, NULL , 0 , 0 , "run");
-  ecl_config_type * ecl_config = ecl_config_alloc( );
+  ecl_config_type * ecl_config = ecl_config_alloc(NULL);
+
   forward_load_context_type * load_context = forward_load_context_alloc( run_arg , false , ecl_config , "BASE" , NULL );
 
   test_assert_false( forward_load_context_load_restart_file( load_context , 10 ));
@@ -74,7 +75,7 @@ void test_load_restart2() {
   test_work_area_type * work_area = test_work_area_alloc("forward_load");
   {
     run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", NULL, NULL , 0 , 0 , "run");
-    ecl_config_type * ecl_config = ecl_config_alloc( );
+    ecl_config_type * ecl_config = ecl_config_alloc(NULL);
     forward_load_context_type * load_context = forward_load_context_alloc( run_arg , false , ecl_config , "BASE" , NULL );
     util_make_path("run");
     make_restart_mock( "run" , "BASE" , 1 );

--- a/libenkf/tests/enkf_hook_manager_test.c
+++ b/libenkf/tests/enkf_hook_manager_test.c
@@ -23,7 +23,7 @@
 int main(int argc, char ** argv) {
 
   ert_workflow_list_type * list = NULL;
-  hook_manager_type * hook_manager = hook_manager_alloc(list);
+  hook_manager_type * hook_manager = hook_manager_alloc_default(list);
 
   char * expected_path = "<CWD>/.ert_runpath_list";
   test_assert_string_equal(expected_path, hook_manager_get_runpath_list_file(hook_manager));

--- a/libenkf/tests/enkf_model_config.c
+++ b/libenkf/tests/enkf_model_config.c
@@ -26,14 +26,14 @@
 
 
 void test_create() {
-  model_config_type * model_config = model_config_alloc();
+  model_config_type * model_config = model_config_alloc_empty();
   test_assert_true( model_config_is_instance( model_config));
   model_config_free( model_config );
 }
 
 
 void test_runpath() {
-  model_config_type * model_config = model_config_alloc();
+  model_config_type * model_config = model_config_alloc_empty();
   model_config_add_runpath(model_config , "KEY" , "RunPath%d");
   model_config_add_runpath(model_config , "KEY2" , "2-RunPath%d");
   test_assert_true( model_config_select_runpath(model_config , "KEY"));

--- a/libenkf/tests/enkf_workflow_job_test_version.c
+++ b/libenkf/tests/enkf_workflow_job_test_version.c
@@ -53,7 +53,7 @@ int main(int argc , const char ** argv) {
   test_version( );
   {
     const char * path = argv[1];
-    ert_workflow_list_type * workflows = ert_workflow_list_alloc( NULL );
+    ert_workflow_list_type * workflows = ert_workflow_list_alloc_empty(NULL);
     ert_workflow_list_add_jobs_in_directory( workflows , path );
     
     // The CONF1 only exists as default - unversioned

--- a/python/python/res/enkf/ecl_config.py
+++ b/python/python/res/enkf/ecl_config.py
@@ -16,6 +16,7 @@
 
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
+from res.config import ConfigContent
 from ecl.ecl import EclSum, EclGrid
 from ecl.util import StringList, UIReturn
 from res.sched import SchedFile
@@ -23,7 +24,7 @@ from res.sched import SchedFile
 class EclConfig(BaseCClass):
     TYPE_NAME = "ecl_config"
 
-    _alloc                  = EnkfPrototype("void* ecl_config_alloc( )", bind = False)
+    _alloc                  = EnkfPrototype("void* ecl_config_alloc(config_content)", bind = False)
     _free                   = EnkfPrototype("void  ecl_config_free( ecl_config )")
     _get_eclbase            = EnkfPrototype("char* ecl_config_get_eclbase( ecl_config )")
     _validate_eclbase       = EnkfPrototype("ui_return_obj ecl_config_validate_eclbase( ecl_config , char*)")
@@ -55,7 +56,7 @@ class EclConfig(BaseCClass):
     _get_start_date         = EnkfPrototype("time_t ecl_config_get_start_date(ecl_config)")
 
     def __init__(self):
-        c_ptr = self._alloc()
+        c_ptr = self._alloc(None)
         if c_ptr:
             super(EclConfig, self).__init__(c_ptr)
         else:

--- a/python/python/res/enkf/ensemble_config.py
+++ b/python/python/res/enkf/ensemble_config.py
@@ -15,7 +15,9 @@
 #  for more details.
 from cwrap import BaseCClass
 from ecl.util import StringList
+from ecl.ecl import EclGrid, EclSum
 from res.enkf import EnkfPrototype, SummaryKeyMatcher
+from res.config import ConfigContent
 from res.enkf.config import EnkfConfigNode, CustomKWConfig
 from res.enkf.enums import EnkfVarType, ErtImplType
 
@@ -23,7 +25,7 @@ from res.enkf.enums import EnkfVarType, ErtImplType
 
 class EnsembleConfig(BaseCClass):
     TYPE_NAME = "ens_config"
-    _alloc = EnkfPrototype("void* ensemble_config_alloc()" , bind = False)
+    _alloc = EnkfPrototype("void* ensemble_config_alloc(config_content, ecl_grid, ecl_sum)", bind = False)
     _free = EnkfPrototype("void ensemble_config_free( ens_config )")
     _has_key = EnkfPrototype("bool ensemble_config_has_key( ens_config , char* )")
     _size = EnkfPrototype("int ensemble_config_get_size( ens_config)")
@@ -41,7 +43,7 @@ class EnsembleConfig(BaseCClass):
 
     
     def __init__(self):
-        c_ptr = self._alloc( )
+        c_ptr = self._alloc(None, None, None)
         super(EnsembleConfig , self).__init__(c_ptr)
         
 


### PR DESCRIPTION
**Task**
_It should be possible to allocate a res_config instance from a config_content. Currently, config_contents are created by the various sub-configs from the user configuration filename._


**Approach**
_Create a single config_content that all sub-configs can load from._


**Future work**
_We are now ready to start installing configurations from a yaml-config file into a config_content, before passing this to the initialization of res_config.__


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps
