### PR TITLE
Error in span section

### DIFF
--- a/libjob_queue/src/lsf_driver.c
+++ b/libjob_queue/src/lsf_driver.c
@@ -330,6 +330,90 @@ static void lsf_driver_assert_submit_method( const lsf_driver_type * driver ) {
 
 
 
+/*
+  The resource request string contains spaces, and when passed
+  through the shell it must be protected with \"..\"; this applies
+  when submitting to a remote lsf server with ssh. However when
+  submitting to the local workstation using a bsub command the
+  command will be invoked with the util_spawn() command - and no
+  shell is involved. In this latter case we must avoid the \"...\"
+  quoting.
+*/
+static char * construct_quoted_resource_string(lsf_driver_type * driver) {
+  stringlist_type * select_list = stringlist_alloc_new();
+  if (stringlist_get_size(driver->exclude_hosts) > 0) {
+    for (int i = 0; i < stringlist_get_size(driver->exclude_hosts); i++) {
+      char * exclude_host = util_alloc_sprintf("hname!='%s'",
+                                               stringlist_iget(driver->exclude_hosts, i));
+      stringlist_append_owned_ref(select_list, exclude_host);
+    }
+  }
+
+  char * req = NULL;
+
+  if (stringlist_get_size(select_list) == 0) {
+    if (driver->resource_request)
+      req = util_alloc_string_copy(driver->resource_request);
+  } else {
+    // select_list is non-empty
+    if (driver->resource_request != NULL) {
+      char * resreq = util_alloc_string_copy(driver->resource_request);
+      char * excludes_string = stringlist_alloc_joined_string(select_list, " && ");
+
+      /*
+        A resource string can be "span[host=1] select[A && B] bla[xyz]".
+        The blacklisting feature is to have select[hname!=bad1 && hname!=bad2].
+      */
+
+      char* pos = strstr(resreq, "select["); // find select[...]
+      if (pos != NULL) {
+        // add select string to existing select[...]
+        char* endpos = strstr(pos, "]");
+        if (endpos != NULL)
+          *endpos = ' ';
+        else
+          util_abort("%s could not find termination of select statement: %s", __func__, resreq);
+
+        // We split string into (before) "bla[..] bla[..] select[xxx_"
+        // and (after) "... bla[..] bla[..]". (we replaced one ']' with ' ')
+        // Then we make final string:  before + &&excludes] + after
+        int before_size = endpos - resreq;
+        char before[before_size + 1];
+        strncpy(before, &resreq[0], before_size);
+        before[before_size] = '\0';
+
+        int after_size = strlen(resreq) - before_size;
+        char after[after_size + 1];
+        strncpy(after, &resreq[before_size], after_size);
+        after[after_size] = '\0';
+
+        req = util_alloc_sprintf("%s && %s]%s", before, excludes_string, after);
+      } else {
+        // no select string in request, add select[...]
+        req = util_alloc_sprintf("%s select[%s]", resreq, excludes_string);
+      }
+
+      free(excludes_string);
+      free(resreq);
+    } else {
+      char * select_string = stringlist_alloc_joined_string(select_list, " && ");
+      req = util_alloc_sprintf("select[%s]", select_string);
+      free(select_string);
+    }
+  }
+  stringlist_free(select_list);
+
+  char * quoted_resource_request = NULL;
+  if (req) {
+    if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL)
+      quoted_resource_request = util_alloc_sprintf("\"%s\"", req);
+    else
+      quoted_resource_request = util_alloc_string_copy(req);
+    free(req);
+  }
+  return quoted_resource_request;
+}
+
 
 
 stringlist_type * lsf_driver_alloc_cmd(lsf_driver_type * driver ,
@@ -342,58 +426,8 @@ stringlist_type * lsf_driver_alloc_cmd(lsf_driver_type * driver ,
 
   stringlist_type * argv  = stringlist_alloc_new();
   char *  num_cpu_string  = util_alloc_sprintf("%d" , num_cpu);
-  char * quoted_resource_request = NULL;
 
-  /*
-    The resource request string contains spaces, and when passed
-    through the shell it must be protected with \"..\"; this applies
-    when submitting to a remote lsf server with ssh. However when
-    submitting to the local workstation using a bsub command the
-    command will be invoked with the util_spawn() command - and no
-    shell is involved. In this latter case we must avoid the \"...\"
-    quoting.
-  */
-
-  {
-    stringlist_type * select_list = stringlist_alloc_new();
-    if (stringlist_get_size(driver->exclude_hosts) > 0) {
-      for (int i = 0; i < stringlist_get_size(driver->exclude_hosts); i++) {
-        char * exclude_host = util_alloc_sprintf("hname!='%s'", stringlist_iget(driver->exclude_hosts, i));
-        stringlist_append_owned_ref(select_list, exclude_host);
-      }
-    }
-
-    char * req = NULL;
-
-    if (stringlist_get_size(select_list) > 0) {
-      if (driver->resource_request != NULL) {
-        char * resreq = util_alloc_string_copy(driver->resource_request);
-        char * excludes_string = stringlist_alloc_joined_string(select_list, " && ");
-
-        util_string_tr(resreq, ']', ' '); // remove "]" from "select[A && B]
-        req = util_alloc_sprintf("%s && %s]", resreq, excludes_string);
-
-        free(excludes_string);
-        free(resreq);
-      } else {
-        char * select_string = stringlist_alloc_joined_string(select_list, " && ");
-        req = util_alloc_sprintf("select[%s]", select_string);
-        free(select_string);
-      }
-    } else {
-      if (driver->resource_request)
-        req = util_alloc_string_copy(driver->resource_request);
-    }
-
-    if (req) {
-      if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL)
-        quoted_resource_request = util_alloc_sprintf("\"%s\"", req);
-      else
-        quoted_resource_request = util_alloc_string_copy(req);
-      free(req);
-    }
-    stringlist_free(select_list);
-  }
+  char * quoted_resource_request = construct_quoted_resource_string(driver);
 
   if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL)
     stringlist_append_ref( argv , driver->bsub_cmd);
@@ -425,11 +459,9 @@ stringlist_type * lsf_driver_alloc_cmd(lsf_driver_type * driver ,
   }
 
   stringlist_append_ref( argv , submit_cmd);
-  {
-    int iarg;
-    for (iarg = 0; iarg < job_argc; iarg++)
-      stringlist_append_ref( argv , job_argv[ iarg ]);
-  }
+  for (int iarg = 0; iarg < job_argc; iarg++)
+    stringlist_append_ref( argv , job_argv[ iarg ]);
+
   free( num_cpu_string );
   util_safe_free( quoted_resource_request );
   return argv;
@@ -1342,4 +1374,3 @@ void * lsf_driver_alloc( ) {
 
 
 /*****************************************************************/
-

--- a/libjob_queue/src/lsf_driver.c
+++ b/libjob_queue/src/lsf_driver.c
@@ -329,6 +329,47 @@ static void lsf_driver_assert_submit_method( const lsf_driver_type * driver ) {
 }
 
 
+/*
+  A resource string can be "span[host=1] select[A && B] bla[xyz]".
+  The blacklisting feature is to have select[hname!=bad1 && hname!=bad2].
+
+  This function injects additional "hname!=node1 && ... && hname!=node2" into
+  the select[..] clause.  This addition is the result of '&&'.join(select_list).
+*/
+char* alloc_composed_resource_request(const lsf_driver_type * driver,
+                                      const stringlist_type * select_list) {
+  char* resreq = util_alloc_string_copy(driver->resource_request);
+  char* excludes_string = stringlist_alloc_joined_string(select_list, " && ");
+
+  char* req = NULL;
+  char* pos = strstr(resreq, "select["); // find select[...]
+
+  if (pos == NULL) {
+    // no select string in request, add select[...]
+    req = util_alloc_sprintf("%s select[%s]", resreq, excludes_string);
+  } else {
+    // add select string to existing select[...]
+    char* endpos = strstr(pos, "]");
+    if (endpos != NULL)
+      *endpos = ' ';
+    else
+      util_abort("%s could not find termination of select statement: %s",
+                 __func__, resreq);
+
+    // We split string into (before) "bla[..] bla[..] select[xxx_"
+    // and (after) "... bla[..] bla[..]". (we replaced one ']' with ' ')
+    // Then we make final string:  before + &&excludes] + after
+    int before_size = endpos - resreq;
+    char * before = util_alloc_substring_copy(resreq, 0, before_size);
+    char * after = util_alloc_string_copy(&resreq[before_size]);
+
+    req = util_alloc_sprintf("%s && %s]%s", before, excludes_string, after);
+  }
+  free(excludes_string);
+  free(resreq);
+  return req;
+}
+
 
 /*
   The resource request string contains spaces, and when passed
@@ -339,69 +380,30 @@ static void lsf_driver_assert_submit_method( const lsf_driver_type * driver ) {
   shell is involved. In this latter case we must avoid the \"...\"
   quoting.
 */
-static char * construct_quoted_resource_string(lsf_driver_type * driver) {
-  stringlist_type * select_list = stringlist_alloc_new();
-  if (stringlist_get_size(driver->exclude_hosts) > 0) {
-    for (int i = 0; i < stringlist_get_size(driver->exclude_hosts); i++) {
-      char * exclude_host = util_alloc_sprintf("hname!='%s'",
-                                               stringlist_iget(driver->exclude_hosts, i));
-      stringlist_append_owned_ref(select_list, exclude_host);
-    }
-  }
-
+static char * alloc_quoted_resource_string(const lsf_driver_type * driver) {
   char * req = NULL;
-
-  if (stringlist_get_size(select_list) == 0) {
+  if (stringlist_get_size(driver->exclude_hosts) == 0) {
     if (driver->resource_request)
       req = util_alloc_string_copy(driver->resource_request);
   } else {
+    stringlist_type * select_list = stringlist_alloc_new();
+    if (stringlist_get_size(driver->exclude_hosts) > 0) {
+      for (int i = 0; i < stringlist_get_size(driver->exclude_hosts); i++) {
+        char * exclude_host = util_alloc_sprintf("hname!='%s'",
+                                                 stringlist_iget(driver->exclude_hosts, i));
+        stringlist_append_owned_ref(select_list, exclude_host);
+      }
+    }
     // select_list is non-empty
     if (driver->resource_request != NULL) {
-      char * resreq = util_alloc_string_copy(driver->resource_request);
-      char * excludes_string = stringlist_alloc_joined_string(select_list, " && ");
-
-      /*
-        A resource string can be "span[host=1] select[A && B] bla[xyz]".
-        The blacklisting feature is to have select[hname!=bad1 && hname!=bad2].
-      */
-
-      char* pos = strstr(resreq, "select["); // find select[...]
-      if (pos != NULL) {
-        // add select string to existing select[...]
-        char* endpos = strstr(pos, "]");
-        if (endpos != NULL)
-          *endpos = ' ';
-        else
-          util_abort("%s could not find termination of select statement: %s", __func__, resreq);
-
-        // We split string into (before) "bla[..] bla[..] select[xxx_"
-        // and (after) "... bla[..] bla[..]". (we replaced one ']' with ' ')
-        // Then we make final string:  before + &&excludes] + after
-        int before_size = endpos - resreq;
-        char before[before_size + 1];
-        strncpy(before, &resreq[0], before_size);
-        before[before_size] = '\0';
-
-        int after_size = strlen(resreq) - before_size;
-        char after[after_size + 1];
-        strncpy(after, &resreq[before_size], after_size);
-        after[after_size] = '\0';
-
-        req = util_alloc_sprintf("%s && %s]%s", before, excludes_string, after);
-      } else {
-        // no select string in request, add select[...]
-        req = util_alloc_sprintf("%s select[%s]", resreq, excludes_string);
-      }
-
-      free(excludes_string);
-      free(resreq);
+      req = alloc_composed_resource_request(driver, select_list);
     } else {
       char * select_string = stringlist_alloc_joined_string(select_list, " && ");
       req = util_alloc_sprintf("select[%s]", select_string);
       free(select_string);
     }
+    stringlist_free(select_list);
   }
-  stringlist_free(select_list);
 
   char * quoted_resource_request = NULL;
   if (req) {
@@ -427,7 +429,7 @@ stringlist_type * lsf_driver_alloc_cmd(lsf_driver_type * driver ,
   stringlist_type * argv  = stringlist_alloc_new();
   char *  num_cpu_string  = util_alloc_sprintf("%d" , num_cpu);
 
-  char * quoted_resource_request = construct_quoted_resource_string(driver);
+  char * quoted_resource_request = alloc_quoted_resource_string(driver);
 
   if (driver->submit_method == LSF_SUBMIT_REMOTE_SHELL)
     stringlist_append_ref( argv , driver->bsub_cmd);

--- a/libjob_queue/tests/job_lsf_exclude_hosts_test.c
+++ b/libjob_queue/tests/job_lsf_exclude_hosts_test.c
@@ -26,28 +26,48 @@
 #include <ert/job_queue/lsf_driver.h>
 #include <ert/job_queue/lsf_job_stat.h>
 
-void test_submit(lsf_driver_type * driver, const char * cmd) {
-  {
-    char * node1 = "enern";
-    char * node2 = "toern";
-    char * node3 = "tre-ern.statoil.org";
-    char * black1 = util_alloc_sprintf("hname!='%s'", node1);
-    char * black2 = util_alloc_sprintf("hname!='%s'", node2);
-    char * black3 = util_alloc_sprintf("hname!='%s'", node3);
-    char * select = util_alloc_sprintf("select[%s && %s && %s]", black1, black2, black3);
+static char * add_excluded(lsf_driver_type * driver) {
+  char * node1 = "enern";
+  char * node2 = "toern";
+  char * node3 = "tre-ern.statoil.org";
+  char * black1 = util_alloc_sprintf("hname!='%s'", node1);
+  char * black2 = util_alloc_sprintf("hname!='%s'", node2);
+  char * black3 = util_alloc_sprintf("hname!='%s'", node3);
 
-    lsf_driver_add_exclude_hosts(driver, node1);
-    lsf_driver_add_exclude_hosts(driver, node2);
-    lsf_driver_add_exclude_hosts(driver, node3);
+  lsf_driver_add_exclude_hosts(driver, node1);
+  lsf_driver_add_exclude_hosts(driver, node2);
+  lsf_driver_add_exclude_hosts(driver, node3);
+  char * select = util_alloc_sprintf("select[%s && %s && %s]", black1, black2, black3);
+  return select;
+}
 
-    {
-      stringlist_type * argv = lsf_driver_alloc_cmd(driver, "", "NAME", "bsub", 1, 0, NULL);
-      if (!stringlist_contains(argv, select)) {
-        printf("%s lsf_driver_alloc_cmd argv does not contain %s\n", __func__, select);
-        printf("%s lsf_driver_alloc_cmd was %s\n", __func__, stringlist_alloc_joined_string(argv, " "));
-        exit(1);
-      }
-    }
+void test_submit_with_resources() {
+  lsf_driver_type * driver = lsf_driver_alloc();
+
+  // mimic:  QUEUE_OPTION LSF LSF_RESOURCE span[hosts=1] (see ERT-1403)
+  lsf_driver_set_option(driver, "LSF_RESOURCE", "span[hosts=1]");
+
+  char * select = add_excluded(driver);
+  stringlist_type * argv = lsf_driver_alloc_cmd(driver, "", "NAME", "bsub", 1, 0, NULL);
+  lsf_driver_free(driver);
+
+  if (!stringlist_contains(argv, select)) {
+    printf("%s lsf_driver_alloc_cmd argv does not contain %s\n", __func__, select);
+    printf("%s lsf_driver_alloc_cmd was %s\n", __func__, stringlist_alloc_joined_string(argv, " "));
+    exit(1);
+  }
+}
+
+void test_submit() {
+  lsf_driver_type * driver = lsf_driver_alloc();
+  char * select = add_excluded(driver);
+  stringlist_type * argv = lsf_driver_alloc_cmd(driver, "", "NAME", "bsub", 1, 0, NULL);
+  lsf_driver_free(driver);
+
+  if (!stringlist_contains(argv, select)) {
+    printf("%s lsf_driver_alloc_cmd argv does not contain %s\n", __func__, select);
+    printf("%s lsf_driver_alloc_cmd was %s\n", __func__, stringlist_alloc_joined_string(argv, " "));
+    exit(1);
   }
 }
 
@@ -82,11 +102,9 @@ void test_bjobs_parse_hosts() {
 }
 
 int main(int argc, char ** argv) {
-  {
-    lsf_driver_type * driver = lsf_driver_alloc();
-    test_submit(driver, argv[1]);
-    lsf_driver_free(driver);
-  }
+  test_submit();
+  test_submit_with_resources();
+
   test_bjobs_parse_hosts();
   exit(0);
 }

--- a/libjob_queue/tests/job_lsf_exclude_hosts_test.c
+++ b/libjob_queue/tests/job_lsf_exclude_hosts_test.c
@@ -37,15 +37,28 @@ static char * add_excluded(lsf_driver_type * driver) {
   lsf_driver_add_exclude_hosts(driver, node1);
   lsf_driver_add_exclude_hosts(driver, node2);
   lsf_driver_add_exclude_hosts(driver, node3);
-  char * select = util_alloc_sprintf("select[%s && %s && %s]", black1, black2, black3);
+  char * select = util_alloc_sprintf("select[%s && %s && %s]",
+                                     black1, black2, black3);
   return select;
 }
 
-static bool stringlist_contains_substring(stringlist_type * lst, char * substr) {
+static bool stringlist_contains_substring(const stringlist_type * lst,
+                                          const char * substr) {
   for (int i = 0; i < stringlist_get_size(lst); i++)
     if (strstr(stringlist_iget(lst, i), substr))
       return true;
   return false;
+}
+
+static void assert_stringlist_contains_substring(const stringlist_type * lst,
+                                                 const char * substr,
+                                                 const char * caller) {
+  if (!stringlist_contains_substring(lst, substr)) {
+    printf("%s stringlist does not contain \"%s\" as substring\n",
+           caller, substr);
+    printf("\twas: %s\n", stringlist_alloc_joined_string(lst, " "));
+    exit(1);
+  }
 }
 
 
@@ -66,47 +79,23 @@ void test_submit_with_select_resources() {
   stringlist_type * argv = lsf_driver_alloc_cmd(driver, "", "NAME", "bsub", 1, 0, NULL);
   lsf_driver_free(driver);
 
-  bool found = stringlist_contains_substring(argv, select);
-
-  if (!found) {
-    printf("%s lsf_driver_alloc_cmd argv does not contain %s\n", __func__, select);
-    printf("%s lsf_driver_alloc_cmd was %s\n", __func__, stringlist_alloc_joined_string(argv, " "));
-    exit(1);
-  }
-
-  bool found_span = stringlist_contains_substring(argv, "span[hosts=1]");
-  if (!found_span) {
-    printf("%s lsf_driver_alloc_cmd argv does not contain span[hosts=1]\n", __func__);
-    printf("%s lsf_driver_alloc_cmd was %s\n", __func__, stringlist_alloc_joined_string(argv, " "));
-    exit(1);
-  }
+  assert_stringlist_contains_substring(argv, select, __func__);
+  assert_stringlist_contains_substring(argv, "span[hosts=1]", __func__);
+  assert_stringlist_contains_substring(argv, "bs[yes]", __func__);
 }
 
 
 void test_submit_with_resources() {
   lsf_driver_type * driver = lsf_driver_alloc();
-
-  // mimic:  QUEUE_OPTION LSF LSF_RESOURCE span[hosts=1] (see ERT-1403)
   lsf_driver_set_option(driver, "LSF_RESOURCE", "span[hosts=1]");
 
   char * select = add_excluded(driver);
   stringlist_type * argv = lsf_driver_alloc_cmd(driver, "", "NAME", "bsub", 1, 0, NULL);
   lsf_driver_free(driver);
 
-  bool found = stringlist_contains_substring(argv, select);
 
-  if (!found) {
-    printf("%s lsf_driver_alloc_cmd argv does not contain %s\n", __func__, select);
-    printf("%s lsf_driver_alloc_cmd was %s\n", __func__, stringlist_alloc_joined_string(argv, "\t\n"));
-    exit(1);
-  }
-
-  bool found_span = stringlist_contains_substring(argv, "span[hosts=1]");
-  if (!found_span) {
-    printf("%s lsf_driver_alloc_cmd argv does not contain span[hosts=1]\n", __func__);
-    printf("%s lsf_driver_alloc_cmd was %s\n", __func__, stringlist_alloc_joined_string(argv, " "));
-    exit(1);
-  }
+  assert_stringlist_contains_substring(argv, select, __func__);
+  assert_stringlist_contains_substring(argv, "span[hosts=1]", __func__);
 }
 
 void test_submit() {


### PR DESCRIPTION
**Task**
The blacklisting feature implemented on top of LSF should result in a _resource string_ similar to

```
-R "select[hname!='badhost' && hname!='worsehost']"
```
however, if the resource string is non-empty, e.g.
```
-R "span[hosts=1]"
```
the resulting string was:
```
-R "span[hosts=1  && hname!='badhost' && hname!='worsehost']"
```

The **correct** resource string is (I believe):
```
-R "span[hosts=1] select[hname!='badhost' && hname!='worsehost']"
```

** Test driven development **
I have replicated the error:
```
statoil/libres/build
    Start 31: job_lsf_exclude_hosts_test
1/1 Test #31: job_lsf_exclude_hosts_test .......***Failed    0.01 sec
test_submit_with_resources lsf_driver_alloc_cmd argv does not contain select[hname!='enern' && hname!='toern' && hname!='tre-ern.statoil.org']
test_submit_with_resources lsf_driver_alloc_cmd was -o  -J NAME -n 1 -R span[hosts=1  && hname!='enern' && hname!='toern' && hname!='tre-ern.statoil.org'] bsub
```

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps