### PR TITLE
Remove some network-log calls

### DIFF
--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -225,7 +225,6 @@ class JobManager(object):
         with open(self.STATUS_file, "a") as f:
             now = time.localtime()
             f.write("%-32s: %02d:%02d:%02d .... " % (job["name"], now.tm_hour, now.tm_min, now.tm_sec))
-        self.postMessage(job=job, extra_fields={"status": "startStatus"})
 
 
     def completeStatus(self, exit_status, error_msg, job=None):
@@ -236,11 +235,9 @@ class JobManager(object):
         with open(self.STATUS_file, "a") as f:
             if exit_status == 0:
                 status = ""
-                self.postMessage(job=job, extra_fields=extra_fields)
             else:
                 status = " EXIT: %d/%s" % (exit_status, error_msg)
                 extra_fields.update({"error_msg": error_msg})
-                self.postMessage(job=job, extra_fields=extra_fields)
 
             f.write("%02d:%02d:%02d  %s\n" % (now.tm_hour, now.tm_min, now.tm_sec, status))
 
@@ -409,13 +406,10 @@ class JobManager(object):
             f.write("%02d:%02d:%02d  Calling: %s %s\n" %
                     (now.tm_hour, now.tm_min, now.tm_sec,
                      job.get('executable'), args))
-        self.postMessage(job=job,extra_fields={"status": "running"})
-
 
     def runJob(self, job):
         assert_file_executable(job.get('executable'))
         self.addLogLine(job)
-        self.postMessage(job=job, extra_fields={"status": "runJob", "finished": False})
         pid = os.fork()
         exit_status, err_msg = 0, ''
         if pid == 0:


### PR DESCRIPTION
The log-calls "runJob", "running", "startStatus", and "completeStatus"
were posted for every job, causing a lot more messages than needed. Now
we only keep post on init and OK/Exit.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
