### PR TITLE
Full config programmatically

### DIFF
--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(enkf src/active_list.c
                  src/trans_func.c
                  src/subst_config.c
                  src/log_config.c
+                 src/config_keys.c
 )
 
 target_include_directories(enkf

--- a/libenkf/include/ert/enkf/config_keys.h
+++ b/libenkf/include/ert/enkf/config_keys.h
@@ -154,7 +154,9 @@ extern "C" {
 #define  PLOT_SETTING_KEY                  "PLOT_SETTINGS"
 #define  UPDATE_SETTING_KEY                "UPDATE_SETTINGS"
 
-#define  CONFIG_DIRECTORY_KEY              "WORKING_DIRECTORY"
+#define  CONFIG_DIRECTORY_KEY              "CONFIG_DIRECTORY"
+#define  RES_CONFIG_FILE_KEY               "RES_CONFIG_FILE"
+
 
 #define CONFIG_BOOL_STRING( var ) (var) ? "TRUE" : "FALSE"
 

--- a/libenkf/src/config_keys.c
+++ b/libenkf/src/config_keys.c
@@ -1,0 +1,23 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   The file 'config_keys.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <ert/enkf/config_keys.h>
+
+const char * config_keys_get_config_directory_key() {
+  return CONFIG_DIRECTORY_KEY;
+}

--- a/libenkf/src/config_keys.c
+++ b/libenkf/src/config_keys.c
@@ -21,3 +21,7 @@
 const char * config_keys_get_config_directory_key() {
   return CONFIG_DIRECTORY_KEY;
 }
+
+const char * config_keys_get_queue_system_key() {
+  return QUEUE_SYSTEM_KEY;
+}

--- a/libenkf/src/config_keys.c
+++ b/libenkf/src/config_keys.c
@@ -25,3 +25,23 @@ const char * config_keys_get_config_directory_key() {
 const char * config_keys_get_queue_system_key() {
   return QUEUE_SYSTEM_KEY;
 }
+
+const char * config_keys_get_run_template_key() {
+  return RUN_TEMPLATE_KEY;
+}
+
+const char * config_keys_get_gen_kw_key() {
+  return GEN_KW_KEY;
+}
+
+const char * config_keys_get_queue_option_key() {
+  return QUEUE_OPTION_KEY;
+}
+
+const char * config_keys_get_install_job_key() {
+  return INSTALL_JOB_KEY;
+}
+
+const char * config_keys_get_plot_setting_key() {
+  return PLOT_SETTING_KEY;
+}

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -36,8 +36,6 @@
 #include <ert/enkf/model_config.h>
 #include <ert/enkf/log_config.h>
 
-#define  RES_CONFIG_FILE_KEY "RES_CONFIG_FILE"
-
 struct res_config_struct {
 
   char * user_config_file;

--- a/python/python/res/config/config_content.py
+++ b/python/python/res/config/config_content.py
@@ -157,6 +157,7 @@ class ConfigContent(BaseCClass):
     _get_warnings =  ConfigPrototype("stringlist_ref config_content_get_warnings( config_content )")
     _get_config_path = ConfigPrototype("char* config_content_get_config_path( config_content )")
     _create_path_elm = ConfigPrototype("config_path_elm_ref config_content_add_path_elm(config_content, char*)")
+    _add_define = ConfigPrototype("void config_content_add_define(config_content, char*, char*)")
 
     def __init__(self, filename):
         c_ptr = self._alloc(filename)
@@ -223,3 +224,6 @@ class ConfigContent(BaseCClass):
 
     def create_path_elm(self, path):
         return self._create_path_elm(path)
+
+    def add_define(self, key, value):
+        self._add_define(key, value)

--- a/python/python/res/enkf/CMakeLists.txt
+++ b/python/python/res/enkf/CMakeLists.txt
@@ -46,6 +46,7 @@ set(PYTHON_SOURCES
     forward_load_context.py
     es_update.py
     log_config.py
+    config_keys.py
 )
 
 add_python_package("python.res.enkf" ${PYTHON_INSTALL_PREFIX}/res/enkf "${PYTHON_SOURCES}" True)

--- a/python/python/res/enkf/__init__.py
+++ b/python/python/res/enkf/__init__.py
@@ -70,6 +70,7 @@ from .analysis_iter_config import AnalysisIterConfig
 from .analysis_config import AnalysisConfig
 from .ecl_config import EclConfig
 
+from .config_keys import ConfigKeys
 from .queue_config import QueueConfig
 from .site_config import SiteConfig
 from .subst_config import SubstConfig

--- a/python/python/res/enkf/config_keys.py
+++ b/python/python/res/enkf/config_keys.py
@@ -21,9 +21,32 @@ class ConfigKeys:
 
     _config_directory_key = EnkfPrototype("char* config_keys_get_config_directory_key()", bind=False)
     _queue_system_key     = EnkfPrototype("char* config_keys_get_queue_system_key()", bind=False)
+    _run_template_key     = EnkfPrototype("char* config_keys_get_run_template_key()", bind=False)
+    _gen_kw_key           = EnkfPrototype("char* config_keys_get_gen_kw_key()", bind=False)
+    _history_source_key   = EnkfPrototype("char* config_keys_get_history_source_key()", bind=False)
+    _queue_option_key     = EnkfPrototype("char* config_keys_get_queue_option_key()", bind=False)
+    _install_job_key      = EnkfPrototype("char* config_keys_get_install_job_key()", bind=False)
+    _plot_settings_key    = EnkfPrototype("char* config_keys_get_plot_setting_key()", bind=False)
+
 
     CONFIG_DIRECTORY = _config_directory_key()
     DEFINES          = "DEFINES"
     INTERNALS        = "INTERNALS"
     SIMULATION       = "SIMULATION"
+    LOGGING          = "LOGGING"
+    SEED             = "SEED"
     QUEUE_SYSTEM     = _queue_system_key()
+    RUN_TEMPLATE     = _run_template_key()
+    TEMPLATE         = "TEMPLATE"
+    EXPORT           = "EXPORT"
+    GEN_KW           = _gen_kw_key()
+    NAME             = "NAME"
+    OUT_FILE         = "OUT_FILE"
+    PARAMETER_FILE   = "PARAMETER_FILE"
+    PATH             = "PATH"
+    QUEUE_OPTION     = _queue_option_key()
+    DRIVER_NAME      = "DRIVER_NAME"
+    OPTION           = "OPTION"
+    VALUE            = "VALUE"
+    INSTALL_JOB      = _install_job_key()
+    PLOT_SETTINGS    = _plot_settings_key()

--- a/python/python/res/enkf/config_keys.py
+++ b/python/python/res/enkf/config_keys.py
@@ -1,0 +1,25 @@
+#  Copyright (C) 2017  Statoil ASA, Norway.
+#
+#  The file 'config_keys.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+from res.enkf import EnkfPrototype
+from enum import Enum
+
+class ConfigKeys:
+
+    _config_directory_key = EnkfPrototype("char* config_keys_get_config_directory_key()", bind=False)
+
+    CONFIG_DIRECTORY = _config_directory_key()
+    DEFINES          = "DEFINES"

--- a/python/python/res/enkf/config_keys.py
+++ b/python/python/res/enkf/config_keys.py
@@ -20,6 +20,10 @@ from enum import Enum
 class ConfigKeys:
 
     _config_directory_key = EnkfPrototype("char* config_keys_get_config_directory_key()", bind=False)
+    _queue_system_key     = EnkfPrototype("char* config_keys_get_queue_system_key()", bind=False)
 
     CONFIG_DIRECTORY = _config_directory_key()
     DEFINES          = "DEFINES"
+    INTERNALS        = "INTERNALS"
+    SIMULATION       = "SIMULATION"
+    QUEUE_SYSTEM     = _queue_system_key()

--- a/python/python/res/enkf/res_config.py
+++ b/python/python/res/enkf/res_config.py
@@ -25,7 +25,7 @@ from res.config import (ConfigParser, ConfigContent, ConfigSettings,
                         UnrecognizedEnum)
 from res.enkf import EnkfPrototype
 from res.enkf import (SiteConfig, AnalysisConfig, SubstConfig, ModelConfig, EclConfig,
-                      EnsembleConfig, RNGConfig)
+                      EnsembleConfig, RNGConfig, ConfigKeys)
 
 class ResConfig(BaseCClass):
 
@@ -97,15 +97,18 @@ class ResConfig(BaseCClass):
 
     def _build_config_content(self, config):
         self._failed_keys = {}
+
         config_parser  = ConfigParser()
         ResConfig.init_config_parser(config_parser)
-
         config_content = ConfigContent(None)
         config_content.setParser(config_parser)
 
-        config["WORKING_DIRECTORY"] = os.path.realpath(config["WORKING_DIRECTORY"])
-        path_elm = config_content.create_path_elm(config["WORKING_DIRECTORY"])
+        dir_key = ConfigKeys.CONFIG_DIRECTORY
+        if dir_key not in config:
+            raise ValueError("Expected config to specify %s" % dir_key)
+        config[dir_key] = os.path.realpath(config[dir_key])
 
+        path_elm = config_content.create_path_elm(config[dir_key])
         for key in config.keys():
             value = str(config[key]) # TODO: Support lists of arguments
             ok = config_parser.add_key_value(config_content,

--- a/python/python/res/enkf/res_config.py
+++ b/python/python/res/enkf/res_config.py
@@ -95,8 +95,24 @@ class ResConfig(BaseCClass):
                                       "available when loading from file.")
 
 
+    def _filter_config(self, config):
+        defines = {}
+        if ConfigKeys.DEFINES in config:
+            for key in config[ConfigKeys.DEFINES]:
+                defines[key] = config[ConfigKeys.DEFINES][key]
+
+        key_filter = [ConfigKeys.DEFINES]
+        filtered_config = {}
+        for key in config:
+            if key not in key_filter:
+                filtered_config[key] = config[key]
+
+        return defines, filtered_config
+
+
     def _build_config_content(self, config):
         self._failed_keys = {}
+        defines, config = self._filter_config(config)
 
         config_parser  = ConfigParser()
         ResConfig.init_config_parser(config_parser)
@@ -108,6 +124,11 @@ class ResConfig(BaseCClass):
             raise ValueError("Expected config to specify %s" % dir_key)
         config[dir_key] = os.path.realpath(config[dir_key])
 
+        # Insert defines
+        for key in defines:
+            config_content.add_define(key, defines[key])
+
+        # Insert key values
         path_elm = config_content.create_path_elm(config[dir_key])
         for key in config.keys():
             value = str(config[key]) # TODO: Support lists of arguments

--- a/python/tests/res/enkf/test_programmatic_res_config.py
+++ b/python/tests/res/enkf/test_programmatic_res_config.py
@@ -24,18 +24,18 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
         self.minimum_config = {
                                 "INTERNALS" :
                                 {
-                                  "CONFIG_DIRECTORY"   : "simple_config",
+                                  "CONFIG_DIRECTORY" : "simple_config",
                                 },
 
                                 "SIMULATION" :
                                 {
                                   "QUEUE_SYSTEM" :
                                   {
-                                    "JOBNAME"            : "Job%d",
+                                    "JOBNAME" : "Job%d",
                                   },
 
                                   "RUNPATH"            : "/tmp/simulations/run%d",
-                                  "NUM_REALIZATIONS"   : "1",
+                                  "NUM_REALIZATIONS"   : 1,
                                   "JOB_SCRIPT"         : "script.sh",
                                   "ENSPATH"            : "Ensemble"
                                 }
@@ -44,29 +44,133 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
         self.large_config  = {
                                 "DEFINES" :
                                 {
-                                  "<USER>"        : "TEST_USER",
-                                  "<SCRATCH>"     : "scratch/ert",
-                                  "<CASE_DIR>"    : "the_extensive_case",
-                                  "<ECLIPSE_NAME>": "XYZ"
+                                  "<USER>"         : "TEST_USER",
+                                  "<SCRATCH>"      : "scratch/ert",
+                                  "<CASE_DIR>"     : "the_extensive_case",
+                                  "<ECLIPSE_NAME>" : "XYZ"
                                 },
 
                                 "INTERNALS" :
                                 {
-                                  "CONFIG_DIRECTORY"   : "snake_oil_structure/ert/model",
+                                  "CONFIG_DIRECTORY" : "snake_oil_structure/ert/model",
                                 },
 
                                 "SIMULATION" :
                                 {
                                   "QUEUE_SYSTEM" :
                                   {
-                                    "JOBNAME"            : "SNAKE_OIL_STRUCTURE_%d",
+                                    "JOBNAME"          : "SNAKE_OIL_STRUCTURE_%d",
+                                    "QUEUE_SYSTEM"     : "LSF",
+                                    "MAX_RUNTIME"      : 23400,
+                                    "MIN_REALIZATIONS" : "50%",
+                                    "MAX_SUBMIT"       : 13,
+                                    "UMASK"            : "007",
+                                    "QUEUE_OPTION"     :
+                                    [
+                                      {
+                                        "DRIVER_NAME" : "LSF",
+                                        "OPTION"      : "MAX_RUNNING",
+                                        "VALUE"       : 100
+                                      }
+                                    ]
                                   },
 
-                                  "RUNPATH"            : "<SCRATCH>/<USER>/<CASE_DIR>/realization-%d/iter-%d",
-                                  "NUM_REALIZATIONS"   : "10",
-                                  "ENSPATH"            : "../output/storage/<CASE_DIR>"
+                                  "DATA_FILE"        : "../../eclipse/model/SNAKE_OIL.DATA",
+                                  "RUNPATH"          : "<SCRATCH>/<USER>/<CASE_DIR>/realization-%d/iter-%d",
+                                  "RUNPATH_FILE"     : "../output/run_path_file/.ert-runpath-list_<CASE_DIR>",
+                                  "ECLBASE"          : "eclipse/model/<ECLIPSE_NAME>-%d",
+                                  "NUM_REALIZATIONS" : "10",
+                                  "ENSPATH"          : "../output/storage/<CASE_DIR>",
+                                  "GRID"             : "../../eclipse/include/grid/CASE.EGRID",
+                                  "REFCASE"          : "../input/refcase/SNAKE_OIL_FIELD",
+                                  "HISTORY_SOURCE"   : "REFCASE_HISTORY",
+                                  "OBS_CONFIG"       : "../input/observations/obsfiles/observations.txt",
+                                  "TIME_MAP"         : "../input/refcase/time_map.txt",
+
+                                  "PLOT_SETTINGS" :
+                                  {
+                                    "PATH" : "../output/results/plot/<CASE_DIR>"
+                                  },
+
+                                  "SUMMARY" :
+                                  [
+                                    "WOPR:PROD",
+                                    "WOPT:PROD",
+                                    "WWPR:PROD",
+                                    "WWCT:PROD",
+                                    "WWPT:PROD",
+                                    "WBHP:PROD",
+                                    "WWIR:INJ",
+                                    "WWIT:INJ",
+                                    "WBHP:INJ",
+                                    "ROE:1"
+                                  ],
+
+                                  "INSTALL_JOB" :
+                                  [
+                                    {
+                                      "NAME" : "SNAKE_OIL_SIMULATOR",
+                                      "PATH" : "../../snake_oil/jobs/SNAKE_OIL_SIMULATOR"
+                                    },
+                                    {
+                                      "NAME" : "SNAKE_OIL_NPV",
+                                      "PATH" : "../../snake_oil/jobs/SNAKE_OIL_NPV"
+                                    },
+                                    {
+                                      "NAME" : "SNAKE_OIL_DIFF",
+                                      "PATH" : "../../snake_oil/jobs/SNAKE_OIL_DIFF"
+                                    }
+                                  ],
+
+                                  "LOAD_WORKFLOW_JOB" :
+                                  [
+                                    "../bin/workflows/workflowjobs/UBER_PRINT"
+                                  ],
+
+                                  "LOAD_WORKFLOW" :
+                                  [
+                                    "../bin/workflows/MAGIC_PRINT"
+                                  ],
+
+                                  "FORWARD_MODEL" :
+                                  [
+                                    "SNAKE_OIL_SIMULATOR",
+                                    "SNAKE_OIL_NPV",
+                                    "SNAKE_OIL_DIFF"
+                                  ],
+
+                                  "RUN_TEMPLATE" :
+                                  [
+                                    {
+                                      "TEMPLATE" : "../input/templates/seed_template.txt",
+                                      "EXPORT"   : "seed.txt"
+                                    }
+                                  ],
+
+                                  "GEN_KW" :
+                                  [
+                                    {
+                                      "NAME"           : "SIGMA",
+                                      "TEMPLATE"       : "../input/templates/sigma.tmpl",
+                                      "OUT_FILE"       : "coarse.sigma",
+                                      "PARAMETER_FILE" : "../input/distributions/sigma.dist"
+                                    }
+                                  ],
+
+                                  "LOGGING" :
+                                  {
+                                    "LOG_LEVEL"       : "INFO",
+                                    "UPDATE_LOG_PATH" : "../output/update_log/<CASE_DIR>",
+                                    "LOG_FILE"        : "../output/log/ert_<CASE_DIR>.log"
+                                  },
+
+                                  "SEED" :
+                                  {
+                                    "STORE_SEED" : "../input/rng/SEED",
+                                    "LOAD_SEED"  : "../input/rng/SEED"
+                                  }
                                 }
-                             }
+                              }
 
     def test_minimum_config(self):
         case_directory = self.createTestPath("local/simple_config")
@@ -143,6 +247,142 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
                              res_config.failed_keys["UNKNOWN_KEY"])
 
 
+    def assert_equal_model_config(self, loaded_model_config, prog_model_config):
+        self.assertEqual(loaded_model_config.num_realizations,
+                         prog_model_config.num_realizations)
+
+        self.assertEqual(loaded_model_config.getJobnameFormat(),
+                         prog_model_config.getJobnameFormat())
+
+        self.assertEqual(loaded_model_config.getRunpathAsString(),
+                         prog_model_config.getRunpathAsString())
+
+        self.assertEqual(loaded_model_config.getEnspath(),
+                         prog_model_config.getEnspath())
+
+        self.assertEqual(loaded_model_config.get_history_source(),
+                         prog_model_config.get_history_source())
+
+        self.assertEqual(loaded_model_config.obs_config_file,
+                         prog_model_config.obs_config_file)
+
+        self.assertEqual(loaded_model_config.getForwardModel().joblist(),
+                         prog_model_config.getForwardModel().joblist())
+
+
+    def assert_equal_site_config(self, loaded_site_config, prog_site_config):
+        self.assertEqual(loaded_site_config.queue_config.queue_name,
+                         prog_site_config.queue_config.queue_name)
+
+        self.assertEqual(loaded_site_config.queue_config.max_submit,
+                         prog_site_config.queue_config.max_submit)
+
+        self.assertEqual(loaded_site_config.umask,
+                         prog_site_config.umask)
+
+        self.assertEqual(loaded_site_config.queue_config.driver.get_option("MAX_RUNNING"),
+                         prog_site_config.queue_config.driver.get_option("MAX_RUNNING"))
+
+        loaded_job_list = loaded_site_config.get_installed_jobs()
+        prog_job_list = prog_site_config.get_installed_jobs()
+
+        self.assertEqual(loaded_job_list.getAvailableJobNames(),
+                         prog_job_list.getAvailableJobNames())
+
+        for job_name in loaded_job_list.getAvailableJobNames():
+            self.assertEqual(loaded_job_list[job_name].get_config_file(),
+                             prog_job_list[job_name].get_config_file())
+
+            self.assertEqual(loaded_job_list[job_name].get_stderr_file(),
+                             prog_job_list[job_name].get_stderr_file())
+
+            self.assertEqual(loaded_job_list[job_name].get_stdout_file(),
+                             prog_job_list[job_name].get_stdout_file())
+
+
+    def assert_equal_ecl_config(self, loaded_ecl_config, prog_ecl_config):
+        self.assertEqual(loaded_ecl_config.getDataFile(),
+                         prog_ecl_config.getDataFile())
+
+        self.assertEqual(loaded_ecl_config.get_gridfile(),
+                         prog_ecl_config.get_gridfile())
+
+        self.assertEqual(loaded_ecl_config.getEclBase(),
+                         prog_ecl_config.getEclBase())
+
+        self.assertEqual(loaded_ecl_config.getRefcaseName(),
+                         prog_ecl_config.getRefcaseName())
+
+
+    def assert_equal_analysis_config(self, loaded_config, prog_config):
+        self.assertEqual(loaded_config.get_log_path(),
+                         prog_config.get_log_path())
+
+        self.assertEqual(loaded_config.get_max_runtime(),
+                         prog_config.get_max_runtime())
+
+    def assert_equal_hook_manager(self, loaded_hook_manager, prog_hook_manager):
+        self.assertEqual(loaded_hook_manager.getRunpathList().getExportFile(),
+                         prog_hook_manager.getRunpathList().getExportFile())
+
+
+    def assert_equal_log_config(self, loaded_log_config, prog_log_config):
+        self.assertEqual(loaded_log_config.log_file,
+                         prog_log_config.log_file)
+
+        self.assertEqual(loaded_log_config.log_level,
+                         prog_log_config.log_level)
+
+
+    def assert_equal_rng_config(self, loaded_rng_config, prog_rng_config):
+        self.assertEqual(loaded_rng_config.store_filename,
+                         prog_rng_config.store_filename)
+
+        self.assertEqual(loaded_rng_config.load_filename,
+                         prog_rng_config.load_filename)
+
+
+    def assert_equal_ensemble_config(self, loaded_config, prog_config):
+        self.assertEqual(set(loaded_config.alloc_keylist()),
+                         set(prog_config.alloc_keylist()))
+
+
+    def assert_equal_ert_templates(self, loaded_templates, prog_templates):
+        self.assertEqual(loaded_templates.getTemplateNames(),
+                         prog_templates.getTemplateNames())
+
+        for template_name in loaded_templates.getTemplateNames():
+            let = loaded_templates.get_template(template_name)
+            pet = prog_templates.get_template(template_name)
+
+            self.assertEqual(let.get_template_file(), pet.get_template_file())
+            self.assertEqual(let.get_target_file(), pet.get_target_file())
+
+
+    def assert_equal_ert_workflow(self, loaded_workflow_list, prog_workflow_list):
+        self.assertEqual(loaded_workflow_list.getWorkflowNames(),
+                         prog_workflow_list.getWorkflowNames())
+
+        for wname in loaded_workflow_list.getWorkflowNames():
+            self.assertEqual(loaded_workflow_list[wname].src_file,
+                             prog_workflow_list[wname].src_file)
+
+        self.assertEqual(loaded_workflow_list.getJobNames(),
+                         prog_workflow_list.getJobNames())
+
+        for jname in loaded_workflow_list.getJobNames():
+            ljob = loaded_workflow_list.getJob(jname)
+            pjob = prog_workflow_list.getJob(jname)
+
+            self.assertEqual(ljob.name(), pjob.name())
+            self.assertEqual(ljob.executable(), pjob.executable())
+
+
+    def assert_equal_plot_config(self, loaded_plot_config, prog_plot_config):
+        self.assertEqual(loaded_plot_config.getPath(),
+                         prog_plot_config.getPath())
+
+
     def test_large_config(self):
         case_directory = self.createTestPath("local/snake_oil_structure")
         config_file = "snake_oil_structure/ert/model/user_config.ert"
@@ -153,14 +393,35 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
             loaded_res_config = ResConfig(user_config_file=config_file)
             prog_res_config   = ResConfig(config=self.large_config)
 
-            self.assertEqual(loaded_res_config.model_config.num_realizations,
-                             prog_res_config.model_config.num_realizations)
+            self.assert_equal_model_config(loaded_res_config.model_config,
+                                           prog_res_config.model_config)
 
-            self.assertEqual(loaded_res_config.model_config.getJobnameFormat(),
-                             prog_res_config.model_config.getJobnameFormat())
+            self.assert_equal_site_config(loaded_res_config.site_config,
+                                          prog_res_config.site_config)
 
-            self.assertEqual(loaded_res_config.model_config.getRunpathAsString(),
-                             prog_res_config.model_config.getRunpathAsString())
+            self.assert_equal_ecl_config(loaded_res_config.ecl_config,
+                                         prog_res_config.ecl_config)
 
-            self.assertEqual(loaded_res_config.model_config.getEnspath(),
-                             prog_res_config.model_config.getEnspath())
+            self.assert_equal_analysis_config(loaded_res_config.analysis_config,
+                                              prog_res_config.analysis_config)
+
+            self.assert_equal_hook_manager(loaded_res_config.hook_manager,
+                                           prog_res_config.hook_manager)
+
+            self.assert_equal_log_config(loaded_res_config.log_config,
+                                         prog_res_config.log_config)
+
+            self.assert_equal_rng_config(loaded_res_config.rng_config,
+                                         prog_res_config.rng_config)
+
+            self.assert_equal_ensemble_config(loaded_res_config.ensemble_config,
+                                              prog_res_config.ensemble_config)
+
+            self.assert_equal_ert_templates(loaded_res_config.ert_templates,
+                                            prog_res_config.ert_templates)
+
+            self.assert_equal_ert_workflow(loaded_res_config.ert_workflow_list,
+                                           prog_res_config.ert_workflow_list)
+
+            self.assert_equal_plot_config(loaded_res_config.plot_config,
+                                          prog_res_config.plot_config)

--- a/python/tests/res/enkf/test_programmatic_res_config.py
+++ b/python/tests/res/enkf/test_programmatic_res_config.py
@@ -16,20 +16,19 @@
 
 from ecl.test import ExtendedTestCase, TestAreaContext
 
-from res.enkf import ResConfig
+from res.enkf import ResConfig, ConfigKeys
 
 class ProgrammaticResConfigTest(ExtendedTestCase):
 
     def setUp(self):
         self.minimum_config = {
-                                "WORKING_DIRECTORY"  : "simple_config",
+                                "CONFIG_DIRECTORY"   : "simple_config",
                                 "JOBNAME"            : "Job%d",
                                 "RUNPATH"            : "/tmp/simulations/run%d",
                                 "NUM_REALIZATIONS"   : 1,
                                 "JOB_SCRIPT"         : "script.sh",
                                 "ENSPATH"            : "Ensemble"
                               }
-
 
     def test_minimum_config(self):
         case_directory = self.createTestPath("local/simple_config")
@@ -55,6 +54,18 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
 
             self.assertEqual(0, len(prog_res_config.errors))
             self.assertEqual(0, len(prog_res_config.failed_keys))
+
+
+    def test_no_config_directory(self):
+        case_directory = self.createTestPath("local/simple_config")
+        config_file = "simple_config/minimum_config"
+
+        with TestAreaContext("res_config_prog_test") as work_area:
+            work_area.copy_directory(case_directory)
+            del self.minimum_config[ConfigKeys.CONFIG_DIRECTORY]
+
+            with self.assertRaises(ValueError):
+                ResConfig(config=self.minimum_config)
 
 
     def test_errors(self):

--- a/python/tests/res/enkf/test_programmatic_res_config.py
+++ b/python/tests/res/enkf/test_programmatic_res_config.py
@@ -25,10 +25,24 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
                                 "CONFIG_DIRECTORY"   : "simple_config",
                                 "JOBNAME"            : "Job%d",
                                 "RUNPATH"            : "/tmp/simulations/run%d",
-                                "NUM_REALIZATIONS"   : 1,
+                                "NUM_REALIZATIONS"   : "1",
                                 "JOB_SCRIPT"         : "script.sh",
                                 "ENSPATH"            : "Ensemble"
                               }
+
+        self.large_config  = {
+                                "DEFINES" : {
+                                              "<USER>"        : "TEST_USER",
+                                              "<SCRATCH>"     : "scratch/ert",
+                                              "<CASE_DIR>"    : "the_extensive_case",
+                                              "<ECLIPSE_NAME>": "XYZ"
+                                            },
+                                "CONFIG_DIRECTORY"   : "snake_oil_structure/ert/model",
+                                "JOBNAME"            : "SNAKE_OIL_STRUCTURE_%d",
+                                "RUNPATH"            : "<SCRATCH>/<USER>/<CASE_DIR>/realization-%d/iter-%d",
+                                "NUM_REALIZATIONS"   : "10",
+                                "ENSPATH"            : "../output/storage/<CASE_DIR>"
+                             }
 
     def test_minimum_config(self):
         case_directory = self.createTestPath("local/simple_config")
@@ -100,3 +114,23 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
             self.assertEqual(["UNKNOWN_KEY"], res_config.failed_keys.keys())
             self.assertEqual(self.minimum_config["UNKNOWN_KEY"],
                              res_config.failed_keys["UNKNOWN_KEY"])
+
+
+    def test_large_config(self):
+        case_directory = self.createTestPath("local/snake_oil_structure")
+        config_file = "snake_oil_structure/ert/model/user_config.ert"
+
+        with TestAreaContext("res_config_prog_test") as work_area:
+            work_area.copy_directory(case_directory)
+
+            loaded_res_config = ResConfig(user_config_file=config_file)
+            prog_res_config   = ResConfig(config=self.large_config)
+
+            self.assertEqual(loaded_res_config.model_config.num_realizations,
+                             prog_res_config.model_config.num_realizations)
+
+            self.assertEqual(loaded_res_config.model_config.getJobnameFormat(),
+                             prog_res_config.model_config.getJobnameFormat())
+
+            self.assertEqual(loaded_res_config.model_config.getRunpathAsString(),
+                             prog_res_config.model_config.getRunpathAsString())

--- a/python/tests/res/enkf/test_programmatic_res_config.py
+++ b/python/tests/res/enkf/test_programmatic_res_config.py
@@ -22,26 +22,50 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
 
     def setUp(self):
         self.minimum_config = {
-                                "CONFIG_DIRECTORY"   : "simple_config",
-                                "JOBNAME"            : "Job%d",
-                                "RUNPATH"            : "/tmp/simulations/run%d",
-                                "NUM_REALIZATIONS"   : "1",
-                                "JOB_SCRIPT"         : "script.sh",
-                                "ENSPATH"            : "Ensemble"
+                                "INTERNALS" :
+                                {
+                                  "CONFIG_DIRECTORY"   : "simple_config",
+                                },
+
+                                "SIMULATION" :
+                                {
+                                  "QUEUE_SYSTEM" :
+                                  {
+                                    "JOBNAME"            : "Job%d",
+                                  },
+
+                                  "RUNPATH"            : "/tmp/simulations/run%d",
+                                  "NUM_REALIZATIONS"   : "1",
+                                  "JOB_SCRIPT"         : "script.sh",
+                                  "ENSPATH"            : "Ensemble"
+                                }
                               }
 
         self.large_config  = {
-                                "DEFINES" : {
-                                              "<USER>"        : "TEST_USER",
-                                              "<SCRATCH>"     : "scratch/ert",
-                                              "<CASE_DIR>"    : "the_extensive_case",
-                                              "<ECLIPSE_NAME>": "XYZ"
-                                            },
-                                "CONFIG_DIRECTORY"   : "snake_oil_structure/ert/model",
-                                "JOBNAME"            : "SNAKE_OIL_STRUCTURE_%d",
-                                "RUNPATH"            : "<SCRATCH>/<USER>/<CASE_DIR>/realization-%d/iter-%d",
-                                "NUM_REALIZATIONS"   : "10",
-                                "ENSPATH"            : "../output/storage/<CASE_DIR>"
+                                "DEFINES" :
+                                {
+                                  "<USER>"        : "TEST_USER",
+                                  "<SCRATCH>"     : "scratch/ert",
+                                  "<CASE_DIR>"    : "the_extensive_case",
+                                  "<ECLIPSE_NAME>": "XYZ"
+                                },
+
+                                "INTERNALS" :
+                                {
+                                  "CONFIG_DIRECTORY"   : "snake_oil_structure/ert/model",
+                                },
+
+                                "SIMULATION" :
+                                {
+                                  "QUEUE_SYSTEM" :
+                                  {
+                                    "JOBNAME"            : "SNAKE_OIL_STRUCTURE_%d",
+                                  },
+
+                                  "RUNPATH"            : "<SCRATCH>/<USER>/<CASE_DIR>/realization-%d/iter-%d",
+                                  "NUM_REALIZATIONS"   : "10",
+                                  "ENSPATH"            : "../output/storage/<CASE_DIR>"
+                                }
                              }
 
     def test_minimum_config(self):
@@ -63,6 +87,9 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
             self.assertEqual(loaded_res_config.model_config.getRunpathAsString(),
                              prog_res_config.model_config.getRunpathAsString())
 
+            self.assertEqual(loaded_res_config.model_config.getEnspath(),
+                             prog_res_config.model_config.getEnspath())
+
             self.assertEqual(loaded_res_config.site_config.queue_config.job_script,
                              prog_res_config.site_config.queue_config.job_script)
 
@@ -76,7 +103,7 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
 
         with TestAreaContext("res_config_prog_test") as work_area:
             work_area.copy_directory(case_directory)
-            del self.minimum_config[ConfigKeys.CONFIG_DIRECTORY]
+            del self.minimum_config[ConfigKeys.INTERNALS]
 
             with self.assertRaises(ValueError):
                 ResConfig(config=self.minimum_config)
@@ -88,7 +115,7 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
 
         with TestAreaContext("res_config_prog_test") as work_area:
             work_area.copy_directory(case_directory)
-            del self.minimum_config["NUM_REALIZATIONS"]
+            del self.minimum_config[ConfigKeys.SIMULATION]["NUM_REALIZATIONS"]
 
             with self.assertRaises(ValueError):
                 res_config = ResConfig(config=self.minimum_config)
@@ -134,3 +161,6 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
 
             self.assertEqual(loaded_res_config.model_config.getRunpathAsString(),
                              prog_res_config.model_config.getRunpathAsString())
+
+            self.assertEqual(loaded_res_config.model_config.getEnspath(),
+                             prog_res_config.model_config.getEnspath())


### PR DESCRIPTION
**Task**
_Instantiate a large configuration (like test_data/snake_oil_structure) programmatically._


**Approach**
This should be done in the following steps:
- Create a sensible structure of the dictionary representing the configuration.
- Support this structure.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
