### PR TITLE
Updated pre simulation copy job.

### DIFF
--- a/libenkf/include/ert/enkf/model_config.h
+++ b/libenkf/include/ert/enkf/model_config.h
@@ -46,6 +46,7 @@ extern "C" {
   typedef struct model_config_struct model_config_type;
   const char *           model_config_get_data_root( const model_config_type * model_config );
   void                   model_config_set_data_root( model_config_type * model_config , const char * data_root);
+  bool                   model_config_data_root_is_set( const model_config_type * model_config );
 
   const char *           model_config_get_jobname_fmt( const model_config_type * model_config );
   void                   model_config_set_jobname_fmt( model_config_type * model_config , const char * jobname_fmt);

--- a/libenkf/tests/enkf_model_config.c
+++ b/libenkf/tests/enkf_model_config.c
@@ -55,8 +55,17 @@ void test_runpath() {
 }
 
 
+void test_data_root( ) {
+  model_config_type * model_config = model_config_alloc_empty();
+  test_assert_false( model_config_data_root_set( model_config ));
+  model_config_set_data_root( model_config ,  "root");
+  test_assert_true( model_config_data_root_set( model_config ));
+}
+
 int main(int argc , char ** argv) {
   test_create();
+  test_runpath( );
+  test_data_root( );
   exit(0);
 }
 

--- a/libenkf/tests/enkf_workflow_job_test.c
+++ b/libenkf/tests/enkf_workflow_job_test.c
@@ -39,34 +39,53 @@ ert_test_context_type * create_context( const char * config_file, const char * n
 void test_pre_simulation_copy__( ert_test_context_type * test_context,
                                  const char * job_name,
                                  const char * source_path,
-                                 const char * target_path,
-                                 const char * expected_DATA_ROOT) {
+                                 const char * target_path) {
 
   stringlist_type * args = stringlist_alloc_new();
-  unsetenv("DATA_ROOT");
   stringlist_append_copy( args , source_path );
-  stringlist_append_copy( args , target_path );
-  test_assert_true( ert_test_context_run_worklow_job( test_context , job_name , args) );
-
-  test_assert_string_equal( expected_DATA_ROOT , getenv("DATA_ROOT") );
-  if (expected_DATA_ROOT)
-    test_assert_true( util_is_directory( target_path ));
+  if (target_path)
+    stringlist_append_copy( args , target_path );
+  ert_test_context_run_worklow_job( test_context , job_name , args);
 
   stringlist_free( args );
 }
 
 void test_pre_simulation_copy(ert_test_context_type * test_context, const char * job_name , const char * job_file) {
+  enkf_main_type * enkf_main = ert_test_context_get_main( test_context );
+  model_config_type * model_config = enkf_main_get_model_config( enkf_main );
+  test_assert_false( model_config_data_root_set( model_config ));
+
   test_assert_true( ert_test_context_install_workflow_job( test_context , job_name , job_file ));
 
-  test_pre_simulation_copy__( test_context , job_name, "does_not_exist" , "target" , NULL );
+  test_pre_simulation_copy__( test_context , job_name, "does_not_exist" , "target");
 
   {
     FILE * f = util_mkdir_fopen("input/path/xxx/model/file", "w");
     fprintf(f, "File \n");
     fclose( f );
   }
-  test_pre_simulation_copy__( test_context , job_name, "input/path/xxx/model" , "target" , "target");
-  test_assert_true( util_is_file( "target/model/file"));
+  test_pre_simulation_copy__( test_context , job_name, "input/path/xxx/model" , NULL);
+  test_pre_simulation_copy__( test_context , job_name, "input/path/xxx/model" , "target");
+  test_pre_simulation_copy__( test_context , job_name, "input/path/xxx/model/file" , "target/extra_path");
+  test_pre_simulation_copy__( test_context , job_name, "input/path/xxx/model" , "target/extra_path2");
+
+  test_assert_false( util_is_file( "root/model/file"));
+  test_assert_false( util_is_file( "root/target/model/file"));
+  test_assert_false( util_is_file( "root/target/extra_path/file"));
+  test_assert_false( util_is_file( "root/target/extra_path2/model/file"));
+
+  model_config_set_data_root( model_config , "root");
+  test_assert_true( model_config_data_root_is_set( model_config ));
+
+  test_pre_simulation_copy__( test_context , job_name, "input/path/xxx/model" , NULL );
+  test_pre_simulation_copy__( test_context , job_name, "input/path/xxx/model" , "target");
+  test_pre_simulation_copy__( test_context , job_name, "input/path/xxx/model/file" , "target/extra_path");
+  test_pre_simulation_copy__( test_context , job_name, "input/path/xxx/model" , "target/extra_path2");
+
+  test_assert_true( util_is_file( "root/model/file"));
+  test_assert_true( util_is_file( "root/target/model/file"));
+  test_assert_true( util_is_file( "root/target/extra_path/file"));
+  test_assert_true( util_is_file( "root/target/extra_path2/model/file"));
 }
 
 
@@ -492,7 +511,6 @@ void test_export_runpath_files(const char * config_file,
 
 
 
-
 int main(int argc , const char ** argv) {
   enkf_main_install_SIGNALS();
 
@@ -525,6 +543,5 @@ int main(int argc , const char ** argv) {
   ert_test_context_free( test_context );
 
   test_export_runpath_files(config_file, config_file_iterations, job_file_export_runpath);
-
   exit(0);
 }


### PR DESCRIPTION
**Task**
The `PRE_SIMULATION_COPY` workflow job is used to copy files & directories to a temporary location $DATA_ROOT on `/scratch`. With this PR it is possible to:

- Specify subfolders in the `$DATA_ROOT` target.
- Copy only files.

In addition the workflow job will not run unless the `$DATA_ROOT` has been *explicitly set*.

This should be cherry-pucken to 2.2


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps


