### PR TITLE
Make sure node is reference.

### DIFF
--- a/python/python/res/enkf/ensemble_config.py
+++ b/python/python/res/enkf/ensemble_config.py
@@ -79,7 +79,7 @@ class EnsembleConfig(BaseCClass):
     def addNode(self , config_node):
         assert isinstance(config_node , EnkfConfigNode)
         self._add_node( config_node )
-        config_node.setParent( self )
+        config_node.convertToCReference( self )
 
 
     def add_field(self, key, eclipse_grid):


### PR DESCRIPTION
**Task**
When adding an enkf_config_node to an ensemble config structure the ensemble config will take ownership. Make sure it is a reference.

**Approach**
Call `convertToCReference( )`


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

