### PR TITLE
Fixed location of .ert_runpath_list file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ enable_testing()
 
 set( RES_VERSION_MAJOR 2 )   # Remember to update release notes whenever
 set( RES_VERSION_MINOR 2 )   # you change the ERT_VERSION_MINOR or MAJOR
-set( RES_VERSION_MICRO 10 )   # with "new in Ert Version X.X.X"!
+set( RES_VERSION_MICRO 11 )   # with "new in Ert Version X.X.X"!
 
 # If the micro version is not integer, that should be interpreted as a
 # development version leading towards version MAJOR.MINOR.0

--- a/libconfig/include/ert/config/config_content.h
+++ b/libconfig/include/ert/config/config_content.h
@@ -76,6 +76,7 @@ typedef struct config_content_struct config_content_type;
   config_path_elm_type * config_content_add_path_elm( config_content_type * content , const char * path );
   void config_content_pop_path_stack( config_content_type * content );
   const stringlist_type * config_content_get_warnings( const config_content_type * content);
+  const char * config_content_get_config_path( const config_content_type * content );
 
   UTIL_IS_INSTANCE_HEADER( config_content );
 

--- a/libconfig/src/config_content.c
+++ b/libconfig/src/config_content.c
@@ -43,6 +43,7 @@ struct config_content_struct {
   subst_list_type    * define_list;
   char               * config_file;
   char               * abs_path;
+  char               * config_path;
 
   config_root_path_type * invoke_path;
   vector_type           * path_elm_storage;
@@ -69,11 +70,8 @@ config_content_type * config_content_alloc(const char * filename) {
 
   content->config_file = util_alloc_string_copy( filename );
   content->abs_path = util_alloc_abs_path( filename );
-  {
-    char * path = util_split_alloc_dirname( filename );
-    content->invoke_path = config_root_path_alloc( NULL );
-    free( path );
-  }
+  content->config_path = util_split_alloc_dirname( content->abs_path );
+  content->invoke_path = config_root_path_alloc( NULL );
 
 
   return content;
@@ -138,6 +136,7 @@ void config_content_free( config_content_type * content ) {
   subst_list_free( content->define_list );
   util_safe_free( content->config_file );
   util_safe_free( content->abs_path );
+  util_safe_free( content->config_path );
   set_free( content->parsed_files );
   if (content->invoke_path != NULL)
     config_root_path_free( content->invoke_path );
@@ -427,4 +426,8 @@ config_path_elm_type * config_content_add_path_elm( config_content_type * conten
 
 void config_content_pop_path_stack( config_content_type * content ) {
   vector_pop_back( content->path_elm_stack );
+}
+
+const char * config_content_get_config_path( const config_content_type * content ) {
+  return content->config_path;
 }

--- a/libenkf/include/ert/enkf/runpath_list.h
+++ b/libenkf/include/ert/enkf/runpath_list.h
@@ -23,7 +23,7 @@ extern "C" {
 #endif
 
 #define RUNPATH_LIST_DEFAULT_LINE_FMT "%03d  %s  %s  %03d\n"
-
+#define RUNPATH_LIST_FILE ".ert_runpath_list"
 
   typedef struct runpath_list_struct runpath_list_type;
 

--- a/libenkf/src/hook_manager.c
+++ b/libenkf/src/hook_manager.c
@@ -161,6 +161,10 @@ void hook_manager_init( hook_manager_type * hook_manager , const config_content_
     const char * runpath_file = config_content_get_value_as_abspath(config_content, RUNPATH_FILE_KEY);
     hook_manager_set_runpath_list_file(hook_manager, NULL, runpath_file);
   }
+  else {
+    const char * runpath_path = config_content_get_config_path( config_content );
+    hook_manager_set_runpath_list_file(hook_manager, runpath_path, RUNPATH_LIST_FILE);
+  }
 }
 
 

--- a/libenkf/src/runpath_list.c
+++ b/libenkf/src/runpath_list.c
@@ -27,9 +27,6 @@
 
 #include <ert/enkf/runpath_list.h>
 
-#define RUNPATH_LIST_DIR  "<CWD>"
-#define RUNPATH_LIST_FILE ".ert_runpath_list"
-
 typedef struct runpath_node_struct runpath_node_type;
 
 
@@ -246,7 +243,7 @@ char * runpath_list_alloc_filename(const char * basepath, const char * filename)
     filename = RUNPATH_LIST_FILE;
 
   if(!basepath)
-    return util_alloc_filename(RUNPATH_LIST_DIR, filename, NULL);
+    return util_alloc_abs_path(filename);
 
   char * file_with_prefix = util_alloc_filename(basepath, filename, NULL);
   char * absolute_path    = util_alloc_abs_path(file_with_prefix);

--- a/libenkf/src/subst_config.c
+++ b/libenkf/src/subst_config.c
@@ -229,10 +229,11 @@ static void subst_config_init_load(
     hash_free(data_kw);
   }
 
-  if (config_content_has_item(content, RUNPATH_FILE_KEY)) {
-    const char * runpath_file = config_content_get_value_as_abspath(content, RUNPATH_FILE_KEY);
-    subst_config_add_internal_subst_kw(subst_config, "RUNPATH_FILE", runpath_file, "The name of a file with a list of run directories.");
-  }
+  const char * runpath_file = config_content_has_item(content, RUNPATH_FILE_KEY) ?
+      config_content_get_value_as_abspath(content, RUNPATH_FILE_KEY) :
+      util_alloc_filename(config_content_get_config_path( content ), RUNPATH_LIST_FILE, NULL);
+  subst_config_add_internal_subst_kw(subst_config, "RUNPATH_FILE", runpath_file,
+      "The name of a file with a list of run directories.");
 
   if (config_content_has_item(content, DATA_FILE_KEY)) {
     const char * data_file = config_content_get_value_as_abspath(content, DATA_FILE_KEY);

--- a/libenkf/tests/enkf_hook_manager_test.c
+++ b/libenkf/tests/enkf_hook_manager_test.c
@@ -25,8 +25,9 @@ int main(int argc, char ** argv) {
   ert_workflow_list_type * list = NULL;
   hook_manager_type * hook_manager = hook_manager_alloc_default(list);
 
-  char * expected_path = "<CWD>/.ert_runpath_list";
+  char * expected_path = util_alloc_abs_path(".ert_runpath_list");
   test_assert_string_equal(expected_path, hook_manager_get_runpath_list_file(hook_manager));
+  free(expected_path);
 
   hook_manager_set_runpath_list_file(hook_manager, "Folder", NULL);
   expected_path = util_alloc_abs_path("Folder/.ert_runpath_list");


### PR DESCRIPTION
Replaced <CWD> with the actual path

**Task**
Make sure that the .ert_runpath_list file is written to the same folder as the config file (unless otherwise specified in the config file itself)


**Approach**
Use the absolute path of the config file when needed


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
