### PR TITLE
Include res_util/res_log to remove warning

### DIFF
--- a/libenkf/src/enkf_main_jobs.c
+++ b/libenkf/src/enkf_main_jobs.c
@@ -22,6 +22,7 @@
 #include <ert/util/string_util.h>
 #include <ert/util/int_vector.h>
 
+#include <ert/res_util/res_log.h>
 #include <ert/enkf/enkf_main.h>
 #include <ert/enkf/field_config.h>
 #include <ert/enkf/local_obsdata.h>


### PR DESCRIPTION
**Task**

626a7cf8 calls `res_log_add_message` in `enkf_main_jobs.c` but without including the headers.

Include header
```c
#include <ert/res_util/res_log.h>
```
