### PR TITLE
Fix fprintf() warning.

### DIFF
--- a/libconfig/tests/config_typeFail.c
+++ b/libconfig/tests/config_typeFail.c
@@ -26,7 +26,7 @@
 
 
 void error(char * msg) {
-  fprintf(stderr , msg);
+  fprintf(stderr , "%s" , msg);
   exit(1);
 }
 


### PR DESCRIPTION
**Task**
fprintf( ) created a warning.




