### PR TITLE
Added "drop constant columns" option to the CSV export

### DIFF
--- a/share/workflows/jobs/internal-gui/config/CSV_EXPORT
+++ b/share/workflows/jobs/internal-gui/config/CSV_EXPORT
@@ -1,7 +1,7 @@
 INTERNAL    True
 SCRIPT      ../scripts/csv_export.py
 MIN_ARG     1
-MAX_ARG     4
+MAX_ARG     5
 ARG_TYPE    0  STRING
 ARG_TYPE    1  STRING
 ARG_TYPE    2  STRING

--- a/share/workflows/jobs/internal-gui/config/GEN_DATA_RFT_CSV_EXPORT
+++ b/share/workflows/jobs/internal-gui/config/GEN_DATA_RFT_CSV_EXPORT
@@ -1,7 +1,7 @@
 INTERNAL    True
 SCRIPT      ../scripts/gen_data_rft_export.py
 MIN_ARG     2
-MAX_ARG     4
+MAX_ARG     5
 ARG_TYPE    0  STRING
 ARG_TYPE    1  STRING
 ARG_TYPE    2  STRING


### PR DESCRIPTION
When using the CSV export (ERT plugins), a checkbox now allows to exclude columns whose value is the same for every entry

I couldn't test this appropriately since I don't have suitable data

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps