### PR TITLE
Remove unused enum module

### DIFF
--- a/python/python/res/enkf/config_keys.py
+++ b/python/python/res/enkf/config_keys.py
@@ -15,7 +15,6 @@
 #  for more details.
 
 from res.enkf import EnkfPrototype
-from enum import Enum
 
 class ConfigKeys:
 


### PR DESCRIPTION
Module `Enum` was unused.  Remove.