### PR TITLE
Test context dict init

### DIFF
--- a/libenkf/include/ert/enkf/ert_test_context.h
+++ b/libenkf/include/ert/enkf/ert_test_context.h
@@ -23,7 +23,9 @@
 #include <stdbool.h>
 
 #include <ert/util/type_macros.h>
+#include <ert/util/test_work_area.h>
 
+#include <ert/enkf/res_config.h>
 #include <ert/enkf/enkf_main.h>
 
 #ifdef __cplusplus
@@ -34,7 +36,7 @@ typedef struct ert_test_context_struct ert_test_context_type;
 
 void                    ert_test_context_set_store( ert_test_context_type * test_context , bool store);
 ert_test_context_type * ert_test_context_alloc( const char * test_name , const char * model_config);
-ert_test_context_type * ert_test_context_alloc_python( const char * test_name , const char * model_config);
+ert_test_context_type * ert_test_context_alloc_python( test_work_area_type * work_area, res_config_type * res_config);
 void                    ert_test_context_free( ert_test_context_type * test_context );
 enkf_main_type        * ert_test_context_get_main( ert_test_context_type * test_context );
 bool                    ert_test_context_install_workflow_job( ert_test_context_type * test_context , const char * job_name , const char * job_file);

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -42,7 +42,6 @@ res_config_type * res_config_alloc_load(const char *);
 res_config_type * res_config_alloc(const config_content_type *);
 void              res_config_free(res_config_type *);
 
-void                           res_config_update_config_directory(res_config_type * res_config, const char * config_dir);
 const site_config_type       * res_config_get_site_config(const res_config_type *);
 rng_config_type              * res_config_get_rng_config(const res_config_type *);
 const analysis_config_type   * res_config_get_analysis_config(const res_config_type *);

--- a/libenkf/include/ert/enkf/res_config.h
+++ b/libenkf/include/ert/enkf/res_config.h
@@ -42,6 +42,7 @@ res_config_type * res_config_alloc_load(const char *);
 res_config_type * res_config_alloc(const config_content_type *);
 void              res_config_free(res_config_type *);
 
+void                           res_config_update_config_directory(res_config_type * res_config, const char * config_dir);
 const site_config_type       * res_config_get_site_config(const res_config_type *);
 rng_config_type              * res_config_get_rng_config(const res_config_type *);
 const analysis_config_type   * res_config_get_analysis_config(const res_config_type *);

--- a/libenkf/src/ecl_config.c
+++ b/libenkf/src/ecl_config.c
@@ -587,22 +587,29 @@ void ecl_config_init(ecl_config_type * ecl_config, const config_content_type * c
   }
 
   if (config_content_has_item(config, SCHEDULE_FILE_KEY)) {
-    const char * schedule_target_file = config_content_safe_iget(config, SCHEDULE_FILE_KEY, 0, 1);
-    if (schedule_target_file) {
+    const config_content_item_type * schedule_item = config_content_get_item( config,  SCHEDULE_FILE_KEY);
+    config_content_node_type * schedule_node = config_content_item_get_last_node( schedule_item );
+    char * schedule_target_file = NULL;
+
+    if (config_content_node_get_size( schedule_node ) > 1) {
+      schedule_target_file = config_content_node_iget_as_abspath( schedule_node, 1 );
       ui_return_type * ui_return_sched_target_file = ecl_config_validate_schedule_file(ecl_config, schedule_target_file);
       if (!ui_return_get_status(ui_return_sched_target_file) == UI_RETURN_OK) {
-         util_abort("%s: failed to set target schedule file. Error:%s\n",__func__ , ui_return_get_last_error(ui_return_sched_target_file));
+        util_abort("%s: failed to set target schedule file. Error:%s\n",__func__ , ui_return_get_last_error(ui_return_sched_target_file));
       }
       ui_return_free(ui_return_sched_target_file);
     }
 
-    ui_return_type * ui_return = ecl_config_validate_schedule_file(ecl_config, config_content_iget(config, SCHEDULE_FILE_KEY, 0, 0));
-    if (ui_return_get_status(ui_return) == UI_RETURN_OK)
-      ecl_config_set_schedule_file(ecl_config, config_content_iget(config, SCHEDULE_FILE_KEY, 0, 0), schedule_target_file);
-    else
-      util_abort("%s: failed to set schedule file. Error:%s\n",__func__ , ui_return_get_last_error(ui_return));
 
-    ui_return_free(ui_return);
+    {
+      const char * schedule_src_file = config_content_node_iget_as_abspath( schedule_node, 0 );
+      ui_return_type * ui_return = ecl_config_validate_schedule_file(ecl_config, schedule_src_file);
+      if (ui_return_get_status(ui_return) == UI_RETURN_OK)
+        ecl_config_set_schedule_file(ecl_config, schedule_src_file, schedule_target_file);
+      else
+        util_abort("%s: failed to set schedule file. Error:%s\n",__func__ , ui_return_get_last_error(ui_return));
+      ui_return_free(ui_return);
+    }
   }
 
   if (config_content_has_item(config, GRID_KEY)) {

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -359,3 +359,18 @@ const char * res_config_get_user_config_file(const res_config_type * res_config)
 const char * res_config_get_site_config_file(const res_config_type * res_config) {
   return site_config_get_config_file(res_config->site_config);
 }
+
+
+/*
+  This functionality is only present to support the following situation:
+
+  1. The res_config object is created in memory from a dictionary.
+  2. A test_area is created.
+  3. An EnKFMain instance is created with
+     this res_config - to run in the newly created test area.
+
+*/
+
+void res_config_update_config_directory(res_config_type * res_config, const char * config_dir) {
+  res_config->config_dir = util_realloc_string_copy( res_config->config_dir, config_dir);
+}

--- a/libenkf/src/res_config.c
+++ b/libenkf/src/res_config.c
@@ -361,16 +361,3 @@ const char * res_config_get_site_config_file(const res_config_type * res_config)
 }
 
 
-/*
-  This functionality is only present to support the following situation:
-
-  1. The res_config object is created in memory from a dictionary.
-  2. A test_area is created.
-  3. An EnKFMain instance is created with
-     this res_config - to run in the newly created test area.
-
-*/
-
-void res_config_update_config_directory(res_config_type * res_config, const char * config_dir) {
-  res_config->config_dir = util_realloc_string_copy( res_config->config_dir, config_dir);
-}

--- a/libenkf/tests/enkf_ert_test_context.c
+++ b/libenkf/tests/enkf_ert_test_context.c
@@ -1,20 +1,20 @@
 /*
-   Copyright (C) 2014  Statoil ASA, Norway. 
-    
+   Copyright (C) 2014  Statoil ASA, Norway.
+
    The file 'enkf_ert_test_context.c' is part of ERT - Ensemble based
    Reservoir Tool.
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 
@@ -64,7 +64,7 @@ void test_install_job( const char * config_file, const char * job_file_OK , cons
   test_assert_false( ert_test_context_install_workflow_job( test_context , "JOB" , "File/does/not/exist"));
   test_assert_false( ert_test_context_install_workflow_job( test_context , "ERROR" , job_file_ERROR));
   test_assert_true( ert_test_context_install_workflow_job( test_context , "OK" , job_file_OK));
-  
+
   ert_test_context_free( test_context );
 }
 
@@ -78,10 +78,10 @@ void test_run_workflow_job( const char * config_file , const char * job_file ) {
   stringlist_append_ref( args1 , "NewCase");
   test_assert_false( ert_test_context_run_worklow_job( test_context , "NO-this-does-not-exist" , args1));
   ert_test_context_install_workflow_job( test_context , "JOB" , job_file );
-  
+
   test_assert_false( ert_test_context_run_worklow_job( test_context , "JOB" , args0));
   test_assert_true( ert_test_context_run_worklow_job( test_context , "JOB" , args1));
-  
+
   stringlist_free( args0 );
   stringlist_free( args1 );
   ert_test_context_free( test_context );
@@ -109,7 +109,7 @@ void test_install_workflow( const char * config_file , const char * job_file ) {
 void test_run_workflow(const char * config_file , const char * job_file) {
   ert_test_context_type * test_context = ert_test_context_alloc("INSTALL_WORKFLOW" , config_file );
   test_assert_false( ert_test_context_run_worklow( test_context , "No-does.not.exist"));
-  
+
   ert_test_context_install_workflow_job( test_context , "JOB" , job_file );
   {
     FILE * stream1 = util_fopen( "WFLOW1", "w");
@@ -118,14 +118,14 @@ void test_run_workflow(const char * config_file , const char * job_file) {
     ert_test_context_fwrite_workflow_job( stream1 , "JOB" , args);
     stringlist_append_ref( args , "NewCase");
     ert_test_context_fwrite_workflow_job( stream2 , "JOB" , args);
-        
+
     stringlist_free( args );
     fclose( stream1 );
     fclose( stream2 );
   }
   test_assert_true( ert_test_context_install_workflow( test_context , "WFLOW1" , "WFLOW1"));
   test_assert_true( ert_test_context_install_workflow( test_context , "WFLOW2" , "WFLOW2"));
-  
+
   test_assert_true( ert_test_context_run_worklow( test_context , "WFLOW2"));
   test_assert_false( ert_test_context_run_worklow( test_context , "WFLOW1"));
 

--- a/libenkf/tests/enkf_ert_test_context.c
+++ b/libenkf/tests/enkf_ert_test_context.c
@@ -27,17 +27,8 @@
 
 
 void test_create_invalid(const char * config_file) {
-  char * cwd0 = util_alloc_cwd();
   ert_test_context_type * test_context = ert_test_context_alloc("CREATE_CONTEXT" , config_file );
-  test_assert_true( ert_test_context_is_instance( test_context ));
-  test_assert_NULL( ert_test_context_get_main( test_context ));
-  {
-    char * cwd1 = util_alloc_cwd();
-    test_assert_string_equal(cwd1 , cwd0);
-    free( cwd1 );
-  }
-  free( cwd0 );
-  ert_test_context_free( test_context );
+  test_assert_NULL( test_context );
 }
 
 

--- a/libenkf/tests/enkf_export_field_test.c
+++ b/libenkf/tests/enkf_export_field_test.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2013  Statoil ASA, Norway. 
-    
-   The file 'enkf_export_field_test.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2013  Statoil ASA, Norway.
+
+   The file 'enkf_export_field_test.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>
@@ -34,13 +34,13 @@ void test_export_field(ert_test_context_type * test_context , const char * job_n
   test_assert_true( ert_test_context_install_workflow_job( test_context , job_name , job_file ));
   {
     stringlist_type * args = stringlist_alloc_new();
-    
+
     stringlist_append_copy(args, "PERMZ");
     stringlist_append_copy(args, "TEST_EXPORT/test_export_field/PermZ%d.grdecl");
     stringlist_append_copy(args, "0");
     stringlist_append_copy(args, "FORECAST");
     stringlist_append_copy(args, "0, 2");
-    
+
     test_assert_true( ert_test_context_run_worklow_job( test_context , job_name , args) );
     stringlist_free( args );
   }
@@ -53,13 +53,13 @@ void job_file_export_field_ecl_grdecl(ert_test_context_type * test_context , con
   ert_test_context_install_workflow_job( test_context , job_name , job_file );
   {
     stringlist_type * args = stringlist_alloc_new();
-    
+
     stringlist_append_copy(args, "PERMX");
     stringlist_append_copy(args, "TEST_EXPORT/test_export_field_ecl_grdecl/PermX%d.grdecl");
     stringlist_append_copy(args, "0");
     stringlist_append_copy(args, "ANALYZED");
     test_assert_true( ert_test_context_run_worklow_job( test_context , job_name , args) );
-    
+
     stringlist_clear(args);
     stringlist_append_copy(args, "PERMZ");
     stringlist_append_copy(args, "TEST_EXPORT/test_export_field_ecl_grdecl/PermZ%d");
@@ -67,15 +67,15 @@ void job_file_export_field_ecl_grdecl(ert_test_context_type * test_context , con
     stringlist_append_copy(args, "FORECAST");
     stringlist_append_copy(args, "0-1");
     test_assert_true( ert_test_context_run_worklow_job( test_context , job_name , args) );
-    
-    
+
+
     test_assert_true(util_file_exists("TEST_EXPORT/test_export_field_ecl_grdecl/PermX0.grdecl"));
     test_assert_true(util_file_exists("TEST_EXPORT/test_export_field_ecl_grdecl/PermX1.grdecl"));
     test_assert_true(util_file_exists("TEST_EXPORT/test_export_field_ecl_grdecl/PermX2.grdecl"));
-    
+
     test_assert_true(util_file_exists("TEST_EXPORT/test_export_field_ecl_grdecl/PermZ0"));
     test_assert_true(util_file_exists("TEST_EXPORT/test_export_field_ecl_grdecl/PermZ1"));
-    
+
     stringlist_free( args );
   }
 }
@@ -85,28 +85,28 @@ void job_file_export_field_rms_roff(ert_test_context_type * test_context , const
   test_assert_true( ert_test_context_install_workflow_job( test_context , job_name , job_file ) );
   {
     stringlist_type * args = stringlist_alloc_new();
-    
+
     stringlist_append_copy(args, "PERMZ");
     stringlist_append_copy(args, "TEST_EXPORT/test_export_field_rms_roff/PermZ%d");
     stringlist_append_copy(args, "0");
     stringlist_append_copy(args, "ANALYZED");
     test_assert_true( ert_test_context_run_worklow_job( test_context , job_name , args) );
-    
+
     stringlist_clear(args);
     stringlist_append_copy(args, "PERMX");
     stringlist_append_copy(args, "TEST_EXPORT/test_export_field_rms_roff/PermX%d.roff");
     stringlist_append_copy(args, "0");
     stringlist_append_copy(args, "FORECAST");
     test_assert_true( ert_test_context_run_worklow_job( test_context , job_name , args) );
-    
+
     test_assert_true(util_file_exists("TEST_EXPORT/test_export_field_rms_roff/PermZ0"));
     test_assert_true(util_file_exists("TEST_EXPORT/test_export_field_rms_roff/PermZ1"));
     test_assert_true(util_file_exists("TEST_EXPORT/test_export_field_rms_roff/PermZ2"));
-    
+
     test_assert_true(util_file_exists("TEST_EXPORT/test_export_field_rms_roff/PermX0.roff"));
     test_assert_true(util_file_exists("TEST_EXPORT/test_export_field_rms_roff/PermX1.roff"));
     test_assert_true(util_file_exists("TEST_EXPORT/test_export_field_rms_roff/PermX2.roff"));
-    
+
     stringlist_free( args );
   }
 }

--- a/libenkf/tests/enkf_plot_gendata_fs.c
+++ b/libenkf/tests/enkf_plot_gendata_fs.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2014  Statoil ASA, Norway. 
-    
+   Copyright (C) 2014  Statoil ASA, Norway.
+
    The file 'enkf_plot_gendata_fs.c' is part of ERT - Ensemble based Reservoir Tool.
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 

--- a/libenkf/tests/gen_kw_logarithmic_test.c
+++ b/libenkf/tests/gen_kw_logarithmic_test.c
@@ -1,19 +1,19 @@
 /*
    Copyright (C) 2014  Statoil ASA, Norway.
-    
+
    The file 'gen_kw_test.c' is part of ERT - Ensemble based Reservoir Tool.
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 #include <stdlib.h>
 #include <stdbool.h>

--- a/libjob_queue/tests/job_queue_timeout_test.c
+++ b/libjob_queue/tests/job_queue_timeout_test.c
@@ -46,7 +46,7 @@ typedef struct
   int run_usleep;
   int argc;
   char ** argv;
-  const char * cmd;
+  char * cmd;
   int retry_call_count;
   int exit_call_count;
 } job_type;

--- a/python/python/res/enkf/res_config.py
+++ b/python/python/res/enkf/res_config.py
@@ -53,6 +53,7 @@ class ResConfig(BaseCClass):
     _add_config_items  = EnkfPrototype("void res_config_add_config_items(config_parser)")
     _init_parser       = EnkfPrototype("void res_config_init_config_parser(config_parser)", bind=False)
 
+
     def __init__(self, user_config_file=None, config=None, throw_on_error=True):
         self._errors, self._failed_keys = None, None
         self._assert_input(user_config_file, config, throw_on_error)
@@ -330,6 +331,9 @@ class ResConfig(BaseCClass):
             config_content.add_define(key, defines[key])
 
         # Insert key values
+        if not os.path.exists( config_dir ):
+            raise IOError("The configuration direcetory: %s does not exist" % config_dir)
+        
         path_elm = config_content.create_path_elm(config_dir)
         add_key_value = lambda key, value : config_parser.add_key_value(
                                                             config_content,

--- a/python/python/res/test/ert_test_context.py
+++ b/python/python/res/test/ert_test_context.py
@@ -31,20 +31,24 @@ class ErtTest(BaseCClass):
 
 
 
-    def __init__(self, test_name, model_config, store_area=False):
-        if not os.path.exists(model_config):
-            raise IOError("The configuration file: %s does not exist" % model_config)
-        else:
-            work_area = TestArea( test_name )
+    def __init__(self, test_name, model_config = None, config_dict = None, store_area=False):
+        if model_config is None and config_dict is None:
+            raise ValueError("Must suuply either model_config or config_dict argument")
+
+        work_area = TestArea( test_name )
+        work_area.convertToCReference( self )
+
+        if model_config:
             work_area.copy_parent_content( model_config )
-            work_area.convertToCReference( self )
-
             res_config = ResConfig( user_config_file = os.path.basename(model_config) )
-            res_config.convertToCReference( self )
+        else:
+            work_area.copy_directory_content( work_area.get_original_cwd( ))
+            res_config = ResConfig( config = config_dict )
 
-            c_ptr = self._alloc(work_area, res_config)
-            super(ErtTest, self).__init__(c_ptr)
-            self.setStore(store_area)
+        res_config.convertToCReference( self )
+        c_ptr = self._alloc(work_area, res_config)
+        super(ErtTest, self).__init__(c_ptr)
+        self.setStore(store_area)
 
         self.__ert = None
 
@@ -97,11 +101,12 @@ class ErtTest(BaseCClass):
 
 
 class ErtTestContext(object):
-    def __init__(self, test_name, model_config, store_area=False):
+    def __init__(self, test_name, model_config = None, config_dict = None, store_area=False):
         self.__test_name = test_name
         self.__model_config = model_config
         self.__store_area = store_area
-        self.__test_context = ErtTest(self.__test_name, self.__model_config, store_area=self.__store_area)
+        self.__config_dict = config_dict
+        self.__test_context = ErtTest(self.__test_name, model_config = self.__model_config, config_dict = config_dict, store_area=self.__store_area)
 
 
     def __enter__(self):

--- a/python/tests/res/enkf/test_res_config.py
+++ b/python/tests/res/enkf/test_res_config.py
@@ -24,7 +24,7 @@ from ecl.util.enums import RngAlgTypeEnum, MessageLevelEnum
 from res.sched import HistorySourceEnum
 
 from res.enkf import ResConfig, SiteConfig, AnalysisConfig
-
+from res.test import ErtTestContext
 
 # The res_config object should set the environment variable
 # 'DATA_ROOT' to the root directory with the config
@@ -492,3 +492,25 @@ class ResConfigTest(ExtendedTestCase):
 
             # TODO: Not tested
             # - MIN_REALIZATIONS
+
+    def test_missing_directory(self):
+        config = {
+            "INTERNALS" :
+            {
+                "CONFIG_DIRECTORY" : "does_not_exist",
+            },
+            "SIMULATION" :
+            {
+                "QUEUE_SYSTEM" :
+                {
+                    "JOBNAME" : "Job%d",
+                },
+                "RUNPATH"            : "/tmp/simulations/run%d",
+                "NUM_REALIZATIONS"   : 1,
+                "JOB_SCRIPT"         : "script.sh",
+                "ENSPATH"            : "Ensemble"
+            }
+        }
+
+        with self.assertRaises(IOError):
+            ResConfig( config = config )

--- a/python/tests/res/enkf/test_runpath_list.py
+++ b/python/tests/res/enkf/test_runpath_list.py
@@ -109,7 +109,7 @@ class RunpathListTest(ExtendedTestCase):
                     iteration = int(tmp[3])
 
                     path_list.append( (iens , iteration) )
-                
+
             for iens in range(4):
                 t0 = path_list[iens]
                 t4 = path_list[iens + 4]
@@ -129,7 +129,7 @@ class RunpathListTest(ExtendedTestCase):
             ens_size = ert.getEnsembleSize( )
             runner = ert.getEnkfSimulationRunner( )
             fs_manager = ert.getEnkfFsManager( )
-            
+
             init_fs = fs_manager.getFileSystem("init_fs")
             mask = BoolVector( initial_size = 100 , default_value = True )
             runpath_fmt = ert.getModelConfig().getRunpathFormat( )
@@ -141,9 +141,9 @@ class RunpathListTest(ExtendedTestCase):
 
             self.assertTrue( path.isfile( runpath_list.getExportFile( ) ))
             self.assertEqual( "test_runpath_list.txt" , path.basename( runpath_list.getExportFile( ) ))
-            
 
-            
+
+
     def test_assert_symlink_deleted(self):
         with ErtTestContext("create_runpath2" , self.createTestPath("local/snake_oil_field/snake_oil.ert")) as tc:
             ert = tc.getErt( )


### PR DESCRIPTION
**Task**
Ability to create `ErtTestContext` programatically with a dict instance instead of a configuration file.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

Depends on #133 