### PR TITLE
Add "application":"ert" to logged json

### DIFF
--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -336,6 +336,8 @@ class JobManager(object):
 
         payload = {"user": self.user,
                    "cwd": os.getcwd(),
+                   "application": "ert",
+                   "subsystem": "ert_forward_model",
                    "file_server": self.isilon_node,
                    "node": self.node,
                    "start_time": self.start_time.isoformat(),


### PR DESCRIPTION
Add  "application":"ert" to logged json so we can filter on ert in the central log.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
