### PR TITLE
Make travis spawn a single MacOS runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - TEST_SUITE="-LE SLOW"  # Run all tests not labeled as slow
     - TEST_SUITE="-L SLOW_1" # Run all tests labeled as SLOW in group 1
     - TEST_SUITE="-L SLOW_2" # Run all tests labeled as SLOW in group 2
+    - TEST_SUITE=""          # TODO: Can be removed when libres is MacOS compliant
 
 matrix:
   fast_finish: true
@@ -29,6 +30,16 @@ matrix:
       compiler: gcc
     - os: linux
       compiler: clang
+    # TODO: The excludes below should be removed after MacOS is supported
+    - os: linux
+      env: TEST_SUITE=""
+    - os: osx
+      env: TEST_SUITE="-LE SLOW"
+    - os: osx
+      env: TEST_SUITE="-L SLOW_1"
+    - os: osx
+      env: TEST_SUITE="-L SLOW_2"
+
 
 addons:
   apt:


### PR DESCRIPTION
**Task**
_Currently we split the tests into 3 parts to decrease test time. However, the MacOS runners are allowed to fail and will fail. It is unnecessary to dedicate 3 runners to discover this. Hence, I suggest to merge these three runners until MacOS support is accomplished._


**Approach**
_Minor changes in the Travis setup._