### PR TITLE
Changing LOG_LEVEL from int to string

### DIFF
--- a/test-data/local/snake_oil_structure/ert/model/user_config.ert
+++ b/test-data/local/snake_oil_structure/ert/model/user_config.ert
@@ -27,7 +27,7 @@ RUNPATH_FILE        ../output/run_path_file/.ert-runpath-list_<CASE_DIR>  -- Ert
  
 REFCASE             ../input/refcase/SNAKE_OIL_FIELD                      -- Used for plotting and neccessary for AHM for reading historical production, files needed by ert: .SMSPEC and .UNSMRY
 
-LOG_LEVEL           3
+LOG_LEVEL           INFO
 UPDATE_LOG_PATH     ../output/update_log/<CASE_DIR>                       -- Storage of update log (list of active and inactive data points)
 LOG_FILE            ../output/log/ert_<CASE_DIR>.log                      -- Ert log file
 


### PR DESCRIPTION
**Task**
This little file was left unchanged from previous commits, and use old log-level indicators. Causes unnecessary deprecation warnings on tests. 

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
