### PR TITLE
Removed init_fs argument from run_context.

### DIFF
--- a/libenkf/include/ert/enkf/ert_run_context.h
+++ b/libenkf/include/ert/enkf/ert_run_context.h
@@ -42,36 +42,33 @@ typedef struct ert_run_context_struct ert_run_context_type;
 
   ert_run_context_type * ert_run_context_alloc(run_mode_type run_mode,
                                                init_mode_type init_mode,
-                                               enkf_fs_type * init_fs, 
-                                               enkf_fs_type * simulate_fs ,
+                                               enkf_fs_type * sim_fs ,
                                                enkf_fs_type * target_update_fs ,
                                                bool_vector_type * iactive ,
                                                path_fmt_type * runpath_fmt ,
                                                subst_list_type * subst_list ,
                                                int iter);
 
-  ert_run_context_type * ert_run_context_alloc_ENSEMBLE_EXPERIMENT(enkf_fs_type * init_fs ,
-                                                                   enkf_fs_type * result_fs ,
+  ert_run_context_type * ert_run_context_alloc_ENSEMBLE_EXPERIMENT(enkf_fs_type * sim_fs ,
                                                                    bool_vector_type * iactive ,
                                                                    const path_fmt_type * runpath_fmt ,
                                                                    const subst_list_type * subst_list ,
                                                                    int iter);
 
-  ert_run_context_type * ert_run_context_alloc_INIT_ONLY(enkf_fs_type * init_fs,
+  ert_run_context_type * ert_run_context_alloc_INIT_ONLY(enkf_fs_type * sim_fs,
                                                          init_mode_type init_mode,
                                                          bool_vector_type * iactive ,
                                                          const path_fmt_type * runpath_fmt ,
                                                          const subst_list_type * subst_list ,
                                                          int iter);
 
-  ert_run_context_type * ert_run_context_alloc_SMOOTHER_RUN(enkf_fs_type * simulate_fs , enkf_fs_type * target_update_fs ,
+  ert_run_context_type * ert_run_context_alloc_SMOOTHER_RUN(enkf_fs_type * sim_fs , enkf_fs_type * target_update_fs ,
                                                             bool_vector_type * iactive ,
                                                             const path_fmt_type * runpath_fmt ,
                                                             const subst_list_type * subst_list ,
                                                             int iter);
 
-  void                     ert_run_context_set_init_fs(ert_run_context_type * context,  enkf_fs_type * init_fs);
-  void                     ert_run_context_set_result_fs(ert_run_context_type * context, enkf_fs_type * result_fs);
+  void                     ert_run_context_set_sim_fs(ert_run_context_type * context, enkf_fs_type * sim_fs);
   void                     ert_run_context_set_update_target_fs(ert_run_context_type * context, enkf_fs_type * update_target_fs);
 
   void                     ert_run_context_free( ert_run_context_type * );
@@ -89,8 +86,7 @@ typedef struct ert_run_context_struct ert_run_context_type;
   init_mode_type           ert_run_context_get_init_mode( const ert_run_context_type * context );
   char                   * ert_run_context_alloc_run_id( );
 
-  enkf_fs_type * ert_run_context_get_init_fs(const ert_run_context_type * run_context);
-  enkf_fs_type * ert_run_context_get_result_fs(const ert_run_context_type * run_context);
+  enkf_fs_type * ert_run_context_get_sim_fs(const ert_run_context_type * run_context);
   enkf_fs_type * ert_run_context_get_update_target_fs(const ert_run_context_type * run_context);
 
   UTIL_IS_INSTANCE_HEADER( ert_run_context );

--- a/libenkf/include/ert/enkf/forward_load_context.h
+++ b/libenkf/include/ert/enkf/forward_load_context.h
@@ -47,7 +47,7 @@ extern "C" {
   const run_arg_type        * forward_load_context_get_run_arg( const forward_load_context_type * load_context );
   const char                * forward_load_context_get_run_path( const forward_load_context_type * load_context );
   int                         forward_load_context_get_load_step(const forward_load_context_type * load_context);
-  enkf_fs_type              * forward_load_context_get_result_fs( const forward_load_context_type * load_context );
+  enkf_fs_type              * forward_load_context_get_sim_fs( const forward_load_context_type * load_context );
   bool                        forward_load_context_load_restart_file( forward_load_context_type * load_context , int report_step );
   void                        forward_load_context_select_step( forward_load_context_type * load_context , int report_step);
 

--- a/libenkf/include/ert/enkf/run_arg.h
+++ b/libenkf/include/ert/enkf/run_arg.h
@@ -36,9 +36,9 @@ UTIL_SAFE_CAST_HEADER( run_arg );
 UTIL_IS_INSTANCE_HEADER( run_arg );
 
 
-  run_arg_type * run_arg_alloc_ENSEMBLE_EXPERIMENT(const char * run_id, enkf_fs_type * init_fs , enkf_fs_type * result_fs, int iens , int iter , const char * runpath);
-  run_arg_type * run_arg_alloc_INIT_ONLY(const char * run_id, enkf_fs_type * init_fs , int iens , int iter , const char * runpath);
-  run_arg_type * run_arg_alloc_SMOOTHER_RUN(const char * run_id , enkf_fs_type * simulate_fs , enkf_fs_type * update_target_fs , int iens , int iter , const char * runpath);
+  run_arg_type * run_arg_alloc_ENSEMBLE_EXPERIMENT(const char * run_id, enkf_fs_type * sim_fs, int iens , int iter , const char * runpath);
+  run_arg_type * run_arg_alloc_INIT_ONLY(const char * run_id, enkf_fs_type * sim_fs , int iens , int iter , const char * runpath);
+  run_arg_type * run_arg_alloc_SMOOTHER_RUN(const char * run_id , enkf_fs_type * sim_fs , enkf_fs_type * update_target_fs , int iens , int iter , const char * runpath);
 
   int            run_arg_get_step1( const run_arg_type * run_arg );
   int            run_arg_get_step2( const run_arg_type * run_arg );
@@ -64,9 +64,8 @@ UTIL_IS_INSTANCE_HEADER( run_arg );
   run_status_type run_arg_get_run_status( const run_arg_type * run_arg);
   void            run_arg_set_run_status( run_arg_type * run_arg , run_status_type run_status);
 
-  enkf_fs_type * run_arg_get_init_fs(const run_arg_type * run_arg);
   enkf_fs_type * run_arg_get_update_target_fs(const run_arg_type * run_arg);
-  enkf_fs_type * run_arg_get_result_fs(const run_arg_type * run_arg);
+  enkf_fs_type * run_arg_get_sim_fs(const run_arg_type * run_arg);
 
 #ifdef __cplusplus
 }

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1330,7 +1330,7 @@ void * enkf_main_icreate_run_path( enkf_main_type * enkf_main, run_arg_type * ru
 
   if (init_mode != INIT_NONE) {
     stringlist_type * param_list = ensemble_config_alloc_keylist_from_var_type(enkf_main_get_ensemble_config(enkf_main), PARAMETER );
-    enkf_fs_type * init_fs = run_arg_get_init_fs( run_arg );
+    enkf_fs_type * init_fs = run_arg_get_sim_fs( run_arg );
     enkf_state_initialize( enkf_state , init_fs , param_list , init_mode);
     stringlist_free( param_list );
   }
@@ -1362,7 +1362,7 @@ void enkf_main_create_run_path(enkf_main_type * enkf_main , const ert_run_contex
   {
     stringlist_type * param_list = ensemble_config_alloc_keylist_from_var_type(enkf_main_get_ensemble_config(enkf_main), PARAMETER );
     enkf_main_initialize_from_scratch(enkf_main ,
-                                      ert_run_context_get_init_fs( run_context ),
+                                      ert_run_context_get_sim_fs( run_context ),
                                       param_list ,
                                       ert_run_context_get_iactive( run_context ),
                                       init_mode);
@@ -1493,7 +1493,7 @@ static int enkf_main_run_step(enkf_main_type * enkf_main,
     bool     verbose_queue    = enkf_main->verbose;
     const int active_ens_size = util_int_min( bool_vector_size( ert_run_context_get_iactive( run_context )) , enkf_main_get_ensemble_size( enkf_main ));
 
-    state_map_deselect_matching( enkf_fs_get_state_map( ert_run_context_get_init_fs( run_context )) ,
+    state_map_deselect_matching( enkf_fs_get_state_map( ert_run_context_get_sim_fs( run_context )) ,
                                  ert_run_context_get_iactive( run_context ), STATE_LOAD_FAILURE | STATE_PARENT_FAILURE);
 
     job_size = bool_vector_count_equal( ert_run_context_get_iactive(run_context) , true );
@@ -1519,7 +1519,7 @@ static int enkf_main_run_step(enkf_main_type * enkf_main,
       }
     }
 
-    enkf_fs_fsync( ert_run_context_get_result_fs( run_context ) );
+    enkf_fs_fsync( ert_run_context_get_sim_fs( run_context ) );
     if (totalFailed == 0)
       res_log_add_fmt_message( LOG_INFO , NULL , "All jobs complete and data loaded.");
 
@@ -1585,7 +1585,7 @@ void enkf_main_init_run( enkf_main_type * enkf_main, const ert_run_context_type 
   {
     stringlist_type * param_list = ensemble_config_alloc_keylist_from_var_type(enkf_main_get_ensemble_config(enkf_main), PARAMETER );
     enkf_main_initialize_from_scratch(enkf_main ,
-                                      ert_run_context_get_init_fs( run_context ),
+                                      ert_run_context_get_sim_fs( run_context ),
                                       param_list ,
                                       ert_run_context_get_iactive( run_context ),
                                       ert_run_context_get_init_mode( run_context ));
@@ -1783,7 +1783,7 @@ void enkf_main_run_iterated_ES(enkf_main_type * enkf_main,
 
 
 ert_run_context_type * enkf_main_alloc_ert_run_context_ENSEMBLE_EXPERIMENT(const enkf_main_type * enkf_main , enkf_fs_type * fs , bool_vector_type * iactive , int iter) {
-  return ert_run_context_alloc_ENSEMBLE_EXPERIMENT( fs, fs , iactive , model_config_get_runpath_fmt(enkf_main_get_model_config(enkf_main)) , enkf_main_get_data_kw(enkf_main) , iter );
+  return ert_run_context_alloc_ENSEMBLE_EXPERIMENT( fs , iactive , model_config_get_runpath_fmt(enkf_main_get_model_config(enkf_main)) , enkf_main_get_data_kw(enkf_main) , iter );
 }
 
 
@@ -2276,7 +2276,7 @@ int enkf_main_load_from_forward_model_with_fs(enkf_main_type * enkf_main, int it
   int result[ens_size];
   model_config_type * model_config = enkf_main_get_model_config(enkf_main);
 
-  ert_run_context_type * run_context = ert_run_context_alloc_ENSEMBLE_EXPERIMENT( fs, fs , iactive , model_config_get_runpath_fmt( model_config ) , enkf_main_get_data_kw(enkf_main) , iter );
+  ert_run_context_type * run_context = ert_run_context_alloc_ENSEMBLE_EXPERIMENT( fs , iactive , model_config_get_runpath_fmt( model_config ) , enkf_main_get_data_kw(enkf_main) , iter );
   arg_pack_type ** arg_list = util_calloc( ens_size , sizeof * arg_list );
   thread_pool_type * tp     = thread_pool_alloc( 4 , true );  /* num_cpu - HARD coded. */
 

--- a/libenkf/src/enkf_state_nodes.c
+++ b/libenkf/src/enkf_state_nodes.c
@@ -86,7 +86,7 @@ static void enkf_state_internalize_eclipse_state(enkf_state_type * enkf_state ,
 
   {
     const run_arg_type * run_arg = forward_load_context_get_run_arg( load_context );
-    enkf_fs_type * result_fs = run_arg_get_result_fs( run_arg );
+    enkf_fs_type * sim_fs = run_arg_get_sim_fs( run_arg );
 
     member_config_type * my_config     = enkf_state->my_config;
     const int  iens                    = member_config_get_iens( my_config );
@@ -106,7 +106,7 @@ static void enkf_state_internalize_eclipse_state(enkf_state_type * enkf_state ,
         if (enkf_node_forward_load(enkf_node , load_context)) {
           node_id_type node_id = {.report_step = report_step ,
                                   .iens = iens };
-          enkf_node_store( enkf_node , result_fs, store_vectors , node_id );
+          enkf_node_store( enkf_node , sim_fs, store_vectors , node_id );
         } else {
           forward_load_context_update_result(load_context, LOAD_FAILURE);
           res_log_add_fmt_message(LOG_ERROR, NULL , "[%03d:%04d] Failed load data for FIELD node:%s.",iens , report_step , enkf_node_get_key( enkf_node ));
@@ -135,7 +135,7 @@ int enkf_state_forward_init(enkf_state_type * enkf_state ,
     while ( !hash_iter_is_complete(iter) ) {
       enkf_node_type * node = hash_iter_get_next_value(iter);
       if (enkf_node_use_forward_init(node)) {
-        enkf_fs_type * result_fs = run_arg_get_result_fs( run_arg );
+        enkf_fs_type * sim_fs = run_arg_get_sim_fs( run_arg );
         node_id_type node_id = {.report_step = 0 ,
                                 .iens = iens };
 
@@ -146,9 +146,9 @@ int enkf_state_forward_init(enkf_state_type * enkf_state ,
            instance, and not from the current run of e.g. RMS.
         */
 
-        if (!enkf_node_has_data( node , result_fs , node_id)) {
+        if (!enkf_node_has_data( node , sim_fs , node_id)) {
           if (enkf_node_forward_init(node , run_arg_get_runpath( run_arg ) , iens ))
-            enkf_node_store( node , result_fs , false , node_id );
+            enkf_node_store( node , sim_fs , false , node_id );
           else {
             char * init_file = enkf_config_node_alloc_initfile( enkf_node_get_config( node ) , run_arg_get_runpath(run_arg) , iens );
 

--- a/libenkf/src/forward_load_context.c
+++ b/libenkf/src/forward_load_context.c
@@ -248,8 +248,8 @@ const char * forward_load_context_get_run_path( const forward_load_context_type 
 }
 
 
-enkf_fs_type * forward_load_context_get_result_fs( const forward_load_context_type * load_context ) {
-  return run_arg_get_result_fs( load_context->run_arg );
+enkf_fs_type * forward_load_context_get_sim_fs( const forward_load_context_type * load_context ) {
+  return run_arg_get_sim_fs( load_context->run_arg );
 }
 
 

--- a/libenkf/src/gen_data_config.c
+++ b/libenkf/src/gen_data_config.c
@@ -436,7 +436,7 @@ void gen_data_config_update_active(gen_data_config_type * config, const forward_
            i.e. we update the on-disk representation.
         */
         char * filename = util_alloc_sprintf("%s_active" , config->key );
-        FILE * stream   = enkf_fs_open_case_tstep_file( forward_load_context_get_result_fs( load_context ) , 
+        FILE * stream   = enkf_fs_open_case_tstep_file( forward_load_context_get_sim_fs( load_context ) , 
 							filename , 
 							report_step , 
 							"w");

--- a/libenkf/src/run_arg.c
+++ b/libenkf/src/run_arg.c
@@ -43,8 +43,7 @@ struct run_arg_struct {
   run_mode_type           run_mode;             /* What type of run this is */
   int                     queue_index;          /* The job will in general have a different index in the queue than the iens number. */
 
-  enkf_fs_type          * init_fs;
-  enkf_fs_type          * result_fs;
+  enkf_fs_type          * sim_fs;
   enkf_fs_type          * update_target_fs;
 
   /******************************************************************/
@@ -59,8 +58,7 @@ UTIL_IS_INSTANCE_FUNCTION( run_arg , RUN_ARG_TYPE_ID )
 
 
 static run_arg_type * run_arg_alloc(const char * run_id,
-                                    enkf_fs_type * init_fs ,
-                                    enkf_fs_type * result_fs ,
+                                    enkf_fs_type * sim_fs ,
                                     enkf_fs_type * update_target_fs ,
                                     int iens ,
                                     run_mode_type run_mode          ,
@@ -68,14 +66,13 @@ static run_arg_type * run_arg_alloc(const char * run_id,
                                     int step2                       ,
                                     int iter                        ,
                                     const char * runpath) {
-  if ((result_fs != NULL) && (result_fs == update_target_fs))
-    util_abort("%s: internal error - can  not have result_fs == update_target_fs \n",__func__);
+  if ((sim_fs != NULL) && (sim_fs == update_target_fs))
+    util_abort("%s: internal error - can  not have sim_fs == update_target_fs \n",__func__);
   {
     run_arg_type * run_arg = util_malloc(sizeof * run_arg );
     UTIL_TYPE_ID_INIT(run_arg , RUN_ARG_TYPE_ID);
     run_arg->run_id = util_alloc_string_copy( run_id );
-    run_arg->init_fs = init_fs;
-    run_arg->result_fs = result_fs;
+    run_arg->sim_fs = sim_fs;
     run_arg->update_target_fs = update_target_fs;
 
     run_arg->iens = iens;
@@ -101,18 +98,18 @@ static run_arg_type * run_arg_alloc(const char * run_id,
 
 
 
-run_arg_type * run_arg_alloc_ENSEMBLE_EXPERIMENT(const char * run_id, enkf_fs_type * init_fs , enkf_fs_type * result_fs, int iens , int iter , const char * runpath) {
-  return run_arg_alloc(run_id, init_fs , result_fs , NULL , iens , ENSEMBLE_EXPERIMENT , 0 , 0 , iter , runpath);
+run_arg_type * run_arg_alloc_ENSEMBLE_EXPERIMENT(const char * run_id, enkf_fs_type * sim_fs, int iens , int iter , const char * runpath) {
+  return run_arg_alloc(run_id, sim_fs , NULL , iens , ENSEMBLE_EXPERIMENT , 0 , 0 , iter , runpath);
 }
 
 
-run_arg_type * run_arg_alloc_INIT_ONLY(const char * run_id, enkf_fs_type * init_fs , int iens , int iter , const char * runpath) {
-  return run_arg_alloc(run_id , init_fs , NULL , NULL , iens , INIT_ONLY , 0 , 0 , iter , runpath);
+run_arg_type * run_arg_alloc_INIT_ONLY(const char * run_id, enkf_fs_type * sim_fs , int iens , int iter , const char * runpath) {
+  return run_arg_alloc(run_id , sim_fs , NULL , iens , INIT_ONLY , 0 , 0 , iter , runpath);
 }
 
 
-run_arg_type * run_arg_alloc_SMOOTHER_RUN(const char * run_id , enkf_fs_type * simulate_fs , enkf_fs_type * update_target_fs , int iens , int iter , const char * runpath) {
-  return run_arg_alloc(run_id, simulate_fs , simulate_fs , update_target_fs , iens , ENSEMBLE_EXPERIMENT , 0 , 0 , iter , runpath);
+run_arg_type * run_arg_alloc_SMOOTHER_RUN(const char * run_id , enkf_fs_type * sim_fs , enkf_fs_type * update_target_fs , int iens , int iter , const char * runpath) {
+  return run_arg_alloc(run_id, sim_fs, update_target_fs , iens , ENSEMBLE_EXPERIMENT , 0 , 0 , iter , runpath);
 }
 
 
@@ -228,21 +225,13 @@ void run_arg_set_run_status( run_arg_type * run_arg , run_status_type run_status
 
 
 
-enkf_fs_type * run_arg_get_init_fs(const run_arg_type * run_arg) {
-  if (run_arg->init_fs)
-    return run_arg->init_fs;
-  else {
-    util_abort("%s: internal error - tried to access run_arg->init_fs when init_fs == NULL\n",__func__);
-    return NULL;
-  }
-}
 
 
-enkf_fs_type * run_arg_get_result_fs(const run_arg_type * run_arg) {
-  if (run_arg->result_fs)
-    return run_arg->result_fs;
+enkf_fs_type * run_arg_get_sim_fs(const run_arg_type * run_arg) {
+  if (run_arg->sim_fs)
+    return run_arg->sim_fs;
   else {
-    util_abort("%s: internal error - tried to access run_arg->result_fs when result_fs == NULL\n",__func__);
+    util_abort("%s: internal error - tried to access run_arg->sim_fs when sim_fs == NULL\n",__func__);
     return NULL;
   }
 }

--- a/libenkf/tests/enkf_ert_run_context.c
+++ b/libenkf/tests/enkf_ert_run_context.c
@@ -33,7 +33,7 @@ void test_create() {
     enkf_fs_type * fs = NULL;
     subst_list_type * subst_list = subst_list_alloc( NULL );
     path_fmt_type * runpath_fmt = path_fmt_alloc_directory_fmt("/tmp/path/%04d");
-    ert_run_context_type * context = ert_run_context_alloc_ENSEMBLE_EXPERIMENT( fs, fs, iactive , runpath_fmt , subst_list , iter );
+    ert_run_context_type * context = ert_run_context_alloc_ENSEMBLE_EXPERIMENT( fs, iactive , runpath_fmt , subst_list , iter );
 
     test_assert_true( ert_run_context_is_instance( context ));
     test_assert_int_equal( 8 , ert_run_context_get_size( context ));
@@ -61,7 +61,7 @@ void test_create_ENSEMBLE_EXPERIMENT() {
     subst_list_type * subst_list = subst_list_alloc( NULL );
     path_fmt_type * runpath_fmt = path_fmt_alloc_directory_fmt("/tmp/path/%04d/%d");
     enkf_fs_type * fs = NULL;
-    ert_run_context_type * context = ert_run_context_alloc_ENSEMBLE_EXPERIMENT( fs, fs, iactive , runpath_fmt , subst_list , 7 );
+    ert_run_context_type * context = ert_run_context_alloc_ENSEMBLE_EXPERIMENT( fs, iactive , runpath_fmt , subst_list , 7 );
 
     test_assert_true( ert_run_context_is_instance( context ));
     test_assert_int_equal( 8 , ert_run_context_get_size( context ));
@@ -100,7 +100,7 @@ void test_iactive_update() {
     subst_list_type * subst_list = subst_list_alloc( NULL );
     path_fmt_type * runpath_fmt = path_fmt_alloc_directory_fmt("/tmp/path/%04d/%d");
     enkf_fs_type * fs = NULL;
-    ert_run_context_type * context = ert_run_context_alloc_ENSEMBLE_EXPERIMENT( fs, fs, iactive , runpath_fmt , subst_list , 7 );
+    ert_run_context_type * context = ert_run_context_alloc_ENSEMBLE_EXPERIMENT( fs, iactive , runpath_fmt , subst_list , 7 );
 
     ert_run_context_deactivate_realization( context , 0 );
     ert_run_context_deactivate_realization( context , 5 );

--- a/libenkf/tests/enkf_forward_init_FIELD.c
+++ b/libenkf/tests/enkf_forward_init_FIELD.c
@@ -96,7 +96,7 @@ int main(int argc , char ** argv) {
       const enkf_config_node_type * field_config_node = ensemble_config_get_node( ens_config , "PORO" );
       enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
       enkf_node_type * field_node = enkf_node_alloc( field_config_node );
-      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs, fs , 0 ,0 , "simulations/run0");
+      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs, 0 ,0 , "simulations/run0");
       node_id_type node_id = {.report_step = 0 ,
                               .iens = 0 };
 

--- a/libenkf/tests/enkf_forward_init_GEN_KW.c
+++ b/libenkf/tests/enkf_forward_init_GEN_KW.c
@@ -91,7 +91,7 @@ int main(int argc , char ** argv) {
     if (forward_init) {
       enkf_state_type * state   = enkf_main_iget_state( enkf_main , 0 );
       enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
-      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs , fs , 0 , 0 , "simulations/run0");
+      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs , 0 , 0 , "simulations/run0");
       const enkf_config_node_type * gen_kw_config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ), "MULTFLT");
       enkf_node_type * gen_kw_node = enkf_node_alloc( gen_kw_config_node );
       node_id_type node_id = {.report_step = 0 ,

--- a/libenkf/tests/enkf_forward_init_GEN_PARAM.c
+++ b/libenkf/tests/enkf_forward_init_GEN_PARAM.c
@@ -95,7 +95,7 @@ int main(int argc , char ** argv) {
       const enkf_config_node_type * config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ) , "PARAM" );
       enkf_node_type * gen_param_node = enkf_node_alloc( config_node );
       enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
-      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs, fs , 0 , 0 , "simulations/run0");
+      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs , 0 , 0 , "simulations/run0");
 
       node_id_type node_id = {.report_step = 0 ,
                               .iens = 0};

--- a/libenkf/tests/enkf_forward_load_context.c
+++ b/libenkf/tests/enkf_forward_load_context.c
@@ -48,7 +48,7 @@ void test_create() {
 }
 
 void test_load_restart1() {
-  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", NULL, NULL , 0 , 0 , "run");
+  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", NULL, 0 , 0 , "run");
   ecl_config_type * ecl_config = ecl_config_alloc(NULL);
 
   forward_load_context_type * load_context = forward_load_context_alloc( run_arg , false , ecl_config , "BASE" , NULL );
@@ -74,7 +74,7 @@ void make_restart_mock( const char * path , const char * eclbase , int report_st
 void test_load_restart2() {
   test_work_area_type * work_area = test_work_area_alloc("forward_load");
   {
-    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", NULL, NULL , 0 , 0 , "run");
+    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", NULL , 0 , 0 , "run");
     ecl_config_type * ecl_config = ecl_config_alloc(NULL);
     forward_load_context_type * load_context = forward_load_context_alloc( run_arg , false , ecl_config , "BASE" , NULL );
     util_make_path("run");

--- a/libenkf/tests/enkf_run_arg.c
+++ b/libenkf/tests/enkf_run_arg.c
@@ -42,7 +42,7 @@ void test_queue_index() {
   test_work_area_type * test_area = test_work_area_alloc("run_arg/ENS");
   {
     enkf_fs_type * fs   = enkf_fs_create_fs("sim" , BLOCK_FS_DRIVER_ID , NULL , true);
-    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", fs , fs, 0 , 6 , "path");
+    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", fs , 0 , 6 , "path");
 
     test_assert_false( run_arg_is_submitted( run_arg ) );
     test_assert_util_abort("run_arg_get_queue_index" , call_get_queue_index , run_arg );
@@ -58,9 +58,9 @@ void test_queue_index() {
   test_work_area_free( test_area );
 }
 
-void call_get_result_fs( void * arg ) {
+void call_get_sim_fs( void * arg ) {
   run_arg_type * run_arg = run_arg_safe_cast( arg );
-  run_arg_get_result_fs( run_arg );
+  run_arg_get_sim_fs( run_arg );
 }
 
 
@@ -78,8 +78,7 @@ void test_SMOOTHER_RUN( ) {
     enkf_fs_type * target_fs = enkf_fs_create_fs("target" , BLOCK_FS_DRIVER_ID , NULL , true);
     run_arg_type * run_arg = run_arg_alloc_SMOOTHER_RUN("run_id", sim_fs , target_fs , 0 , 6 , "path");
     test_assert_true( run_arg_is_instance( run_arg ));
-    test_assert_ptr_equal( run_arg_get_init_fs( run_arg ) , sim_fs );
-    test_assert_ptr_equal( run_arg_get_result_fs( run_arg ) , sim_fs );
+    test_assert_ptr_equal( run_arg_get_sim_fs( run_arg ) , sim_fs );
     test_assert_ptr_equal( run_arg_get_update_target_fs( run_arg ) , target_fs );
     run_arg_free( run_arg );
 
@@ -114,9 +113,8 @@ void test_INIT_ONLY( ) {
 
     run_arg_type * run_arg = run_arg_alloc_INIT_ONLY("run_id", init_fs , 0 , 6 , "path");
     test_assert_true( run_arg_is_instance( run_arg ));
-    test_assert_ptr_equal( run_arg_get_init_fs( run_arg ) , init_fs );
+    test_assert_ptr_equal( run_arg_get_sim_fs( run_arg ) , init_fs );
 
-    test_assert_util_abort( "run_arg_get_result_fs" , call_get_result_fs , run_arg );
     test_assert_util_abort( "run_arg_get_update_target_fs" , call_get_update_target_fs , run_arg );
     run_arg_free( run_arg );
 
@@ -131,11 +129,10 @@ void test_ENSEMBLE_EXPERIMENT( ) {
   {
     enkf_fs_type * fs   = enkf_fs_create_fs("sim" , BLOCK_FS_DRIVER_ID , NULL , true);
 
-    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", fs, fs , 0 , 6 , "path");
+    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", fs , 0 , 6 , "path");
     test_assert_true( run_arg_is_instance( run_arg ));
 
-    test_assert_ptr_equal( run_arg_get_init_fs( run_arg ) , fs );
-    test_assert_ptr_equal( run_arg_get_result_fs( run_arg ) , fs );
+    test_assert_ptr_equal( run_arg_get_sim_fs( run_arg ) , fs );
     test_assert_util_abort( "run_arg_get_update_target_fs" , call_get_update_target_fs , run_arg );
 
     test_assert_string_equal( run_arg_get_run_id( run_arg ) , "run_id");

--- a/python/python/res/enkf/ert_run_context.py
+++ b/python/python/res/enkf/ert_run_context.py
@@ -21,8 +21,8 @@ from ecl.util import PathFormat, StringList
 
 class ErtRunContext(BaseCClass):
     TYPE_NAME = "ert_run_context"
-    _alloc              = EnkfPrototype("void* ert_run_context_alloc( enkf_run_mode_enum , enkf_init_mode_enum, enkf_fs, enkf_fs , enkf_fs, bool_vector, path_fmt ,subst_list, int)", bind = False)
-    _alloc_ensemble_experiment = EnkfPrototype("ert_run_context_obj ert_run_context_alloc_ENSEMBLE_EXPERIMENT( enkf_fs , enkf_fs, bool_vector, path_fmt ,subst_list, int)", bind = False)
+    _alloc              = EnkfPrototype("void* ert_run_context_alloc( enkf_run_mode_enum , enkf_init_mode_enum, enkf_fs , enkf_fs, bool_vector, path_fmt ,subst_list, int)", bind = False)
+    _alloc_ensemble_experiment = EnkfPrototype("ert_run_context_obj ert_run_context_alloc_ENSEMBLE_EXPERIMENT( enkf_fs, bool_vector, path_fmt ,subst_list, int)", bind = False)
     _alloc_ensemble_smoother = EnkfPrototype("ert_run_context_obj ert_run_context_alloc_SMOOTHER_RUN( enkf_fs , enkf_fs, bool_vector, path_fmt ,subst_list, int)", bind = False)
     _alloc_runpath_list = EnkfPrototype("stringlist_obj ert_run_context_alloc_runpath_list(bool_vector, path_fmt, subst_list, int)", bind = False)
     _alloc_runpath      = EnkfPrototype("char* ert_run_context_alloc_runpath(int, path_fmt, subst_list, int)", bind = False)
@@ -34,11 +34,11 @@ class ErtRunContext(BaseCClass):
     _get_mask           = EnkfPrototype("bool_vector_ref ert_run_context_get_iactive( ert_run_context )")
     _get_iter           = EnkfPrototype("int ert_run_context_get_iter( ert_run_context )")
     _get_target_fs      = EnkfPrototype("enkf_fs_ref ert_run_context_get_update_target_fs( ert_run_context )")
-    _get_result_fs      = EnkfPrototype("enkf_fs_ref ert_run_context_get_result_fs( ert_run_context )")
+    _get_sim_fs         = EnkfPrototype("enkf_fs_ref ert_run_context_get_sim_fs( ert_run_context )")
     _get_init_mode      = EnkfPrototype("enkf_init_mode_enum ert_run_context_get_init_mode( ert_run_context )")
     
-    def __init__(self , run_type , init_fs , result_fs, target_fs , mask , path_fmt , subst_list , itr, init_mode = EnkfInitModeEnum.INIT_CONDITIONAL):
-        c_ptr = self._alloc( run_type, init_mode, init_fs , result_fs, target_fs, mask , path_fmt , subst_list, itr)
+    def __init__(self , run_type , sim_fs, target_fs , mask , path_fmt , subst_list , itr, init_mode = EnkfInitModeEnum.INIT_CONDITIONAL):
+        c_ptr = self._alloc( run_type, init_mode, sim_fs, target_fs, mask , path_fmt , subst_list, itr)
         super(ErtRunContext, self).__init__(c_ptr)
 
         # The C object ert_run_context uses a shared object for the
@@ -49,8 +49,8 @@ class ErtRunContext(BaseCClass):
         self._subst_list = subst_list
 
     @classmethod
-    def ensemble_experiment(cls, init_fs, result_fs, mask, path_fmt, subst_list , itr):
-        run_context = cls._alloc_ensemble_experiment( init_fs , result_fs, mask , path_fmt , subst_list, itr)
+    def ensemble_experiment(cls, sim_fs, mask, path_fmt, subst_list , itr):
+        run_context = cls._alloc_ensemble_experiment( sim_fs, mask , path_fmt , subst_list, itr)
 
         # The C object ert_run_context uses a shared object for the
         # path_fmt, mask and subst_list objects. We therefor hold on
@@ -133,8 +133,8 @@ class ErtRunContext(BaseCClass):
         return self._get_target_fs( )
 
 
-    def get_result_fs(self):
-        return self._get_result_fs( )
+    def get_sim_fs(self):
+        return self._get_sim_fs( )
 
 
     def get_init_mode(self):

--- a/python/python/res/enkf/es_update.py
+++ b/python/python/res/enkf/es_update.py
@@ -32,6 +32,6 @@ class ESUpdate(BaseCClass):
 
 
     def smootherUpdate( self , run_context):
-        data_fs   = run_context.get_result_fs( )
+        data_fs   = run_context.get_sim_fs( )
         target_fs = run_context.get_target_fs( )
         return self._smoother_update(data_fs, target_fs)

--- a/python/python/res/enkf/run_arg.py
+++ b/python/python/res/enkf/run_arg.py
@@ -20,7 +20,7 @@ from res.enkf import EnkfPrototype
 class RunArg(BaseCClass):
     TYPE_NAME = "run_arg"
 
-    _alloc_ENSEMBLE_EXPERIMENT = EnkfPrototype("run_arg_obj run_arg_alloc_ENSEMBLE_EXPERIMENT(char*, enkf_fs , enkf_fs, int, int, char*)", bind = False)
+    _alloc_ENSEMBLE_EXPERIMENT = EnkfPrototype("run_arg_obj run_arg_alloc_ENSEMBLE_EXPERIMENT(char*, enkf_fs, int, int, char*)", bind = False)
     _free                      = EnkfPrototype("void run_arg_free(run_arg)")
     _get_queue_index           = EnkfPrototype("int  run_arg_get_queue_index(run_arg)")
     _is_submitted              = EnkfPrototype("bool run_arg_is_submitted(run_arg)")
@@ -31,7 +31,7 @@ class RunArg(BaseCClass):
 
     @classmethod
     def createEnsembleExperimentRunArg(cls, run_id, fs, iens, runpath, iter=0):
-        return cls._alloc_ENSEMBLE_EXPERIMENT(run_id, fs, fs, iens, iter, runpath)
+        return cls._alloc_ENSEMBLE_EXPERIMENT(run_id, fs, iens, iter, runpath)
 
     def free(self):
         self._free()

--- a/python/python/res/server/simulation_context.py
+++ b/python/python/res/server/simulation_context.py
@@ -9,7 +9,7 @@ from res.enkf.enums import EnkfRunType, EnkfInitModeEnum
 
 
 class SimulationContext(object):
-    def __init__(self, ert, init_fs, result_fs, mask, itr , verbose=False):
+    def __init__(self, ert, sim_fs, mask, itr , verbose=False):
         self._ert = ert
         """ :type: res.enkf.EnKFMain """
         max_runtime = ert.analysisConfig().get_max_runtime()
@@ -26,7 +26,7 @@ class SimulationContext(object):
 
         subst_list = self._ert.getDataKW( )
         path_fmt = self._ert.getModelConfig().getRunpathFormat()
-        self._run_context = ErtRunContext( EnkfRunType.ENSEMBLE_EXPERIMENT, init_fs, result_fs, None, mask, path_fmt, subst_list, itr)
+        self._run_context = ErtRunContext( EnkfRunType.ENSEMBLE_EXPERIMENT, sim_fs, None, mask, path_fmt, subst_list, itr)
 
         
     def addSimulation(self, iens):
@@ -97,8 +97,8 @@ class SimulationContext(object):
         fmt =  fmt % (running, numRunn, numSucc, numFail, numWait)
         return 'SimulationContext(%s)' % fmt
 
-    def get_result_fs(self):
-        return self._run_context.get_result_fs( )
+    def get_sim_fs(self):
+        return self._run_context.get_sim_fs( )
 
 
     def get_run_context(self):

--- a/python/tests/res/enkf/data/test_custom_kw.py
+++ b/python/tests/res/enkf/data/test_custom_kw.py
@@ -101,7 +101,7 @@ class CustomKWTest(ExtendedTestCase):
             fs_manager = ert.getEnkfFsManager( )
             fs = fs_manager.getFileSystem("fs")
             
-            run_context = ErtRunContext( EnkfRunType.ENSEMBLE_EXPERIMENT , fs, fs, fs , active , runpath_fmt, subst_list , iteration_count)
+            run_context = ErtRunContext( EnkfRunType.ENSEMBLE_EXPERIMENT , fs, fs , active , runpath_fmt, subst_list , iteration_count)
             
             simulation_runner.createRunPath( run_context )
             simulation_runner.runEnsembleExperiment(job_queue, run_context)

--- a/python/tests/res/enkf/test_run_context.py
+++ b/python/tests/res/enkf/test_run_context.py
@@ -11,20 +11,19 @@ class ErtRunContextTest(ExtendedTestCase):
     def test_create(self):
         with TestAreaContext("run_context"):
             arg = None
-            init_fs = EnkfFs.createFileSystem("init_fs", EnKFFSType.BLOCK_FS_DRIVER_ID, arg)
-            result_fs = None
+            sim_fs = EnkfFs.createFileSystem("sim_fs", EnKFFSType.BLOCK_FS_DRIVER_ID, arg)
             target_fs = None
 
             mask = BoolVector( initial_size = 100 , default_value = True )
             runpath_fmt = PathFormat( "path/to/sim%d" )
             subst_list = SubstitutionList( )
             itr = 0
-            run_context1 = ErtRunContext( EnkfRunType.ENSEMBLE_EXPERIMENT , init_fs, result_fs, target_fs , mask , runpath_fmt, subst_list , itr )
+            run_context1 = ErtRunContext( EnkfRunType.ENSEMBLE_EXPERIMENT , sim_fs, target_fs , mask , runpath_fmt, subst_list , itr )
             run_id1 = run_context1.get_id( )
             run_arg0 = run_context1[0]
             self.assertEqual( run_id1 , run_arg0.get_run_id( ))
             
-            run_context2 = ErtRunContext( EnkfRunType.ENSEMBLE_EXPERIMENT , init_fs, result_fs , target_fs, mask , runpath_fmt, subst_list , itr )
+            run_context2 = ErtRunContext( EnkfRunType.ENSEMBLE_EXPERIMENT , sim_fs , target_fs, mask , runpath_fmt, subst_list , itr )
             run_id2 = run_context2.get_id( )
 
             self.assertFalse( run_id1 == run_id2 )

--- a/python/tests/res/enkf/test_runpath_list.py
+++ b/python/tests/res/enkf/test_runpath_list.py
@@ -135,7 +135,7 @@ class RunpathListTest(ExtendedTestCase):
             runpath_fmt = ert.getModelConfig().getRunpathFormat( )
             subst_list = SubstitutionList( )
             itr = 0
-            run_context1 = ErtRunContext( EnkfRunType.INIT_ONLY , init_fs, None,None , mask , runpath_fmt, subst_list , itr )
+            run_context1 = ErtRunContext( EnkfRunType.INIT_ONLY , init_fs, None , mask , runpath_fmt, subst_list , itr )
 
             runner.createRunPath( run_context1 )
 
@@ -159,7 +159,7 @@ class RunpathListTest(ExtendedTestCase):
             runpath_fmt = ert.getModelConfig().getRunpathFormat( )
             subst_list = SubstitutionList( )
             itr = 0
-            run_context = ErtRunContext( EnkfRunType.INIT_ONLY , init_fs, None,None , mask , runpath_fmt, subst_list , itr )
+            run_context = ErtRunContext( EnkfRunType.INIT_ONLY , init_fs, None , mask , runpath_fmt, subst_list , itr )
             runner.createRunPath( run_context )
 
             # replace field file with symlink

--- a/python/tests/res/server/test_simulation_context.py
+++ b/python/tests/res/server/test_simulation_context.py
@@ -34,8 +34,8 @@ class SimulationContextTest(ExtendedTestCase):
             first_half = fs_manager.getFileSystem("first_half")
             other_half = fs_manager.getFileSystem("other_half")
 
-            simulation_context1 = SimulationContext(ert, first_half, first_half , mask1 , 0)
-            simulation_context2 = SimulationContext(ert, other_half, other_half , mask2 , 0)
+            simulation_context1 = SimulationContext(ert, first_half, mask1 , 0)
+            simulation_context2 = SimulationContext(ert, other_half, mask2 , 0)
 
             ert.createRunpath( simulation_context1.get_run_context( ) )
             ert.createRunpath( simulation_context2.get_run_context( ) )


### PR DESCRIPTION
**Task**
The `ert_run_context` datatype has taken three `enkf_fs` arguments for initialization, simulation and updates respectively. In principle it is possible to have `init_fs != sim_fs` - but that will in practice always lead to an invalid state in `sim_fs`. With this PR we have just removed the `init_fs` argument.



**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps


