### PR TITLE
Removed warning about missing history matching source

### DIFF
--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -507,10 +507,13 @@ void model_config_init(model_config_type * model_config ,
     }
 
     if (!model_config_select_history( model_config , source_type , sched_file , refcase ))
-      if (!model_config_select_history( model_config , DEFAULT_HISTORY_SOURCE , sched_file , refcase ))
-        if (!model_config_select_any_history( model_config , sched_file , refcase))
-          fprintf(stderr,"** Warning:: Do not have enough information to select a history source \n");
-
+      if (!model_config_select_history( model_config , DEFAULT_HISTORY_SOURCE , sched_file , refcase )) {
+        model_config_select_any_history( model_config , sched_file , refcase);
+        /* If even the last call return false, it means the configuration does not have any of
+         * these keys: HISTORY_SOURCE, SCHEDULE, REFCASE.
+         * History matching won't be supported for this configuration.
+         */
+      }
   }
 
   if (model_config->history != NULL) {


### PR DESCRIPTION
**Task**
Don't show warning about missing history source, unless the user actually want to perform history matching (https://github.com/Statoil/libres/issues/138)

**Approach**
I couldn't find way to identify whether the user want to do history matching or not. 
In the previous version of the code, the warning is displayed iff the configuration does not contain any of the keys HISTORY_SOURCE, SCHEDULE, REFCASE. I assume that, if the user does not specify any of those keys, then he/she does not want history matching, so I've just removed the warning.

@joakim-hove is there any other configuration key that may indicate the user wants history matching, besides those 3?

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
