### PR TITLE
Always add RUNPATH_FILE to the substitution list

### DIFF
--- a/libenkf/src/subst_config.c
+++ b/libenkf/src/subst_config.c
@@ -229,10 +229,11 @@ static void subst_config_init_load(
     hash_free(data_kw);
   }
 
-  if (config_content_has_item(content, RUNPATH_FILE_KEY)) {
-    const char * runpath_file = config_content_get_value_as_abspath(content, RUNPATH_FILE_KEY);
-    subst_config_add_internal_subst_kw(subst_config, "RUNPATH_FILE", runpath_file, "The name of a file with a list of run directories.");
-  }
+  const char * runpath_file = config_content_has_item(content, RUNPATH_FILE_KEY) ?
+      config_content_get_value_as_abspath(content, RUNPATH_FILE_KEY) :
+      util_alloc_filename(config_content_get_config_path( content ), RUNPATH_LIST_FILE, NULL);
+  subst_config_add_internal_subst_kw(subst_config, "RUNPATH_FILE", runpath_file,
+      "The name of a file with a list of run directories.");
 
   if (config_content_has_item(content, DATA_FILE_KEY)) {
     const char * data_file = config_content_get_value_as_abspath(content, DATA_FILE_KEY);


### PR DESCRIPTION
even when it isn't specified in the config file

**Task**
Make sure that the keyword RUNPATH_FILE is correctly replaced when used in workflows


**Approach**
If RUNPATH_FILE is not specified in the config file, use the default name of the runpath file with the absolute path of the config file 


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
