### PR TITLE
WIP: Add log of LSB OS info, python and kernel

### DIFF
--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -18,7 +18,6 @@ import sys
 import os
 import signal
 import shutil
-import os.path
 import random
 from datetime import datetime as dt
 import time
@@ -28,6 +27,7 @@ import pwd
 import requests
 import json
 import imp
+from sys import version as sys_version
 
 def redirect(file, fd, open_mode):
     new_fd = os.open(file, open_mode)
@@ -93,6 +93,24 @@ def _jsonGet(data, key, err_msg=None):
         raise IOError(err_msg)
     return data[key]
 
+def _read_os_release(pfx='LSB_'):
+    fname = '/etc/os-release'
+    if not os.isfile(fname):
+        return {}
+    def processline(ln):
+        return ln.strip().replace('"', '')
+    def splitline(ln, pfx=''):
+        if ln.count('=') == 1:
+            k, v = ln.split('=')
+            return pfx+k, v
+        return None
+    props = {}
+    with open(fname, 'r') as f:
+        for line in f:
+            kv = splitline(processline(line), pfx=pfx)
+            if kv:
+                props[kv[0]] = kv[1]
+    return props
 
 class JobManager(object):
     LOG_file      = "JOB_LOG"
@@ -125,9 +143,16 @@ class JobManager(object):
 
         pw_entry = pwd.getpwuid(os.getuid())
         self.user = pw_entry.pw_name
+        os_info = _read_os_release()
+        _, _, release, _, _ = os.uname()
+        python_vs, _ = sys_version.split('\n')
         logged_fields= {"status": "init",
                         "python_sys_path": sys.path,
                         "pythonpath": os.environ.get('PYTHONPATH', ''),
+                        "LSB_ID": os_info.get('LSB_ID', ''),
+                        "LSB_VERSION_ID": os_info.get('LSB_VERSION_ID', ''),
+                        "python_version": python_vs,
+                        "kernel_version": release,
                         }
         logged_fields.update({"jobs": self._job_map.values()})
         self.postMessage(extra_fields=logged_fields)

--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -95,7 +95,7 @@ def _jsonGet(data, key, err_msg=None):
 
 def _read_os_release(pfx='LSB_'):
     fname = '/etc/os-release'
-    if not os.isfile(fname):
+    if not os.path.isfile(fname):
         return {}
     def processline(ln):
         return ln.strip().replace('"', '')


### PR DESCRIPTION
 Added  some logging of LSB version, python version and kernel version. Only works on Unix. Can be useful for debugging errors when upgrading OS. 

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
