### PR TITLE
Runpath list related cleanup

### DIFF
--- a/libenkf/include/ert/enkf/field.h
+++ b/libenkf/include/ert/enkf/field.h
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'field.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'field.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef ERT_FIELD_H
@@ -34,7 +34,7 @@ extern "C" {
 #include <ert/enkf/field_common.h>
 
 /* Typedef field_type moved to field_config.h */
- 
+
   void         field_scale(field_type * field, double scale_factor);
   int          field_get_global_index(const field_type * , int  , int  , int );
   void         field_ijk_set(field_type * , int  , int  , int  , const void * );
@@ -61,10 +61,10 @@ extern "C" {
   void         field_export(const field_type * , const char * , fortio_type * , field_file_format_type , bool, const char *);
   field_type * field_copyc(const field_type *);
   bool         field_cmp(const field_type *  , const field_type * );
-  
+
   double     * field_indexed_get_alloc(const field_type *, int, const int *);
   void         field_inplace_output_transform(field_type * field);
-  
+
   void          field_iscale(field_type * , double );
   void          field_isqrt(field_type *);
   void          field_isqr(field_type *);
@@ -74,7 +74,7 @@ extern "C" {
   ecl_kw_type * field_alloc_ecl_kw_wrapper(const field_type * );
   void          field_update_sum(field_type * sum , field_type * field , double lower_limit , double upper_limit);
   void          field_upgrade_103(const char * filename);
-  
+
   UTIL_IS_INSTANCE_HEADER(field);
   UTIL_SAFE_CAST_HEADER_CONST(field);
   VOID_ALLOC_HEADER(field);
@@ -101,4 +101,3 @@ extern "C" {
 }
 #endif
 #endif
-

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1277,7 +1277,7 @@ static void enkf_main_monitor_job_queue ( const enkf_main_type * enkf_main, job_
         util_usleep(10000);
       }
     }
-    
+
   }
 }
 
@@ -1289,7 +1289,7 @@ void enkf_main_isubmit_job( enkf_main_type * enkf_main , run_arg_type * run_arg 
   const member_config_type  * member_config = enkf_state_get_member_config( enkf_state );
   const queue_config_type * queue_config    = enkf_main_get_queue_config(enkf_main);
   const char * job_script                   = queue_config_get_job_script( queue_config );
-  
+
   const char * run_path                     = run_arg_get_runpath( run_arg );
 
   // The job_queue_node will take ownership of this arg_pack; and destroy it when

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -2377,45 +2377,47 @@ bool enkf_main_export_field_with_fs(const enkf_main_type * enkf_main,
   if (util_int_format_count(path) < 1)
     return false;
 
-  {
-    enkf_node_type * node = enkf_node_alloc( config_node );
-    model_config_type * mc = enkf_main_get_model_config(enkf_main);
-    path_fmt_type * runpath_fmt = model_config_get_runpath_fmt(mc);
-    const char * init_file = enkf_config_node_get_FIELD_fill_file(config_node, runpath_fmt);
-    if (init_file)
-      printf("init_file found: \"%s\", exporting initial value for inactive cells\n", init_file);
-    else
-      printf("no init_file found, exporting 0 or fill value for inactive cells\n");
 
-    int iens;
-    for (iens = 0; iens < bool_vector_size(iactive); ++iens) {
-      if (bool_vector_iget(iactive, iens)) {
-        node_id_type node_id = {.report_step = report_step , .iens = iens };
-        if (enkf_node_try_load(node , fs , node_id)) {
-          path_fmt_type * export_path = path_fmt_alloc_path_fmt( path );
-          char * filename = path_fmt_alloc_path( export_path , false , iens);
-          path_fmt_free(export_path);
+  enkf_node_type * node = enkf_node_alloc(config_node);
+  model_config_type * mc = enkf_main_get_model_config(enkf_main);
+  path_fmt_type * runpath_fmt = model_config_get_runpath_fmt(mc);
+  const char * init_file = enkf_config_node_get_FIELD_fill_file(config_node, runpath_fmt);
+  if (init_file)
+    printf("init_file found: \"%s\", exporting initial value for inactive cells\n", init_file);
+  else
+    printf("no init_file found, exporting 0 or fill value for inactive cells\n");
 
-          {
-            char * path;
-            util_alloc_file_components(filename , &path , NULL , NULL);
-            if (path) {
-              util_make_path( path );
-              free( path );
-            }
-          }
+  for (int iens = 0; iens < bool_vector_size(iactive); ++iens) {
+    if (!bool_vector_iget(iactive, iens))
+      continue;
 
-          {
-            const field_type * field = enkf_node_value_ptr(node);
-            const bool output_transform = true;
-            field_export(field , filename , NULL , file_type , output_transform, init_file);
-          }
-          free(filename);
-        }
-      }
+    node_id_type node_id = {.report_step = report_step, .iens = iens };
+    if (!enkf_node_try_load(node, fs, node_id))
+      continue;
+
+    path_fmt_type * export_path = path_fmt_alloc_path_fmt(path);
+    char * filename = path_fmt_alloc_path(export_path, false, iens);
+    path_fmt_free(export_path);
+
+    char * path;
+    util_alloc_file_components(filename, &path, NULL, NULL);
+    if (path) {
+      util_make_path(path);
+      free(path);
     }
-    enkf_node_free( node );
+
+    const field_type * field = enkf_node_value_ptr(node);
+    field_export(field,
+                 filename,
+                 NULL,
+                 file_type,
+                 true, //output_transform
+                 init_file);
+
+    free(filename);
   }
+  enkf_node_free(node);
+
 
   return true;
 }

--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -184,7 +184,7 @@ void enkf_state_initialize(enkf_state_type * enkf_state , enkf_fs_type * fs , co
     else {
       for (int ip = 0; ip < stringlist_get_size(param_list); ip++) {
         enkf_node_type * param_node = enkf_state_get_node(enkf_state, stringlist_iget(param_list, ip));
-        node_id_type node_id = { .report_step = 0, .iens = iens }; 
+        node_id_type node_id = { .report_step = 0, .iens = iens };
         bool has_data = enkf_node_has_data(param_node, fs, node_id);
 
         if ((init_mode == INIT_FORCE) || (has_data == false) || (current_state == STATE_LOAD_FAILURE)) {
@@ -502,8 +502,8 @@ static void enkf_state_check_for_missing_eclipse_summary_data(const summary_key_
 }
 
 static bool enkf_state_internalize_dynamic_eclipse_results(enkf_state_type * enkf_state ,
-							   forward_load_context_type * load_context ,
-							   const model_config_type * model_config) {
+                                                           forward_load_context_type * load_context ,
+                                                           const model_config_type * model_config) {
 
   bool load_summary = ensemble_config_has_impl_type(enkf_state->ensemble_config, SUMMARY);
   const run_arg_type * run_arg = forward_load_context_get_run_arg( load_context );
@@ -588,8 +588,8 @@ static bool enkf_state_internalize_dynamic_eclipse_results(enkf_state_type * enk
 
 
 static void enkf_state_internalize_custom_kw(enkf_state_type * enkf_state,
-					     forward_load_context_type * load_context ,
-					     const model_config_type * model_config) {
+                                             forward_load_context_type * load_context ,
+                                             const model_config_type * model_config) {
 
   member_config_type * my_config   = enkf_state->my_config;
   const int iens                   = member_config_get_iens( my_config );
@@ -605,30 +605,29 @@ static void enkf_state_internalize_custom_kw(enkf_state_type * enkf_state,
     const char* custom_kw_key = stringlist_iget(custom_kw_keys, ikey);
     enkf_node_type * node = enkf_state_get_node(enkf_state, custom_kw_key);
 
-    if (enkf_node_vector_storage(node)) {
+    if (enkf_node_vector_storage(node))
       util_abort("%s: Vector storage not correctly implemented for CUSTOM_KW\n", __func__);
-    } else {
-      if (enkf_node_internalize(node, report_step)) {
-        if (enkf_node_has_func(node, forward_load_func)) {
-          if (enkf_node_forward_load(node, load_context)) {
-            node_id_type node_id = {.report_step = report_step, .iens = iens };
 
-            enkf_node_store(node, result_fs, false, node_id);
+    if (enkf_node_internalize(node, report_step) && enkf_node_has_func(node, forward_load_func)) {
+      if (enkf_node_forward_load(node, load_context)) {
+        node_id_type node_id = {.report_step = report_step, .iens = iens };
 
-            const enkf_config_node_type * config_node = enkf_node_get_config(node);
-            const custom_kw_config_type * custom_kw_config = (custom_kw_config_type*) enkf_config_node_get_ref(config_node);
-            custom_kw_config_set_add_config(config_set, custom_kw_config);
-            enkf_state_log_custom_kw_load(node, report_step, load_context);
-          } else {
-            forward_load_context_update_result(load_context, LOAD_FAILURE);
-            res_log_add_fmt_message(LOG_ERROR, stderr, "[%03d:%04d] Failed load data for CUSTOM_KW node: %s.", iens , report_step, enkf_node_get_key(node));
+        enkf_node_store(node, result_fs, false, node_id);
 
-            if (forward_load_context_accept_messages(load_context)) {
-              char * msg = util_alloc_sprintf("Failed to load: %s at step: %d", enkf_node_get_key(node), report_step);
-              forward_load_context_add_message(load_context , msg);
-              free( msg );
-            }
-          }
+        const enkf_config_node_type * config_node = enkf_node_get_config(node);
+        const custom_kw_config_type * custom_kw_config = (custom_kw_config_type*) enkf_config_node_get_ref(config_node);
+        custom_kw_config_set_add_config(config_set, custom_kw_config);
+        enkf_state_log_custom_kw_load(node, report_step, load_context);
+      } else {
+        forward_load_context_update_result(load_context, LOAD_FAILURE);
+        res_log_add_fmt_message(LOG_ERROR, stderr,
+                                "[%03d:%04d] Failed load data for CUSTOM_KW node: %s.",
+                                iens, report_step, enkf_node_get_key(node));
+
+        if (forward_load_context_accept_messages(load_context)) {
+          char * msg = util_alloc_sprintf("Failed to load: %s at step: %d", enkf_node_get_key(node), report_step);
+          forward_load_context_add_message(load_context , msg);
+          free( msg );
         }
       }
     }
@@ -643,68 +642,74 @@ static void enkf_state_internalize_GEN_DATA(enkf_state_type * enkf_state ,
                                             forward_load_context_type * load_context ,
                                             const model_config_type * model_config ,
                                             int last_report) {
-  {
-    member_config_type * my_config     = enkf_state->my_config;
-    const int  iens                    = member_config_get_iens( my_config );
-    stringlist_type * keylist_GEN_DATA = ensemble_config_alloc_keylist_from_impl_type(enkf_state->ensemble_config , GEN_DATA );
-    const run_arg_type * run_arg       = forward_load_context_get_run_arg( load_context );
-    enkf_fs_type * result_fs           = run_arg_get_result_fs( run_arg );
 
-    for (int ikey=0; ikey < stringlist_get_size( keylist_GEN_DATA ); ikey++) {
-      enkf_node_type * node = enkf_state_get_node( enkf_state , stringlist_iget( keylist_GEN_DATA , ikey));
+  member_config_type * my_config     = enkf_state->my_config;
+  const int  iens                    = member_config_get_iens( my_config );
+  stringlist_type * keylist_GEN_DATA = ensemble_config_alloc_keylist_from_impl_type(enkf_state->ensemble_config,
+                                                                                    GEN_DATA);
+  const run_arg_type * run_arg       = forward_load_context_get_run_arg( load_context );
+  enkf_fs_type * result_fs           = run_arg_get_result_fs( run_arg );
 
-      for (int report_step = run_arg_get_load_start( run_arg ); report_step <= last_report; report_step++) {
-	if (enkf_node_internalize(node , report_step)) {
+  for (int ikey=0; ikey < stringlist_get_size( keylist_GEN_DATA ); ikey++) {
+    enkf_node_type * node = enkf_state_get_node( enkf_state , stringlist_iget( keylist_GEN_DATA , ikey));
 
-	  if (enkf_node_has_func(node , forward_load_func)) {
-            forward_load_context_select_step(load_context, report_step);
-	    if (enkf_node_forward_load(node , load_context )) {
-	      node_id_type node_id = {.report_step = report_step ,
-				      .iens = iens };
+    for (int report_step = run_arg_get_load_start( run_arg ); report_step <= last_report; report_step++) {
 
-	      enkf_node_store( node , result_fs, false , node_id );
-              enkf_state_log_GEN_DATA_load( node , report_step , load_context);
-	    } else {
-              forward_load_context_update_result(load_context, LOAD_FAILURE);
-	      res_log_add_fmt_message(LOG_ERROR , stderr , "[%03d:%04d] Failed load data for GEN_DATA node:%s.",iens , report_step , enkf_node_get_key( node ));
+      if (!enkf_node_internalize(node , report_step))
+        continue;
+      if (!enkf_node_has_func(node, forward_load_func))
+        continue;
 
-              if (forward_load_context_accept_messages(load_context)) {
-                char * msg = util_alloc_sprintf("Failed to load: %s at step:%d" , enkf_node_get_key( node ) , report_step);
-		forward_load_context_add_message(load_context, msg);
-                free( msg );
-              }
-            }
-          }
+      forward_load_context_select_step(load_context, report_step);
+      if (enkf_node_forward_load(node , load_context )) {
+        node_id_type node_id = {.report_step = report_step ,
+                                .iens = iens };
+
+        enkf_node_store( node , result_fs, false , node_id );
+        enkf_state_log_GEN_DATA_load( node , report_step , load_context);
+      } else {
+        forward_load_context_update_result(load_context, LOAD_FAILURE);
+        res_log_add_fmt_message(LOG_ERROR, stderr,
+                                "[%03d:%04d] Failed load data for GEN_DATA node:%s.",
+                                iens, report_step, enkf_node_get_key(node));
+
+        if (forward_load_context_accept_messages(load_context)) {
+          char * msg = util_alloc_sprintf("Failed to load: %s at step:%d",
+                                          enkf_node_get_key(node), report_step);
+          forward_load_context_add_message(load_context, msg);
+          free( msg );
         }
       }
     }
-    stringlist_free( keylist_GEN_DATA );
   }
+  stringlist_free( keylist_GEN_DATA );
 }
 
 
 
 
 
-static forward_load_context_type * enkf_state_alloc_load_context( const enkf_state_type * state , run_arg_type * run_arg, stringlist_type * messages) {
-  bool load_summary = ensemble_config_has_impl_type(state->ensemble_config, SUMMARY);
+static forward_load_context_type * enkf_state_alloc_load_context(const enkf_state_type * state,
+                                                                 run_arg_type * run_arg,
+                                                                 stringlist_type * messages) {
+  bool load_summary = ensemble_config_has_impl_type(state->ensemble_config,
+                                                    SUMMARY);
   if (!load_summary) {
     const summary_key_matcher_type * matcher = ensemble_config_get_summary_key_matcher(state->ensemble_config);
     load_summary = (summary_key_matcher_get_size(matcher) > 0);
   }
 
-  {
-    forward_load_context_type * load_context;
-    const ecl_config_type * ecl_config = state->shared_info->ecl_config;
-    const char * eclbase = enkf_state_get_eclbase( state );
+  forward_load_context_type * load_context;
+  const ecl_config_type * ecl_config = state->shared_info->ecl_config;
+  const char * eclbase = enkf_state_get_eclbase( state );
 
-    load_context = forward_load_context_alloc( run_arg,
-                                               load_summary,
-                                               ecl_config ,
-                                               eclbase,
-                                               messages );
-    return load_context;
-  }
+  load_context = forward_load_context_alloc(run_arg,
+                                            load_summary,
+                                            ecl_config,
+                                            eclbase,
+                                            messages);
+  return load_context;
+
 }
 
 
@@ -716,8 +721,6 @@ static forward_load_context_type * enkf_state_alloc_load_context( const enkf_sta
    Will mainly be called at the end of the forward model, but can also
    be called manually from external scope.
 */
-
-
 static int enkf_state_internalize_results(enkf_state_type * enkf_state , run_arg_type * run_arg , stringlist_type * msg_list) {
   model_config_type * model_config = enkf_state->shared_info->model_config;
   forward_load_context_type * load_context = enkf_state_alloc_load_context( enkf_state , run_arg , msg_list);
@@ -730,31 +733,29 @@ static int enkf_state_internalize_results(enkf_state_type * enkf_state , run_arg
   */
 
   enkf_state_internalize_dynamic_eclipse_results(enkf_state ,
-						 load_context ,
-						 model_config);
-  {
-    enkf_fs_type * result_fs = run_arg_get_result_fs( run_arg );
-    int last_report = time_map_get_last_step( enkf_fs_get_time_map( result_fs ));
-    if (last_report < 0)
-      last_report = model_config_get_last_history_restart( enkf_state->shared_info->model_config);
+                                                 load_context ,
+                                                 model_config);
 
-    /* Ensure that the last step is internalized? */
-    model_config_set_internalize_state( model_config , last_report);
+  enkf_fs_type * result_fs = run_arg_get_result_fs( run_arg );
+  int last_report = time_map_get_last_step( enkf_fs_get_time_map( result_fs ));
+  if (last_report < 0)
+    last_report = model_config_get_last_history_restart( enkf_state->shared_info->model_config);
 
-    for (report_step = run_arg_get_load_start( run_arg ); report_step <= last_report; report_step++) {
-      bool store_vectors = (report_step == last_report) ? true : false;
-      if (model_config_load_state( model_config , report_step))
-        enkf_state_internalize_eclipse_state(enkf_state ,
-					     load_context ,
-					     model_config ,
-					     report_step ,
-					     store_vectors);
-    }
+  /* Ensure that the last step is internalized? */
+  model_config_set_internalize_state( model_config , last_report);
 
-    enkf_state_internalize_GEN_DATA(enkf_state , load_context , model_config , last_report);
-    enkf_state_internalize_custom_kw(enkf_state, load_context , model_config);
+  for (report_step = run_arg_get_load_start(run_arg); report_step <= last_report; report_step++) {
+    bool store_vectors = (report_step == last_report);
+    if (model_config_load_state( model_config , report_step))
+      enkf_state_internalize_eclipse_state(enkf_state ,
+                                           load_context ,
+                                           model_config ,
+                                           report_step ,
+                                           store_vectors);
   }
 
+  enkf_state_internalize_GEN_DATA(enkf_state , load_context , model_config , last_report);
+  enkf_state_internalize_custom_kw(enkf_state, load_context , model_config);
 
   int result = forward_load_context_get_result(load_context);
   forward_load_context_free( load_context );
@@ -775,14 +776,12 @@ int enkf_state_load_from_forward_model(enkf_state_type * enkf_state ,
     result |= enkf_state_forward_init( enkf_state , run_arg );
 
   result |= enkf_state_internalize_results( enkf_state , run_arg , msg_list );
-  {
-    state_map_type * state_map = enkf_fs_get_state_map( run_arg_get_result_fs( run_arg ) );
-    int iens = member_config_get_iens( enkf_state->my_config );
-    if (result & LOAD_FAILURE)
-      state_map_iset( state_map , iens , STATE_LOAD_FAILURE);
-    else
-      state_map_iset( state_map , iens , STATE_HAS_DATA);
-  }
+  state_map_type * state_map = enkf_fs_get_state_map( run_arg_get_result_fs( run_arg ) );
+  int iens = member_config_get_iens( enkf_state->my_config );
+  if (result & LOAD_FAILURE)
+    state_map_iset( state_map , iens , STATE_LOAD_FAILURE);
+  else
+    state_map_iset( state_map , iens , STATE_HAS_DATA);
 
   return result;
 }
@@ -823,20 +822,6 @@ void * enkf_state_load_from_forward_model_mt( void * arg ) {
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 void enkf_state_free(enkf_state_type *enkf_state) {
   rng_free( enkf_state->rng );
   hash_free(enkf_state->node_hash);
@@ -845,8 +830,6 @@ void enkf_state_free(enkf_state_type *enkf_state) {
   shared_info_free(enkf_state->shared_info);
   free(enkf_state);
 }
-
-
 
 
 
@@ -869,46 +852,41 @@ static void enkf_state_set_dynamic_subst_kw__(enkf_state_type * enkf_state , con
 
 
   /* Time step */
-  {
-    char * step1_s           = util_alloc_sprintf("%d" , step1);
-    char * step2_s           = util_alloc_sprintf("%d" , step2);
-    char * step1_s04         = util_alloc_sprintf("%04d" , step1);
-    char * step2_s04         = util_alloc_sprintf("%04d" , step2);
+  char * step1_s           = util_alloc_sprintf("%d" , step1);
+  char * step2_s           = util_alloc_sprintf("%d" , step2);
+  char * step1_s04         = util_alloc_sprintf("%04d" , step1);
+  char * step2_s04         = util_alloc_sprintf("%04d" , step2);
 
-    enkf_state_add_subst_kw(enkf_state , "TSTEP1"        , step1_s       , NULL);
-    enkf_state_add_subst_kw(enkf_state , "TSTEP2"        , step2_s       , NULL);
-    enkf_state_add_subst_kw(enkf_state , "TSTEP1_04"     , step1_s04     , NULL);
-    enkf_state_add_subst_kw(enkf_state , "TSTEP2_04"     , step2_s04     , NULL);
+  enkf_state_add_subst_kw(enkf_state , "TSTEP1"        , step1_s       , NULL);
+  enkf_state_add_subst_kw(enkf_state , "TSTEP2"        , step2_s       , NULL);
+  enkf_state_add_subst_kw(enkf_state , "TSTEP1_04"     , step1_s04     , NULL);
+  enkf_state_add_subst_kw(enkf_state , "TSTEP2_04"     , step2_s04     , NULL);
 
-    free(step1_s);
-    free(step2_s);
-    free(step1_s04);
-    free(step2_s04);
-  }
+  free(step1_s);
+  free(step2_s);
+  free(step1_s04);
+  free(step2_s04);
 
 
   /* Restart file names and RESTART keyword in datafile. */
-  {
-    const char * eclbase     = member_config_get_eclbase( enkf_state->my_config );
-    if (eclbase != NULL) {
-      {
-        char * restart_file1     = ecl_util_alloc_filename(NULL , eclbase , ECL_RESTART_FILE , fmt_file , step1);
-        char * restart_file2     = ecl_util_alloc_filename(NULL , eclbase , ECL_RESTART_FILE , fmt_file , step2);
+  const char * eclbase     = member_config_get_eclbase( enkf_state->my_config );
+  if (eclbase != NULL) {
+    char * restart_file1     = ecl_util_alloc_filename(NULL , eclbase , ECL_RESTART_FILE , fmt_file , step1);
+    char * restart_file2     = ecl_util_alloc_filename(NULL , eclbase , ECL_RESTART_FILE , fmt_file , step2);
 
-        enkf_state_add_subst_kw(enkf_state , "RESTART_FILE1" , restart_file1 , NULL);
-        enkf_state_add_subst_kw(enkf_state , "RESTART_FILE2" , restart_file2 , NULL);
+    enkf_state_add_subst_kw(enkf_state , "RESTART_FILE1" , restart_file1 , NULL);
+    enkf_state_add_subst_kw(enkf_state , "RESTART_FILE2" , restart_file2 , NULL);
 
-        free(restart_file1);
-        free(restart_file2);
-      }
+    free(restart_file1);
+    free(restart_file2);
 
-      if (step1 > 0) {
-        char * data_initialize = util_alloc_sprintf("RESTART\n   \'%s\'  %d  /\n" , eclbase , step1);
-        enkf_state_add_subst_kw(enkf_state , "INIT" , data_initialize , NULL);
-        free(data_initialize);
-      }
+    if (step1 > 0) {
+      char * data_initialize = util_alloc_sprintf("RESTART\n   \'%s\'  %d  /\n" , eclbase , step1);
+      enkf_state_add_subst_kw(enkf_state , "INIT" , data_initialize , NULL);
+      free(data_initialize);
     }
   }
+
 
   /**
      The <INIT> magic string:
@@ -926,30 +904,34 @@ static void enkf_state_set_dynamic_subst_kw__(enkf_state_type * enkf_state , con
   }
 
 
-  {
-    /**
-        Adding keys for <RANDINT> and <RANDFLOAT> - these are only
-        added for backwards compatibility, should be replaced with
-        prober function callbacks.
-    */
-    char * randint_value    = util_alloc_sprintf( "%u"      , rng_forward( enkf_state->rng ));
-    char * randfloat_value  = util_alloc_sprintf( "%12.10f" , rng_get_double( enkf_state->rng ));
+  /**
+     Adding keys for <RANDINT> and <RANDFLOAT> - these are only
+     added for backwards compatibility, should be replaced with
+     prober function callbacks.
+  */
+  char * randint_value    = util_alloc_sprintf( "%u"      , rng_forward( enkf_state->rng ));
+  char * randfloat_value  = util_alloc_sprintf( "%12.10f" , rng_get_double( enkf_state->rng ));
 
-    enkf_state_add_subst_kw( enkf_state , "RANDINT"   , randint_value   , NULL);
-    enkf_state_add_subst_kw( enkf_state , "RANDFLOAT" , randfloat_value , NULL);
+  enkf_state_add_subst_kw( enkf_state , "RANDINT"   , randint_value   , NULL);
+  enkf_state_add_subst_kw( enkf_state , "RANDFLOAT" , randfloat_value , NULL);
 
-    free( randint_value );
-    free( randfloat_value );
-  }
+  free( randint_value );
+  free( randfloat_value );
 }
 
-static void enkf_state_set_dynamic_subst_kw(enkf_state_type * enkf_state , const run_arg_type * run_arg ) {
-  enkf_state_set_dynamic_subst_kw__( enkf_state , run_arg_get_runpath( run_arg ) , run_arg_get_step1( run_arg ) , run_arg_get_step2( run_arg ));
+static void enkf_state_set_dynamic_subst_kw(enkf_state_type * enkf_state,
+                                            const run_arg_type * run_arg ) {
+  enkf_state_set_dynamic_subst_kw__(enkf_state,
+                                    run_arg_get_runpath(run_arg),
+                                    run_arg_get_step1(run_arg),
+                                    run_arg_get_step2(run_arg));
 }
 
 
 
-void enkf_state_printf_subst_list(enkf_state_type * enkf_state , int step1 , int step2) {
+void enkf_state_printf_subst_list(enkf_state_type * enkf_state,
+                                  int step1,
+                                  int step2) {
   int ikw;
   const char * fmt_string = "%-16s %-40s :: %s\n";
   printf("\n\n");
@@ -987,69 +969,72 @@ void enkf_state_printf_subst_list(enkf_state_type * enkf_state , int step1 , int
    it is required that report_step1 == 0; otherwise the dynamic data
    will become completely inconsistent. We just don't allow that!
 */
-
-
 void enkf_state_init_eclipse(enkf_state_type *enkf_state, const run_arg_type * run_arg ) {
   const member_config_type  * my_config = enkf_state->my_config;
   const ecl_config_type * ecl_config = enkf_state->shared_info->ecl_config;
-  {
-    util_make_path(run_arg_get_runpath( run_arg ));
-    {
-      if (ecl_config_get_schedule_target( ecl_config ) != NULL) {
 
-        char * schedule_file_target = util_alloc_filename(run_arg_get_runpath( run_arg ) , ecl_config_get_schedule_target( ecl_config ) , NULL);
-        char * schedule_file_target_path = util_split_alloc_dirname(schedule_file_target);
-        util_make_path(schedule_file_target_path);
-        free(schedule_file_target_path);
+  util_make_path(run_arg_get_runpath( run_arg ));
+  if (ecl_config_get_schedule_target( ecl_config ) != NULL) {
 
-        sched_file_fprintf( ecl_config_get_sched_file( ecl_config ) , schedule_file_target);
+    char * schedule_file_target = util_alloc_filename(run_arg_get_runpath( run_arg ),
+                                                      ecl_config_get_schedule_target( ecl_config ),
+                                                      NULL);
+    char * schedule_file_target_path = util_split_alloc_dirname(schedule_file_target);
+    util_make_path(schedule_file_target_path);
+    free(schedule_file_target_path);
 
-        free(schedule_file_target);
-      }
-    }
+    sched_file_fprintf( ecl_config_get_sched_file( ecl_config ) , schedule_file_target);
 
-
-    /**
-       For reruns of various kinds the parameters and the state are
-       generally loaded from different timesteps:
-    */
-    {
-      enkf_fs_type * init_fs = run_arg_get_init_fs( run_arg );
-      /* Loading parameter information: loaded from timestep: run_arg->init_step_parameters. */
-      enkf_state_fread(enkf_state , init_fs , PARAMETER , 0);
-
-
-      /* Loading state information: loaded from timestep: run_arg->step1 */
-      if (run_arg_get_step1(run_arg) == 0)
-        enkf_state_fread_initial_state(enkf_state , init_fs);
-      else
-        enkf_state_fread_state_nodes( enkf_state , init_fs , run_arg_get_step1(run_arg));
-
-      enkf_state_set_dynamic_subst_kw(  enkf_state , run_arg );
-      ert_templates_instansiate( enkf_state->shared_info->templates , run_arg_get_runpath( run_arg ) , enkf_state->subst_list );
-      enkf_state_ecl_write( enkf_state , run_arg , init_fs);
-
-      if (member_config_get_eclbase( my_config ) != NULL) {
-
-        /* Writing the ECLIPSE data file. */
-        if (ecl_config_get_data_file( ecl_config ) != NULL) {
-          char * data_file = ecl_util_alloc_filename(run_arg_get_runpath( run_arg ) , member_config_get_eclbase( my_config ) , ECL_DATA_FILE , true , -1);
-          subst_list_filter_file(enkf_state->subst_list , ecl_config_get_data_file(ecl_config) , data_file);
-          free( data_file );
-        }
-      }
-    }
-    member_config_get_jobname( my_config );
-    mode_t umask = site_config_get_umask(enkf_state->shared_info->site_config);
-
-
-    /* This is where the job script is created */
-    forward_model_formatted_fprintf( model_config_get_forward_model( enkf_state->shared_info->model_config ) ,
-                                     run_arg_get_run_id( run_arg ),
-                                     run_arg_get_runpath( run_arg ) ,
-                                     enkf_state->subst_list,
-                                     umask);
+    free(schedule_file_target);
   }
+
+
+  /**
+     For reruns of various kinds the parameters and the state are
+     generally loaded from different timesteps:
+  */
+  enkf_fs_type * init_fs = run_arg_get_init_fs( run_arg );
+  /* Loading parameter information: loaded from timestep: run_arg->init_step_parameters. */
+  enkf_state_fread(enkf_state , init_fs , PARAMETER , 0);
+
+
+  /* Loading state information: loaded from timestep: run_arg->step1 */
+  if (run_arg_get_step1(run_arg) == 0)
+    enkf_state_fread_initial_state(enkf_state , init_fs);
+  else
+    enkf_state_fread_state_nodes( enkf_state , init_fs , run_arg_get_step1(run_arg));
+
+  enkf_state_set_dynamic_subst_kw(  enkf_state , run_arg );
+  ert_templates_instansiate( enkf_state->shared_info->templates , run_arg_get_runpath( run_arg ) , enkf_state->subst_list );
+  enkf_state_ecl_write( enkf_state , run_arg , init_fs);
+
+  if (member_config_get_eclbase( my_config ) != NULL) {
+
+    /* Writing the ECLIPSE data file. */
+    if (ecl_config_get_data_file( ecl_config ) != NULL) {
+      char * data_file = ecl_util_alloc_filename(run_arg_get_runpath( run_arg ),
+                                                 member_config_get_eclbase( my_config ),
+                                                 ECL_DATA_FILE,
+                                                 true,
+                                                 -1);
+      subst_list_filter_file(enkf_state->subst_list,
+                             ecl_config_get_data_file(ecl_config),
+                             data_file);
+      free( data_file );
+    }
+  }
+
+  member_config_get_jobname( my_config );
+  mode_t umask = site_config_get_umask(enkf_state->shared_info->site_config);
+
+
+  /* This is where the job script is created */
+  forward_model_formatted_fprintf( model_config_get_forward_model( enkf_state->shared_info->model_config ) ,
+                                   run_arg_get_run_id( run_arg ),
+                                   run_arg_get_runpath( run_arg ) ,
+                                   enkf_state->subst_list,
+                                   umask);
+
 }
 
 
@@ -1074,7 +1059,9 @@ static bool enkf_state_complete_forward_modelOK(enkf_state_type * enkf_state , r
      in this scope whether the results can be loaded back; if that
      is OK the final status is updated, otherwise: restart.
   */
-  res_log_add_fmt_message(LOG_INFO , NULL , "[%03d:%04d-%04d] Forward model complete - starting to load results." , iens , run_arg_get_step1(run_arg), run_arg_get_step2(run_arg));
+  res_log_add_fmt_message(LOG_INFO, NULL,
+                          "[%03d:%04d-%04d] Forward model complete - starting to load results.",
+                          iens , run_arg_get_step1(run_arg), run_arg_get_step2(run_arg));
   result = enkf_state_load_from_forward_model(enkf_state , run_arg , NULL);
 
   if (result & REPORT_STEP_INCOMPATIBLE) {
@@ -1092,7 +1079,9 @@ static bool enkf_state_complete_forward_modelOK(enkf_state_type * enkf_state , r
       (should be avoided) to JOB_RUN_OK.
     */
     run_arg_set_run_status( run_arg , JOB_RUN_OK);
-    res_log_add_fmt_message(LOG_INFO , NULL , "[%03d:%04d-%04d] Results loaded successfully." , iens , run_arg_get_step1(run_arg), run_arg_get_step2(run_arg));
+    res_log_add_fmt_message(LOG_INFO, NULL,
+                            "[%03d:%04d-%04d] Results loaded successfully.",
+                            iens , run_arg_get_step1(run_arg), run_arg_get_step2(run_arg));
 
     run_arg_complete_run(run_arg);              /* free() on runpath */
   }
@@ -1111,10 +1100,13 @@ bool enkf_state_complete_forward_modelOK__(void * arg ) {
 
 
 
-static bool enkf_state_complete_forward_model_EXIT_handler__(enkf_state_type * enkf_state , run_arg_type * run_arg) {
+static bool enkf_state_complete_forward_model_EXIT_handler__(enkf_state_type * enkf_state,
+                                                             run_arg_type * run_arg) {
   const member_config_type  * my_config   = enkf_state->my_config;
   const int iens                          = member_config_get_iens( my_config );
-  res_log_add_fmt_message(LOG_ERROR, NULL, "[%03d:%04d-%04d] FAILED COMPLETELY.", iens, run_arg_get_step1(run_arg), run_arg_get_step2(run_arg));
+  res_log_add_fmt_message(LOG_ERROR, NULL,
+                          "[%03d:%04d-%04d] FAILED COMPLETELY.",
+                          iens, run_arg_get_step1(run_arg), run_arg_get_step2(run_arg));
 
   if (run_arg_get_run_status(run_arg) != JOB_LOAD_FAILURE)
     run_arg_set_run_status( run_arg , JOB_RUN_FAILURE);
@@ -1159,20 +1151,21 @@ static void enkf_state_internal_retry(enkf_state_type * enkf_state , run_arg_typ
   const member_config_type  * my_config   = enkf_state->my_config;
   const int iens                          = member_config_get_iens( my_config );
 
-  res_log_add_fmt_message(LOG_ERROR, NULL , "[%03d:%04d - %04d] Forward model failed.",iens, run_arg_get_step1(run_arg) , run_arg_get_step2(run_arg));
+  res_log_add_fmt_message(LOG_ERROR, NULL,
+                          "[%03d:%04d - %04d] Forward model failed.",
+                          iens, run_arg_get_step1(run_arg) , run_arg_get_step2(run_arg));
   if (run_arg_can_retry( run_arg ) ) {
     res_log_add_fmt_message(LOG_ERROR, NULL , "[%03d] Resampling and resubmitting realization." ,iens);
-    {
-      /* Reinitialization of the nodes */
-      stringlist_type * init_keys = ensemble_config_alloc_keylist_from_var_type( enkf_state->ensemble_config , DYNAMIC_STATE + PARAMETER );
-      for (int ikey=0; ikey < stringlist_get_size( init_keys ); ikey++) {
-        enkf_node_type * node = enkf_state_get_node( enkf_state , stringlist_iget( init_keys , ikey) );
-        enkf_node_initialize( node , iens , enkf_state->rng );
-      }
-      stringlist_free( init_keys );
+    /* Reinitialization of the nodes */
+    stringlist_type * init_keys = ensemble_config_alloc_keylist_from_var_type( enkf_state->ensemble_config , DYNAMIC_STATE + PARAMETER );
+    for (int ikey=0; ikey < stringlist_get_size( init_keys ); ikey++) {
+      enkf_node_type * node = enkf_state_get_node( enkf_state , stringlist_iget( init_keys , ikey) );
+      enkf_node_initialize( node , iens , enkf_state->rng );
     }
+    stringlist_free( init_keys );
 
-    enkf_state_init_eclipse( enkf_state , run_arg  );                                  /* Possibly clear the directory and do a FULL rewrite of ALL the necessary files. */
+    /* Possibly clear the directory and do a FULL rewrite of ALL the necessary files. */
+    enkf_state_init_eclipse( enkf_state , run_arg  );
     run_arg_increase_submit_count( run_arg );
   }
 }
@@ -1186,9 +1179,9 @@ bool enkf_state_complete_forward_modelRETRY__(void * arg ) {
   if (run_arg_can_retry(run_arg)) {
     enkf_state_internal_retry(enkf_state, run_arg);
     return true;
-  } else {
-    return false;
   }
+
+  return false;
 }
 
 
@@ -1263,7 +1256,6 @@ void enkf_state_ecl_write(enkf_state_type * enkf_state, const run_arg_type * run
   fclose(export_file);
   free(export_file_name);
 }
-
 
 
 #include "enkf_state_nodes.c"

--- a/libenkf/src/enkf_util.c
+++ b/libenkf/src/enkf_util.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'enkf_util.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'enkf_util.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <math.h>
@@ -48,12 +48,12 @@ void enkf_util_rand_stdnormal_vector(int size , double *R, rng_type * rng) {
 }
 
 /**
-   Vector containing a random permutation of the integers 1,...,size 
+   Vector containing a random permutation of the integers 1,...,size
 */
 
 void enkf_util_randperm( int * P , int size , rng_type * rng) {
   int k, tmp;
-  
+
   for (k = 0; k < size; k++)
     P[k] = k;
 
@@ -65,7 +65,7 @@ void enkf_util_randperm( int * P , int size , rng_type * rng) {
     P[k] = tmp;
   }
 }
- 
+
 
 
 /*****************************************************************/
@@ -82,7 +82,7 @@ void enkf_util_randperm( int * P , int size , rng_type * rng) {
      else if (data[i] > max_value)         \
         data[i] = max_value;               \
    }                                       \
-}  
+}
 
 void enkf_util_truncate(void * void_data , int size , ecl_data_type data_type , void * min_ptr , void *max_ptr) {
   if (ecl_type_is_double(data_type))
@@ -91,7 +91,7 @@ void enkf_util_truncate(void * void_data , int size , ecl_data_type data_type , 
      TRUNCATE(float , void_data , size , min_ptr , max_ptr)
   else if (ecl_type_is_int(data_type))
      TRUNCATE(int , void_data , size , min_ptr , max_ptr)
-  else 
+  else
      util_abort("%s: unrecognized type - aborting \n",__func__);
 }
 #undef TRUNCATE
@@ -133,82 +133,9 @@ void enkf_util_fwrite_target_type(FILE * stream , ert_impl_type target_type) {
 }
 
 
-/*
-size_t util_copy_strided_vector(const void * _src, size_t src_size , int src_stride , void * _target , int target_stride , size_t target_size ,  int type_size , bool * complete) {
-  const char * src    = (const char *) _src;
-  char       * target = (char *)       _target;
-  
-  size_t src_index;
-  size_t target_index = 0;
-
-  for (src_index = 0; src_index < src_size; src_index++) {
-    size_t src_adress    = src_index    * type_size * src_stride;
-    size_t target_adress = target_index * type_size * target_stride;
-    memcpy(&target[target_adress] , &src[src_adress] , type_size);
-    target_index++;
-    if (target_index == target_size) {
-      if (src_index < (src_size - 1)) *complete = false;
-      break;
-    }
-  }
-  return target_index;
-}
-
-*/
-
-
 
 /**
-   Prompts the user for a filename, and reads the filename from
-   stdin. 
-
-   If the parameter 'auto_mkdir' is true, the path part of the
-   filename is created automagically. If 'must_exist' is true, the
-   function will loop until the user gives an existing filename.
-
-   The filename given by the user is returned - it is the
-   responibility of the calling scope to free this memory.
-
-   The options parameter is an integer, which is a sum of the
-   following alternatives:
-
-   EXISTING_FILE  = 1
-   NEW_FILE       = 2
-   AUTO_MKDIR     = 4
-*/
-
-//char * enkf_util_scanf_alloc_filename(const char * prompt , int options) {
-//  if ((options & EXISTING_FILE) && (options & NEW_FILE))
-//    util_abort("%s: internal error - asking for both new and existing file - impossible \n", __func__);
-//  {
-//    bool OK = true;
-//    char * _path;
-//    char file[1024];
-//    do {
-//      printf("%s",prompt);
-//      scanf("%s" , file);
-//      util_alloc_file_components(file , &_path , NULL ,  NULL);
-//      if (_path != NULL) {
-//      if (!util_is_directory(_path)) 
-//        if (options & AUTO_MKDIR)
-//          util_make_path(_path);
-//      free(_path);
-//      }
-//      
-//      if ((options & EXISTING_FILE) && (!util_file_exists(file)))
-//      OK = false;
-//      else if ((options & NEW_FILE) && (util_file_exists(file)))
-//      OK = false;
-//
-//    } while (!OK);
-//    return util_alloc_string_copy(file);    
-//  }
-//}
-
-
-
-/**
-  This function prints the entries in data to a file. 
+  This function prints the entries in data to a file.
 
   data is assumed to be num_colums pointers to double vectors of length num_rows.
   Note that this is not the conventional C style naming.
@@ -216,8 +143,17 @@ size_t util_copy_strided_vector(const void * _src, size_t src_size , int src_str
   If summarize is true, the mean and standard deviation of each column will be printed.
 */
 #define PRINT_LINE(n,c,stream) { int _i; for (_i = 0; _i < (n); _i++) fputc(c , stream); fprintf(stream,"\n"); }
-void enkf_util_fprintf_data(const int * index_column , const double ** data, const char * index_name , const char ** column_names, int num_rows, int num_columns, const bool * active , 
-                            bool summarize, FILE * stream) {
+
+void enkf_util_fprintf_data(const int * index_column ,
+                            const double ** data,
+                            const char * index_name ,
+                            const char ** column_names,
+                            int num_rows,
+                            int num_columns,
+                            const bool * active ,
+                            bool summarize,
+                            FILE * stream) {
+
   const int float_width     =  9;
   const int float_precision =  4;
 
@@ -249,8 +185,8 @@ void enkf_util_fprintf_data(const int * index_column , const double ** data, con
   /* Calculate the mean and std dev of each column. */
   for(int column_nr = 0; column_nr < num_columns; column_nr++) {
     if (active[column_nr]) {
-      mean  [column_nr] = util_double_vector_mean(  num_rows, data[column_nr]); 
-      stddev[column_nr] = util_double_vector_stddev(num_rows, data[column_nr]); 
+      mean  [column_nr] = util_double_vector_mean(  num_rows, data[column_nr]);
+      stddev[column_nr] = util_double_vector_stddev(num_rows, data[column_nr]);
     }
   }
 
@@ -289,7 +225,7 @@ void enkf_util_fprintf_data(const int * index_column , const double ** data, con
     for (int row_nr = 0; row_nr < num_rows; row_nr++) {
       util_fprintf_int(index_column[row_nr], width[0] - 1 , stream);   /* This +1 is not general */
       fprintf(stream , "|");
-      
+
       for (int column_nr = 0; column_nr < num_columns; column_nr++) {
         if (active[column_nr]) {
           util_fprintf_double(data[column_nr][row_nr] , width[column_nr + 1] , float_precision , 'g' , stream);
@@ -300,7 +236,7 @@ void enkf_util_fprintf_data(const int * index_column , const double ** data, con
     }
     PRINT_LINE(total_width , '=' , stream);
   }
-  
+
   free(stddev);
   free(mean);
   free(width);
@@ -355,9 +291,9 @@ int enkf_util_compare_keys( const char * key1 , const char * key2 ) {
       if (stringlist_get_size( items1 ) >= 2)
         cmp = strcmp( stringlist_iget( items1 , 1) , stringlist_iget( items2  , 1));
     }
-    
+
     /* 3: String compare on first item */
-    if (cmp == 0) 
+    if (cmp == 0)
       cmp = strcmp( stringlist_iget( items1 , 0) , stringlist_iget( items2  , 0));
 
     /* String compare of the whole god damn thing. */
@@ -377,5 +313,3 @@ int enkf_util_compare_keys__( const void * __key1 , const void * __key2 ) {
 
   return enkf_util_compare_keys( key1 , key2 );
 }
-
-

--- a/libenkf/src/enkf_util.c
+++ b/libenkf/src/enkf_util.c
@@ -102,17 +102,29 @@ void enkf_util_truncate(void * void_data , int size , ecl_data_type data_type , 
 void enkf_util_assert_buffer_type(buffer_type * buffer, ert_impl_type target_type) {
   ert_impl_type file_type;
   file_type = buffer_fread_int(buffer);
-  if (file_type != target_type) 
-    util_abort("%s: wrong target type in file (expected:%d  got:%d)  - aborting \n",__func__ , target_type , file_type);
+  if (file_type != target_type)
+    util_abort("%s: wrong target type in file (expected:%d  got:%d) - aborting \n",
+               __func__, target_type, file_type);
 
+}
+
+
+static void __fread_from_buffer(void * ptr,
+                                size_t element_size,
+                                size_t items,
+                                char ** buffer) {
+  int bytes = element_size * items;
+  memcpy(ptr, *buffer, bytes);
+  *buffer += bytes;
 }
 
 
 void enkf_util_fread_assert_target_type_from_buffer(char ** ptr , ert_impl_type target_type) {
   ert_impl_type file_type;
-  util_fread_from_buffer( &file_type , sizeof file_type , 1 , ptr);
-  if (file_type != target_type) 
-    util_abort("%s: wrong target type in file (expected:%d  got:%d)  - aborting \n",__func__ , target_type , file_type);
+  __fread_from_buffer(&file_type, sizeof file_type, 1 ,ptr);
+  if (file_type != target_type)
+    util_abort("%s: wrong target type in file (expected:%d  got:%d) - aborting \n",
+                 __func__, target_type, file_type);
 }
 
 

--- a/libenkf/src/enkf_util.c
+++ b/libenkf/src/enkf_util.c
@@ -100,7 +100,7 @@ void enkf_util_truncate(void * void_data , int size , ecl_data_type data_type , 
 
 
 void enkf_util_assert_buffer_type(buffer_type * buffer, ert_impl_type target_type) {
-  ert_impl_type file_type;
+  ert_impl_type file_type = INVALID;
   file_type = buffer_fread_int(buffer);
   if (file_type != target_type)
     util_abort("%s: wrong target type in file (expected:%d  got:%d) - aborting \n",
@@ -109,22 +109,20 @@ void enkf_util_assert_buffer_type(buffer_type * buffer, ert_impl_type target_typ
 }
 
 
-static void __fread_from_buffer(void * ptr,
-                                size_t element_size,
-                                size_t items,
-                                char ** buffer) {
-  int bytes = element_size * items;
-  memcpy(ptr, *buffer, bytes);
-  *buffer += bytes;
+static void fread_file_type(ert_impl_type * file_type,
+                            char ** buffer) {
+  size_t size = sizeof *file_type;
+  memcpy(file_type, *buffer, size);
+  *buffer += size;
 }
 
-
-void enkf_util_fread_assert_target_type_from_buffer(char ** ptr , ert_impl_type target_type) {
-  ert_impl_type file_type;
-  __fread_from_buffer(&file_type, sizeof file_type, 1 ,ptr);
-  if (file_type != target_type)
+void enkf_util_fread_assert_target_type_from_buffer(char ** buffer,
+                                                    ert_impl_type target_type) {
+  ert_impl_type file_type = INVALID;
+  fread_file_type(&file_type, buffer);
+  if (file_type != target_type) // FIXME flaky runpath_list test
     util_abort("%s: wrong target type in file (expected:%d  got:%d) - aborting \n",
-                 __func__, target_type, file_type);
+               __func__, target_type, file_type);
 }
 
 

--- a/libenkf/src/summary.c
+++ b/libenkf/src/summary.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'summary.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'summary.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <stdlib.h>
@@ -24,7 +24,7 @@
 #include <ert/util/double_vector.h>
 
 #include <ert/ecl/ecl_sum.h>
-#include <ert/ecl/ecl_smspec.h> 
+#include <ert/ecl/ecl_smspec.h>
 #include <ert/ecl/ecl_file.h>
 
 #include <ert/enkf/enkf_types.h>
@@ -42,9 +42,9 @@
 #define SUMMARY_UNDEF -9999
 
 struct summary_struct {
-  int                          __type_id;         /* Only used for run_time checking. */
-  summary_config_type        * config;            /* Can not be NULL - var_type is set on first load. */
-  double_vector_type         * data_vector;
+  int                   __type_id;   /* Only used for run_time checking. */
+  summary_config_type * config;      /* Can not be NULL - var_type is set on first load. */
+  double_vector_type  * data_vector;
 };
 
 
@@ -52,13 +52,16 @@ struct summary_struct {
 
 
 
-static double SUMMARY_GET_VALUE( const summary_type * summary , int report_step) {
-  return double_vector_iget( summary->data_vector , report_step );
+static double SUMMARY_GET_VALUE( const summary_type * summary,
+                                 int report_step) {
+  return double_vector_iget( summary->data_vector, report_step );
 }
 
 
-static void SUMMARY_SET_VALUE( summary_type * summary , int report_step , double value) {
-  double_vector_iset( summary->data_vector , report_step , value);
+static void SUMMARY_SET_VALUE( summary_type * summary,
+                               int report_step,
+                               double value) {
+  double_vector_iset( summary->data_vector, report_step, value);
 }
 
 /*****************************************************************/
@@ -74,7 +77,7 @@ summary_type * summary_alloc(const summary_config_type * summary_config) {
   summary_type * summary   = util_malloc(sizeof *summary );
   summary->__type_id       = SUMMARY;
   summary->config          = (summary_config_type *) summary_config;
-  summary->data_vector     = double_vector_alloc(0 , SUMMARY_UNDEF);
+  summary->data_vector     = double_vector_alloc(0, SUMMARY_UNDEF);
   return summary;
 }
 
@@ -89,9 +92,9 @@ bool summary_active_value( double value ) {
 }
 
 
-void summary_copy(const summary_type *src , summary_type * target) {
+void summary_copy(const summary_type *src, summary_type * target) {
   if (src->config == target->config)
-    double_vector_memcpy( target->data_vector , src->data_vector );
+    double_vector_memcpy( target->data_vector, src->data_vector );
   else
     util_abort("%s: do not share config objects \n",__func__);
 }
@@ -99,21 +102,27 @@ void summary_copy(const summary_type *src , summary_type * target) {
 
 
 
-void summary_read_from_buffer(summary_type * summary , buffer_type * buffer, enkf_fs_type * fs, int report_step) {
-  enkf_util_assert_buffer_type( buffer , SUMMARY );
-  double_vector_buffer_fread( summary->data_vector , buffer );
+void summary_read_from_buffer(summary_type * summary,
+                              buffer_type * buffer,
+                              enkf_fs_type * fs,
+                              int report_step) {
+  enkf_util_assert_buffer_type( buffer, SUMMARY );
+  double_vector_buffer_fread( summary->data_vector, buffer );
 }
 
 
-bool summary_write_to_buffer(const summary_type * summary , buffer_type * buffer, int report_step) {
-  buffer_fwrite_int( buffer , SUMMARY );
-  double_vector_buffer_fwrite( summary->data_vector , buffer );
+bool summary_write_to_buffer(const summary_type * summary,
+                             buffer_type * buffer,
+                             int report_step) {
+  buffer_fwrite_int( buffer, SUMMARY );
+  double_vector_buffer_fwrite( summary->data_vector, buffer );
   return true;
 }
 
 
-bool summary_has_data( const summary_type * summary , int report_step) {
-  return (double_vector_size( summary->data_vector ) > report_step) ? true : false;
+bool summary_has_data( const summary_type * summary,
+                       int report_step) {
+  return double_vector_size(summary->data_vector) > report_step;
 }
 
 
@@ -123,20 +132,26 @@ void summary_free(summary_type *summary) {
 }
 
 
-
-
-
-
-void summary_serialize(const summary_type * summary , node_id_type node_id , const active_list_type * active_list , matrix_type * A , int row_offset , int column) {
-  double value = SUMMARY_GET_VALUE( summary , node_id.report_step );
-  enkf_matrix_serialize( &value , 1 , ECL_DOUBLE , active_list , A , row_offset , column);
+void summary_serialize(const summary_type * summary,
+                       node_id_type node_id,
+                       const active_list_type * active_list,
+                       matrix_type * A,
+                       int row_offset,
+                       int column) {
+  double value = SUMMARY_GET_VALUE( summary, node_id.report_step );
+  enkf_matrix_serialize( &value, 1, ECL_DOUBLE, active_list, A, row_offset, column);
 }
 
 
-void summary_deserialize(summary_type * summary , node_id_type node_id , const active_list_type * active_list , const matrix_type * A , int row_offset , int column) {
+void summary_deserialize(summary_type * summary,
+                         node_id_type node_id,
+                         const active_list_type * active_list,
+                         const matrix_type * A,
+                         int row_offset,
+                         int column) {
   double value;
-  enkf_matrix_deserialize( &value , 1 , ECL_DOUBLE , active_list , A , row_offset , column);
-  SUMMARY_SET_VALUE( summary , node_id.report_step , value );
+  enkf_matrix_deserialize( &value, 1, ECL_DOUBLE, active_list, A, row_offset, column);
+  SUMMARY_SET_VALUE( summary, node_id.report_step, value );
 }
 
 int summary_length(const summary_type * summary) {
@@ -144,13 +159,16 @@ int summary_length(const summary_type * summary) {
 }
 
 double summary_get(const summary_type * summary, int report_step) {
-  return SUMMARY_GET_VALUE( summary , report_step );
+  return SUMMARY_GET_VALUE( summary, report_step );
 }
 
 
-bool summary_user_get(const summary_type * summary , const char * index_key , int report_step , double * value) {
+bool summary_user_get(const summary_type * summary,
+                      const char * index_key,
+                      int report_step,
+                      double * value) {
   if (double_vector_size( summary->data_vector ) > report_step) {
-    *value = double_vector_iget( summary->data_vector , report_step);
+    *value = double_vector_iget( summary->data_vector, report_step);
     return true;
   } else {
     *value = -1;
@@ -160,8 +178,10 @@ bool summary_user_get(const summary_type * summary , const char * index_key , in
 
 
 
-void summary_user_get_vector(const summary_type * summary , const char * index_key , double_vector_type * value) {
-  double_vector_memcpy( value , summary->data_vector);
+void summary_user_get_vector(const summary_type * summary,
+                             const char * index_key,
+                             double_vector_type * value) {
+  double_vector_memcpy( value, summary->data_vector);
 }
 
 
@@ -177,13 +197,15 @@ void summary_user_get_vector(const summary_type * summary , const char * index_k
    signaling that the simulation has failed. In the last case we check
    the required flag of the variable, and if this is set to false we
    return true. This is done because this is a typical situation for
-   e.g. a well which has not yet opened.  
+   e.g. a well which has not yet opened.
 */
 
-bool summary_forward_load(summary_type * summary , const char * ecl_file_name , const forward_load_context_type * load_context) {
+bool summary_forward_load(summary_type * summary,
+                          const char * ecl_file_name,
+                          const forward_load_context_type * load_context) {
   bool loadOK = false;
   double load_value;
-  int report_step                    = forward_load_context_get_load_step( load_context );
+  int report_step              = forward_load_context_get_load_step( load_context );
   const ecl_sum_type * ecl_sum = forward_load_context_get_ecl_sum( load_context );
   if (ecl_sum != NULL) {
     const char * var_key               = summary_config_get_var(summary->config);
@@ -240,17 +262,17 @@ bool summary_forward_load(summary_type * summary , const char * ecl_file_name , 
   } 
   
   if (loadOK)
-    SUMMARY_SET_VALUE( summary , report_step , load_value );
-  
+    SUMMARY_SET_VALUE( summary, report_step, load_value );
+
   return loadOK;
 }
 
 
 
-bool summary_forward_load_vector(summary_type * summary , 
-				 const char * ecl_file_name , 
-				 const forward_load_context_type * load_context , 
-				 const int_vector_type * time_index) {
+bool summary_forward_load_vector(summary_type * summary,
+                                 const char * ecl_file_name,
+                                 const forward_load_context_type * load_context,
+                                 const int_vector_type * time_index) {
   bool loadOK = false;
 
   const ecl_sum_type * ecl_sum = forward_load_context_get_ecl_sum( load_context );
@@ -309,14 +331,27 @@ bool summary_forward_load_vector(summary_type * summary ,
 
 
 
+    if (summary_index >= 0) {
+      if (ecl_sum_has_report_step( ecl_sum, summary_index )) {
+        int last_ministep_index = ecl_sum_iget_report_end( ecl_sum, summary_index );
+        double_vector_iset( summary->data_vector,
+                            store_index,
+                            ecl_sum_iget(ecl_sum,
+                                         last_ministep_index,
+                                         key_index ));
+      }
+    }
+  }
+  return true;
 
+}
 
 
 /******************************************************************/
-/* Anonumously generated functions used by the enkf_node object   */
+/* Anonymously generated functions used by the enkf_node object   */
 /******************************************************************/
-UTIL_SAFE_CAST_FUNCTION(summary , SUMMARY)
-UTIL_SAFE_CAST_FUNCTION_CONST(summary , SUMMARY)
+UTIL_SAFE_CAST_FUNCTION(summary, SUMMARY)
+UTIL_SAFE_CAST_FUNCTION_CONST(summary, SUMMARY)
 VOID_ALLOC(summary)
 VOID_FREE(summary)
 VOID_COPY     (summary)

--- a/libenkf/src/surface.c
+++ b/libenkf/src/surface.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'surface.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'surface.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <stdlib.h>
@@ -37,33 +37,31 @@
 
 
 struct surface_struct {
-  int                          __type_id;     /* Only used for run_time checking. */
-  surface_config_type        * config;        /* Can not be NULL - var_type is set on first load. */
-  double                     * data;          /* Size is always one - but what the fuck ... */
+  int                   __type_id; /* Only used for run_time checking. */
+  surface_config_type * config;    /* Can not be NULL - var_type is set on first load. */
+  double              * data;      /* Size is always one - but what the fuck ... */
 };
 
 
-
-
 void surface_clear(surface_type * surface) {
-  const int data_size = surface_config_get_data_size( surface->config );
+  const int data_size = surface_config_get_data_size(surface->config);
   for (int k=0; k < data_size; k++)
     surface->data[k] = 0;
 }
 
-bool surface_fload( surface_type * surface , const char * filename ) {
-  bool ret = false; 
+
+bool surface_fload(surface_type * surface, const char * filename) {
+  bool ret = false;
   if (filename) {
-    const geo_surface_type * base_surface = surface_config_get_base_surface( surface->config );
-    ret = geo_surface_fload_irap_zcoord( base_surface , filename , surface->data );
+    const geo_surface_type * base_surface = surface_config_get_base_surface(surface->config);
+    ret = geo_surface_fload_irap_zcoord(base_surface, filename, surface->data);
   }
-  return ret; 
+  return ret;
 }
 
 
-
-bool surface_initialize(surface_type *surface , int iens , const char * filename , rng_type * rng) {
-  return surface_fload(surface , filename );
+bool surface_initialize(surface_type *surface, int iens, const char * filename, rng_type * rng) {
+  return surface_fload(surface, filename);
 }
 
 
@@ -72,18 +70,16 @@ surface_type * surface_alloc(const surface_config_type * surface_config) {
   surface->__type_id      = SURFACE;
   surface->config         = (surface_config_type *) surface_config;
   {
-    const int data_size = surface_config_get_data_size( surface_config );
-    surface->data       = util_calloc( data_size , sizeof * surface->data );
+    const int data_size = surface_config_get_data_size(surface_config);
+    surface->data       = util_calloc(data_size, sizeof * surface->data);
   }
   return surface;
 }
 
 
-
-
-void surface_copy(const surface_type *src , surface_type * target) {
+void surface_copy(const surface_type *src, surface_type * target) {
   if (src->config == target->config) {
-    const int data_size = surface_config_get_data_size( src->config );
+    const int data_size = surface_config_get_data_size(src->config);
     for (int k=0; k < data_size; k++)
       target->data[k] = src->data[k];
   } else
@@ -91,23 +87,17 @@ void surface_copy(const surface_type *src , surface_type * target) {
 }
 
 
-
-
-void surface_read_from_buffer(surface_type * surface , buffer_type * buffer, enkf_fs_type * fs, int report_step) {
-  int  size = surface_config_get_data_size( surface->config );
-  enkf_util_assert_buffer_type( buffer , SURFACE );
-  buffer_fread( buffer , surface->data , sizeof * surface->data , size);
+void surface_read_from_buffer(surface_type * surface, buffer_type * buffer, enkf_fs_type * fs, int report_step) {
+  int size = surface_config_get_data_size(surface->config);
+  enkf_util_assert_buffer_type(buffer, SURFACE);
+  buffer_fread(buffer, surface->data, sizeof * surface->data, size);
 }
 
 
-
-
-
-
-bool surface_write_to_buffer(const surface_type * surface , buffer_type * buffer, int report_step) {
-  int  size = surface_config_get_data_size( surface->config );
-  buffer_fwrite_int( buffer , SURFACE );
-  buffer_fwrite( buffer , surface->data , sizeof * surface->data , size);
+bool surface_write_to_buffer(const surface_type * surface, buffer_type * buffer, int report_step) {
+  int size = surface_config_get_data_size(surface->config);
+  buffer_fwrite_int(buffer, SURFACE);
+  buffer_fwrite(buffer, surface->data, sizeof * surface->data, size);
   return true;
 }
 
@@ -118,98 +108,123 @@ void surface_free(surface_type *surface) {
 }
 
 
-
-
-void surface_serialize(const surface_type * surface , node_id_type node_id , const active_list_type * active_list , matrix_type * A , int row_offset , int column) {
+void surface_serialize(const surface_type * surface,
+                       node_id_type node_id,
+                       const active_list_type * active_list,
+                       matrix_type * A,
+                       int row_offset,
+                       int column) {
   const surface_config_type *config  = surface->config;
-  const int                data_size = surface_config_get_data_size(config );
-  
-  enkf_matrix_serialize( surface->data , data_size , ECL_DOUBLE , active_list , A , row_offset , column);
+  const int                data_size = surface_config_get_data_size(config);
+
+  enkf_matrix_serialize(surface->data,
+                         data_size,
+                         ECL_DOUBLE,
+                         active_list,
+                         A,
+                         row_offset,
+                         column);
 }
 
 
 
-void surface_deserialize(surface_type * surface , node_id_type node_id , const active_list_type * active_list , const matrix_type * A , int row_offset , int column) {
+void surface_deserialize(surface_type * surface,
+                         node_id_type node_id,
+                         const active_list_type * active_list,
+                         const matrix_type * A,
+                         int row_offset,
+                         int column) {
   const surface_config_type *config  = surface->config;
-  const int                data_size = surface_config_get_data_size(config );
-  
-  enkf_matrix_deserialize( surface->data , data_size , ECL_DOUBLE , active_list , A , row_offset , column);
+  const int                data_size = surface_config_get_data_size(config);
+
+  enkf_matrix_deserialize(surface->data,
+                           data_size,
+                           ECL_DOUBLE,
+                           active_list,
+                           A,
+                           row_offset,
+                           column);
 }
 
 
-void surface_ecl_write(const surface_type * surface , const char * run_path , const char * base_file , void * filestream) {
-  char * target_file = util_alloc_filename( run_path , base_file  , NULL);
-  surface_config_ecl_write( surface->config , target_file , surface->data );
-  free( target_file );
+void surface_ecl_write(const surface_type * surface,
+                       const char * run_path,
+                       const char * base_file,
+                       void * filestream) {
+  char * target_file = util_alloc_filename(run_path, base_file , NULL);
+  surface_config_ecl_write(surface->config, target_file, surface->data);
+  free(target_file);
 }
 
 
-bool surface_user_get(const surface_type * surface , const char * index_key , int report_step , double * value) {
-  const int                data_size = surface_config_get_data_size( surface->config );
+bool surface_user_get(const surface_type * surface,
+                      const char * index_key,
+                      int report_step,
+                      double * value) {
+  const int data_size = surface_config_get_data_size(surface->config);
   int index;
 
   *value = 0.0;
 
-  if (util_sscanf_int( index_key , &index)) 
+  if (util_sscanf_int(index_key, &index))
     if ((index >= 0) && (index < data_size)) {
       *value = surface->data[index];
       return true;
     }
-  
+
   // Not valid
   return false;
 }
 
 
 
-void surface_set_inflation(surface_type * inflation , const surface_type * std , const surface_type * min_std) {
+void surface_set_inflation(surface_type * inflation,
+                           const surface_type * std,
+                           const surface_type * min_std) {
   int size = 1;
-  for (int i = 0; i < size; i++) 
-    inflation->data[i] = util_double_max( 1.0 , min_std->data[i] / std->data[i]);
+  for (int i = 0; i < size; i++)
+    inflation->data[i] = util_double_max(1.0, min_std->data[i] / std->data[i]);
 }
 
 
-void surface_iadd( surface_type * surface , const surface_type * delta) {
+void surface_iadd(surface_type * surface, const surface_type * delta) {
   int size = 1;
-  for (int i = 0; i < size; i++) 
+  for (int i = 0; i < size; i++)
     surface->data[i] += delta->data[i];
 }
 
 
-void surface_iaddsqr( surface_type * surface , const surface_type * delta) {
+void surface_iaddsqr(surface_type * surface, const surface_type * delta) {
   int size = 1;
-  for (int i = 0; i < size; i++) 
+  for (int i = 0; i < size; i++)
     surface->data[i] += delta->data[i] * delta->data[i];
 }
 
 
-void surface_imul( surface_type * surface , const surface_type * delta) {
+void surface_imul(surface_type * surface, const surface_type * delta) {
   int size = 1;
-  for (int i = 0; i < size; i++) 
+  for (int i = 0; i < size; i++)
     surface->data[i] *= delta->data[i];
 }
 
-void surface_scale( surface_type * surface , double scale_factor) {
+void surface_scale(surface_type * surface, double scale_factor) {
   int size = 1;
-  for (int i = 0; i < size; i++) 
+  for (int i = 0; i < size; i++)
     surface->data[i] *= scale_factor;
 }
 
-void surface_isqrt( surface_type * surface ) {
+void surface_isqrt(surface_type * surface) {
   int size = 1;
-  for (int i = 0; i < size; i++) 
-    surface->data[i] = sqrt( surface->data[i] );
+  for (int i = 0; i < size; i++)
+    surface->data[i] = sqrt(surface->data[i]);
 }
 
 
-
-
-
 /******************************************************************/
-/* Anonumously generated functions used by the enkf_node object   */
+/* Anonymously generated functions used by the enkf_node object   */
 /******************************************************************/
-UTIL_SAFE_CAST_FUNCTION(surface , SURFACE)
-UTIL_SAFE_CAST_FUNCTION_CONST(surface , SURFACE)
+UTIL_SAFE_CAST_FUNCTION(surface, SURFACE)
+UTIL_SAFE_CAST_FUNCTION_CONST(surface, SURFACE)
 VOID_ALLOC(surface)
 VOID_FREE(surface)
 VOID_ECL_WRITE(surface)
@@ -227,4 +242,4 @@ VOID_SCALE(surface)
 VOID_IMUL(surface)
 VOID_IADDSQR(surface)
 VOID_ISQRT(surface)
-VOID_FLOAD(surface)     
+VOID_FLOAD(surface)

--- a/libjob_queue/src/forward_model.c
+++ b/libjob_queue/src/forward_model.c
@@ -240,7 +240,7 @@ static void forward_model_json_fprintf(const forward_model_type * forward_model,
 
   fprintf(stream, "\n\"ert_version\" : [%d, %d, \"%s\"],\n", version_get_major_ert_version(), version_get_minor_ert_version(), version_get_micro_ert_version());
   fprintf(stream, "\"run_id\" : \"%s\",\n", run_id);
-  fprintf(stream, "\"ert_pid\" : \"%ld\"\n", getpid()); //Long is big enough to hold __pid_t
+  fprintf(stream, "\"ert_pid\" : \"%ld\"\n", (long)getpid()); //Long is big enough to hold __pid_t
   fprintf(stream, "}\n");
   fclose(stream);
   free(json_file);


### PR DESCRIPTION
**Task**

In search of the flaky runpath list test, I have refactored and given some love to code related to the call path of that test.

But one thing has specifically been done in that respect, that is, moved `util_fread_from_buffer` from libecl and into call point, and initialized a variable
```c
  ert_impl_type file_type = INVALID;
```
See Statoil/libecl#148 for the code that has been moved here.

**Approach**
Refactor and clean up


**Pre un-WIP checklist**
- [X] Statoil tests pass locally
- [X] Have completed graphical integration test steps