### PR TITLE
Test splitting for Travis parallelization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,12 +69,8 @@ install:
     - conda info -a
     - conda install pyqt=4 scipy=0.16.1 pylint numpy pandas matplotlib future
 
-env:
-  global:
-     - ERT_SHOW_BACKTRACE=1
-
 before_script:
   - wget https://raw.githubusercontent.com/Statoil/ert/master/travis/build_total.py
 
 script:
-  - python build_total.py res
+  - python build_total.py res ${TEST_SUITE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,34 @@
 language: c
 
+compiler:
+  - gcc
+  - clang
+
+os:
+  - linux
+  - osx
+
+osx_image: xcode7.3
+sudo: false
+dist: trusty
+
+env:
+  global:
+    - ERT_SHOW_BACKTRACE=1
+  matrix:
+    - TEST_SUITE="-LE SLOW"  # Run all tests not labeled as slow
+    - TEST_SUITE="-L SLOW_1" # Run all tests labeled as SLOW in group 1
+    - TEST_SUITE="-L SLOW_2" # Run all tests labeled as SLOW in group 2
+
 matrix:
   fast_finish: true
   allow_failures:
     - os: osx
-  include:
+  exclude:
     - os: osx
-      osx_image: xcode7.3
-      compiler: clang
-    - os: linux
       compiler: gcc
+    - os: linux
+      compiler: clang
 
 addons:
   apt:

--- a/libjob_queue/CMakeLists.txt
+++ b/libjob_queue/CMakeLists.txt
@@ -121,6 +121,7 @@ target_link_libraries(job_queue_test job_queue)
 add_test(NAME job_queue_test
          COMMAND job_queue_test
                  $<TARGET_FILE:job_program_output>)
+set_tests_properties(job_queue_test PROPERTIES LABELS "SLOW_1")
 
 add_executable(job_queue_stress_task tests/job_queue_stress_task.c)
 target_link_libraries(job_queue_stress_task ecl)
@@ -131,6 +132,8 @@ add_test(NAME job_queue_stress_test
          COMMAND job_queue_stress_test
                  $<TARGET_FILE:job_queue_stress_task>
                  False)
+set_tests_properties(job_queue_stress_test PROPERTIES LABELS "SLOW_1")
+
 add_test(NAME job_queue_user_exit
          COMMAND job_queue_stress_test
                  $<TARGET_FILE:job_queue_stress_task>

--- a/python/tests/res/enkf/data/CMakeLists.txt
+++ b/python/tests/res/enkf/data/CMakeLists.txt
@@ -11,7 +11,7 @@ set(TEST_SOURCES
 
 add_python_package("python.tests.res.enkf.data" ${PYTHON_INSTALL_PREFIX}/tests/res/enkf/data "${TEST_SOURCES}" False)
 
-addPythonTest(tests.res.enkf.data.test_custom_kw.CustomKWTest)
+addPythonTest(tests.res.enkf.data.test_custom_kw.CustomKWTest LABELS SLOW_1)
 addPythonTest(tests.res.enkf.data.test_gen_kw.GenKwTest)
 
 if (STATOIL_TESTDATA_ROOT)

--- a/python/tests/res/server/CMakeLists.txt
+++ b/python/tests/res/server/CMakeLists.txt
@@ -7,6 +7,6 @@ set(TEST_SOURCES
 
 add_python_package("python.tests.res.server" ${PYTHON_INSTALL_PREFIX}/tests/res/server "${TEST_SOURCES}" False)
 
-addPythonTest(tests.res.server.test_simulation_context.SimulationContextTest)
-addPythonTest(tests.res.server.test_rpc_service.RPCServiceTest)
-addPythonTest(tests.res.server.test_rpc_storage.RPCStorageTest)
+addPythonTest(tests.res.server.test_simulation_context.SimulationContextTest LABELS SLOW_2)
+addPythonTest(tests.res.server.test_rpc_service.RPCServiceTest LABELS SLOW_2)
+addPythonTest(tests.res.server.test_rpc_storage.RPCStorageTest LABELS SLOW_1)


### PR DESCRIPTION
**Task**
Travis does not have more than one core available for running build and test, but it is, however, possible to run multiple builds in parallel. This PR adds tags to the build and test process so that Travis can run them simultaneously.

**Depends on**
* Statoil/libecl#149