### PR TITLE
Summary load anyway

### DIFF
--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -653,12 +653,24 @@ static void enkf_state_internalize_GEN_DATA(enkf_state_type * enkf_state ,
                                             const model_config_type * model_config ,
                                             int last_report) {
 
-  member_config_type * my_config     = enkf_state->my_config;
-  const int  iens                    = member_config_get_iens( my_config );
   stringlist_type * keylist_GEN_DATA = ensemble_config_alloc_keylist_from_impl_type(enkf_state->ensemble_config,
                                                                                     GEN_DATA);
+
+
+  if (stringlist_get_size( keylist_GEN_DATA) > 0) {
+    if (last_report <= 0) {
+      res_log_add_message( LOG_ERROR, stderr, "Trying to load GEN_DATA without properly set last_report - THIS WILL FAIL.", false);
+      stringlist_free( keylist_GEN_DATA );
+      return;
+    }
+  }
+
+
   const run_arg_type * run_arg       = forward_load_context_get_run_arg( load_context );
   enkf_fs_type * result_fs           = run_arg_get_result_fs( run_arg );
+  member_config_type * my_config     = enkf_state->my_config;
+  const int  iens                    = member_config_get_iens( my_config );
+
 
   for (int ikey=0; ikey < stringlist_get_size( keylist_GEN_DATA ); ikey++) {
     enkf_node_type * node = enkf_state_get_node( enkf_state , stringlist_iget( keylist_GEN_DATA , ikey));
@@ -752,7 +764,8 @@ static int enkf_state_internalize_results(enkf_state_type * enkf_state , run_arg
     last_report = model_config_get_last_history_restart( enkf_state->shared_info->model_config);
 
   /* Ensure that the last step is internalized? */
-  model_config_set_internalize_state( model_config , last_report);
+  if (last_report > 0)
+    model_config_set_internalize_state( model_config , last_report);
 
   for (report_step = run_arg_get_load_start(run_arg); report_step <= last_report; report_step++) {
     bool store_vectors = (report_step == last_report);

--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -517,8 +517,9 @@ static bool enkf_state_internalize_dynamic_eclipse_results(enkf_state_type * enk
   const run_arg_type * run_arg = forward_load_context_get_run_arg( load_context );
   const summary_key_matcher_type * matcher = ensemble_config_get_summary_key_matcher(enkf_state->ensemble_config);
   int matcher_size = summary_key_matcher_get_size(matcher);
+  const ecl_sum_type * summary = forward_load_context_get_ecl_sum( load_context );
 
-  if (load_summary || matcher_size > 0) {
+  if (load_summary || matcher_size > 0 || summary) {
     int load_start = run_arg_get_load_start( run_arg );
 
     if (load_start == 0) { /* Do not attempt to load the "S0000" summary results. */
@@ -527,7 +528,6 @@ static bool enkf_state_internalize_dynamic_eclipse_results(enkf_state_type * enk
 
     {
       /* Looking for summary files on disk, and loading them. */
-      const ecl_sum_type * summary = forward_load_context_get_ecl_sum( load_context );
       enkf_fs_type * result_fs = run_arg_get_result_fs( run_arg );
       /** OK - now we have actually loaded the ecl_sum instance, or ecl_sum == NULL. */
       if (summary) {

--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -659,10 +659,8 @@ int model_config_get_last_history_restart(const model_config_type * config) {
   else {
     if (config->external_time_map)
       return time_map_get_last_step( config->external_time_map);
-    else {
-      fprintf(stderr,"** Warning: Trying to get the last restart number - no history/time_map object has been registered.\n");
-      return 0;
-    }
+    else
+      return -1;
   }
 }
 


### PR DESCRIPTION
**Task**
The mapping between report_steps and true simulation time is established when loading a summary case. It is legitimate to not have any summary keys, in that case the summary file was not loaded - and we were left without a functional mapping report_step <-> true simulation. If we later wanted to load a GEN_DATA instance that would silently fail.


**Approach**
1. Uconditionally load summary results, even if no summary keywords are requested.
2. Log an error if GEN_DATA is loaded without a properly set last_report_step value.

Will backport to 2.2

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

