### PR TITLE
Create gen data

### DIFF
--- a/libenkf/include/ert/enkf/enkf_config_node.h
+++ b/libenkf/include/ert/enkf/enkf_config_node.h
@@ -138,6 +138,10 @@ extern "C" {
                                                 const char * output_transform );
 
 
+  enkf_config_node_type * enkf_config_node_alloc_GEN_DATA_everest( const char * key ,
+                                                                   const char * result_file_fmt,
+                                                                   const int_vector_type * report_steps);
+
   void enkf_config_node_update_general_field( enkf_config_node_type * config_node ,
                                               const char * enkf_outfile_fmt        ,
                                               const char * enkf_infile_fmt         ,

--- a/libenkf/include/ert/enkf/gen_data_config.h
+++ b/libenkf/include/ert/enkf/gen_data_config.h
@@ -73,7 +73,6 @@ typedef enum { GEN_DATA_UNDEFINED = 0,
   int                          gen_data_config_get_data_size( const gen_data_config_type * config , int report_step);
   gen_data_file_format_type    gen_data_config_check_format( const void * format_string );
 
-  void                        gen_data_config_set_active_report_steps_from_string( gen_data_config_type *config , const char * range_string);
   const int_vector_type     * gen_data_config_get_active_report_steps( const gen_data_config_type *config);
   int                         gen_data_config_iget_report_step( const gen_data_config_type *config , int index);
   void                        gen_data_config_add_report_step( gen_data_config_type * config , int report_step);

--- a/libenkf/src/enkf_config_node.c
+++ b/libenkf/src/enkf_config_node.c
@@ -410,6 +410,24 @@ enkf_config_node_type * enkf_config_node_alloc_GEN_PARAM( const char * node_key 
 }
 
 
+enkf_config_node_type * enkf_config_node_alloc_GEN_DATA_everest( const char * key ,
+                                                                 const char * result_file_fmt,
+                                                                 const int_vector_type * report_steps) {
+
+  if (!gen_data_config_valid_result_format( result_file_fmt ))
+    return NULL;
+
+  enkf_config_node_type * config_node = enkf_config_node_alloc_GEN_DATA_result( key, ASCII , result_file_fmt );
+  gen_data_config_type * gen_data_config = enkf_config_node_get_ref( config_node );
+
+  for (int i=0; i < int_vector_size( report_steps ); i++) {
+    int report_step = int_vector_iget( report_steps , i );
+    gen_data_config_add_report_step( gen_data_config , report_step);
+    enkf_config_node_set_internalize( config_node , report_step );
+  }
+
+  return config_node;
+}
 
 
 enkf_config_node_type * enkf_config_node_alloc_GEN_DATA_result( const char * key ,

--- a/libenkf/src/gen_data_config.c
+++ b/libenkf/src/gen_data_config.c
@@ -544,13 +544,6 @@ int gen_data_config_iget_report_step( const gen_data_config_type *config , int i
   return int_vector_iget( config->active_report_steps , index );
 }
 
-void gen_data_config_set_active_report_steps_from_string( gen_data_config_type *config , const char * range_string) {
-  if (config->dynamic) {
-    int_vector_reset( config->active_report_steps );
-    string_util_update_active_list(range_string , config->active_report_steps );
-  }
-}
-
 
 const int_vector_type * gen_data_config_get_active_report_steps( const gen_data_config_type *config) {
   return config->active_report_steps;

--- a/libenkf/tests/enkf_gen_data_config.c
+++ b/libenkf/tests/enkf_gen_data_config.c
@@ -44,12 +44,6 @@ void test_report_steps_param() {
   test_assert_int_equal( 0 , gen_data_config_num_report_step( config ));
   test_assert_false( gen_data_config_has_report_step( config , 10 ));
 
-  /* Add to parameter should fail. */
-  gen_data_config_set_active_report_steps_from_string( config , "0-9,100");
-  test_assert_int_equal( 0 , gen_data_config_num_report_step( config ));
-  test_assert_false( gen_data_config_has_report_step( config , 10 ));
-
-
   gen_data_config_free( config );
 }
 
@@ -82,13 +76,6 @@ void test_report_steps_dynamic() {
     test_assert_int_equal( int_vector_iget( active_steps  , 0 ) , 5);
     test_assert_int_equal( int_vector_iget( active_steps  , 1 ) , 10);
   }
-
-  gen_data_config_set_active_report_steps_from_string( config , "0-3,7-10,100"); // 0,1,2,3,7,8,9,10,100
-  test_assert_int_equal( 9 , gen_data_config_num_report_step( config ));
-  test_assert_int_equal( 0 , gen_data_config_iget_report_step( config , 0 ));
-  test_assert_int_equal( 3 , gen_data_config_iget_report_step( config , 3));
-  test_assert_int_equal( 9 , gen_data_config_iget_report_step( config , 6));
-  test_assert_int_equal( 100 , gen_data_config_iget_report_step( config , 8));
 
   gen_data_config_free( config );
 }

--- a/python/python/res/enkf/config/enkf_config_node.py
+++ b/python/python/res/enkf/config/enkf_config_node.py
@@ -18,11 +18,12 @@ from res.enkf import EnkfPrototype
 from res.enkf.config import FieldConfig, GenDataConfig, GenKwConfig, SummaryConfig, CustomKWConfig, ExtParamConfig
 from res.enkf.enums import EnkfTruncationType, ErtImplType, LoadFailTypeEnum, EnkfVarType
 from ecl.ecl import EclGrid
-from ecl.util import PathFormat, StringList
+from ecl.util import PathFormat, StringList, IntVector
 
 class EnkfConfigNode(BaseCClass):
     TYPE_NAME = "enkf_config_node"
 
+    _alloc_gen_data_everest = EnkfPrototype("enkf_config_node_obj enkf_config_node_alloc_GEN_DATA_everest(char*, char* , int_vector)", bind = False)
     _alloc_summary_node = EnkfPrototype("enkf_config_node_obj enkf_config_node_alloc_summary(char*, load_fail_type)", bind = False)
     _alloc_field_node   = EnkfPrototype("enkf_config_node_obj enkf_config_node_alloc_field(char*, ecl_grid, void*, bool)", bind = False)
     _alloc_ext_param_node = EnkfPrototype("enkf_config_node_obj enkf_config_node_alloc_EXT_PARAM(char*, stringlist, char*)", bind = False)
@@ -114,6 +115,22 @@ class EnkfConfigNode(BaseCClass):
     def create_ext_param(cls, key, key_list, output_file = None):
         keys = StringList( initial = key_list )
         return cls._alloc_ext_param_node(key, keys, output_file)
+
+
+    # This method only exposes the details relevant for Everest usage.
+    @classmethod
+    def create_gen_data(cls, key, file_fmt, report_steps = (1,)):
+        active_steps = IntVector( )
+        for step in report_steps:
+            active_steps.append( step )
+
+        config_node = cls._alloc_gen_data_everest( key, file_fmt, active_steps)
+        if config_node is None:
+            raise ValueError("Failed to create GEN_DATA node for:%s" % key)
+
+        return config_node
+
+
 
     def free(self):
         self._free()

--- a/python/python/res/enkf/config/gen_data_config.py
+++ b/python/python/res/enkf/config/gen_data_config.py
@@ -1,17 +1,17 @@
-#  Copyright (C) 2012  Statoil ASA, Norway. 
-#   
-#  The file 'gen_data_config.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
+#  Copyright (C) 2012  Statoil ASA, Norway.
+#
+#  The file 'gen_data_config.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
@@ -55,7 +55,7 @@ class GenDataConfig(BaseCClass):
             raise ValueError("No data has been loaded for %s at report step:%d " % (self.getName() , report_step))
         else:
             return data_size
-            
+
     def getActiveMask(self):
          return self._get_active_mask()
 

--- a/python/tests/res/enkf/data/CMakeLists.txt
+++ b/python/tests/res/enkf/data/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES
     test_gen_kw_config.py
     test_ext_param.py
     test_enkf_node.py
+    test_enkf_config_node.py
 )
 
 add_python_package("python.tests.res.enkf.data" ${PYTHON_INSTALL_PREFIX}/tests/res/enkf/data "${TEST_SOURCES}" False)
@@ -17,6 +18,7 @@ addPythonTest(tests.res.enkf.data.test_custom_kw.CustomKWTest LABELS SLOW_1)
 addPythonTest(tests.res.enkf.data.test_gen_kw.GenKwTest)
 addPythonTest(tests.res.enkf.data.test_ext_param.ExtParamTest)
 addPythonTest(tests.res.enkf.data.test_enkf_node.EnkfNodeTest)
+addPythonTest(tests.res.enkf.data.test_enkf_config_node.EnkfConfigNodeTest)
 
 if (STATOIL_TESTDATA_ROOT)
   addPythonTest(tests.res.enkf.data.test_gen_kw_config.GenKwConfigTest LABELS StatoilData)

--- a/python/tests/res/enkf/data/test_enkf_config_node.py
+++ b/python/tests/res/enkf/data/test_enkf_config_node.py
@@ -1,0 +1,28 @@
+import os.path
+import json
+
+from res.enkf.config import EnkfConfigNode
+from ecl.test import TestAreaContext, ExtendedTestCase
+
+
+class EnkfConfigNodeTest(ExtendedTestCase):
+
+    def test_gen_data(self):
+
+        # Must have %d in filename argument
+        with self.assertRaises(ValueError):
+            config_node = EnkfConfigNode.create_gen_data( "KEY", "FILE" )
+
+        config_node = EnkfConfigNode.create_gen_data( "KEY", "FILE%d" )
+        self.assertIsInstance( config_node, EnkfConfigNode )
+        gen_data = config_node.getModelConfig( )
+        self.assertEqual( 1, gen_data.getNumReportStep( ) )
+        self.assertEqual( 1, gen_data.getReportStep(0) )
+
+        config_node = EnkfConfigNode.create_gen_data( "KEY", "FILE%d" , report_steps = [10,20,30])
+        self.assertIsInstance( config_node, EnkfConfigNode )
+        gen_data = config_node.getModelConfig( )
+        self.assertEqual( 3, gen_data.getNumReportStep( ) )
+        for r1,r2 in zip([10,20,30] , gen_data.getReportSteps()):
+            self.assertEqual( r1,r2 )
+


### PR DESCRIPTION
**Task**
The results which should be loaded by Everest will typically come in the form of `GEN_DATA` instances. With this PR creation of GEN_DATA instances from memory has been simplified.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

