### PR TITLE
Queue options

### DIFF
--- a/libconfig/src/config_parser.c
+++ b/libconfig/src/config_parser.c
@@ -426,7 +426,7 @@ static void config_validate(config_parser_type * config, config_content_type * c
 
    These are not strict rules - it is possible to get other things to
    work as well, but the problem is that it very quickly becomes
-   dependant on 'arbitrariness' in the parsing configuration.
+   dependent on 'arbitrariness' in the parsing configuration.
 
    validate: whether we should validate when complete, that should
              typically only be done at the last parsing.

--- a/libjob_queue/include/ert/job_queue/queue_driver.h
+++ b/libjob_queue/include/ert/job_queue/queue_driver.h
@@ -123,6 +123,7 @@ extern "C" {
   const char * queue_driver_get_name(const queue_driver_type * driver);
 
   bool queue_driver_set_option(queue_driver_type * driver, const char * option_key, const void * value);
+  bool queue_driver_unset_option(queue_driver_type * driver, const char * option_key);
   const void * queue_driver_get_option(queue_driver_type * driver, const char * option_key);
   void queue_driver_init_option_list(queue_driver_type * driver, stringlist_type * option_list);
 

--- a/libjob_queue/src/queue_driver.c
+++ b/libjob_queue/src/queue_driver.c
@@ -124,6 +124,16 @@ static bool queue_driver_set_generic_option__(queue_driver_type * driver, const 
   return option_set;
 }
 
+static bool queue_driver_unset_generic_option__(queue_driver_type * driver, const char * option_key) {
+  bool option_unset = false;
+  if (strcmp(MAX_RUNNING, option_key) == 0) {
+    queue_driver_set_max_running(driver, 0);
+    option_unset = true;
+  }
+  return option_unset;
+}
+
+
 static void * queue_driver_get_generic_option__(queue_driver_type * driver, const char * option_key) {
   if (strcmp(MAX_RUNNING, option_key) == 0) {
     return driver->max_running_string;
@@ -156,6 +166,23 @@ bool queue_driver_set_option(queue_driver_type * driver, const char * option_key
   }
   return false;
 }
+
+/**
+   Unset the given option. If the option cannot be unset, it is restored to its default value.
+ */
+bool queue_driver_unset_option(queue_driver_type * driver, const char * option_key) {
+  if (queue_driver_unset_generic_option__(driver, option_key)) {
+    return true;
+  } else if (driver->set_option != NULL)
+    /* The actual low level set functions can not fail! */
+    return driver->set_option(driver->data, option_key, NULL);
+  else {
+    util_abort("%s: driver:%s does not support run time setting of options\n", __func__, driver->name);
+    return false;
+  }
+  return false;
+}
+
 
 
 /**

--- a/libjob_queue/tests/job_lsf_test.c
+++ b/libjob_queue/tests/job_lsf_test.c
@@ -39,14 +39,31 @@ void test_status(int lsf_status , job_status_type job_status) {
 void test_options(void) {
   lsf_driver_type * driver = lsf_driver_alloc();
   test_assert_false( lsf_driver_has_project_code( driver ));
+
+  // test setting values
   test_option( driver , LSF_BSUB_CMD    , "Xbsub");
   test_option( driver , LSF_BJOBS_CMD   , "Xbsub");
   test_option( driver , LSF_BKILL_CMD   , "Xbsub");
   test_option( driver , LSF_RSH_CMD     , "RSH");
   test_option( driver , LSF_LOGIN_SHELL , "shell");
   test_option( driver , LSF_BSUB_CMD    , "bsub");
-  test_option( driver , LSF_PROJECT_CODE    , "my-ppu");
+  test_option( driver , LSF_PROJECT_CODE, "my-ppu");
+  test_option( driver , LSF_BJOBS_TIMEOUT, "1234");
+
   test_assert_true( lsf_driver_has_project_code( driver ));
+
+  // test unsetting/resetting options to default values
+  test_option( driver , LSF_BSUB_CMD    , NULL);
+  test_option( driver , LSF_BJOBS_CMD   , NULL);
+  test_option( driver , LSF_BKILL_CMD   , NULL);
+  test_option( driver , LSF_RSH_CMD     , NULL);
+  test_option( driver , LSF_LOGIN_SHELL , NULL);
+  test_option( driver , LSF_PROJECT_CODE, NULL);
+
+  // Setting NULL to numerical options should leave the value unchanged
+  lsf_driver_set_option( driver, LSF_BJOBS_TIMEOUT, NULL);
+  test_assert_string_equal( lsf_driver_get_option( driver, LSF_BJOBS_TIMEOUT ), "1234");
+
   lsf_driver_free( driver );
 }
 

--- a/libjob_queue/tests/job_torque_test.c
+++ b/libjob_queue/tests/job_torque_test.c
@@ -52,6 +52,21 @@ void setoption_setalloptions_optionsset() {
   test_assert_true( torque_driver_set_option( driver , TORQUE_DEBUG_OUTPUT , "/tmp/torqueue_debug.txt"));
   test_assert_not_NULL( torque_driver_get_debug_stream(driver) );
 
+  test_option(driver, TORQUE_QSUB_CMD      , NULL);
+  test_option(driver, TORQUE_QSTAT_CMD     , NULL);
+  test_option(driver, TORQUE_QDEL_CMD      , NULL);
+  test_option(driver, TORQUE_QUEUE         , NULL);
+  test_option(driver, TORQUE_CLUSTER_LABEL , NULL);
+  test_option(driver, TORQUE_JOB_PREFIX_KEY, NULL);
+
+  // Setting NULL to numerical options should leave the value unchanged
+  torque_driver_set_option(driver, TORQUE_NUM_CPUS_PER_NODE, NULL);
+  torque_driver_set_option(driver, TORQUE_NUM_NODES        , NULL);
+  torque_driver_set_option(driver, TORQUE_KEEP_QSUB_OUTPUT , NULL);
+  test_assert_string_equal( torque_driver_get_option( driver, TORQUE_NUM_CPUS_PER_NODE ), "42");
+  test_assert_string_equal( torque_driver_get_option( driver, TORQUE_NUM_NODES         ), "36");
+  test_assert_string_equal( torque_driver_get_option( driver, TORQUE_KEEP_QSUB_OUTPUT  ), "0");
+
   printf("Options OK\n");
   torque_driver_free(driver);
 }


### PR DESCRIPTION
**Task**
Allow to unset keywords in ert config files


**Approach**
If QUEUE_OPTIONS is specified with only 2 parameters (instead of 3), NULL is passed to the underlying driver set() method


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

