### PR TITLE
Refactor enkf_obs_load into four new functions

### DIFF
--- a/libconfig/src/conf.c
+++ b/libconfig/src/conf.c
@@ -1291,32 +1291,13 @@ bool conf_instance_validate_sub_instances(
 
 
 bool conf_instance_validate(
-  const conf_instance_type * conf_instance)
-{
-  bool ok = true;
-
-  if(conf_instance == NULL)
-  {
-    printf("%s: Trying to dereference NULL pointer.\n", __func__);
-    return false;
-  }
-
-  if(!conf_instance_has_required_items(conf_instance))
-    ok = false;
-
-  if(!conf_instance_has_valid_mutexes(conf_instance))
-    ok = false;
-
-  if(!conf_instance_has_valid_items(conf_instance))
-    ok = false;
-
-  if(!conf_instance_has_required_sub_instances(conf_instance))
-    ok = false;
-
-  if(!conf_instance_validate_sub_instances(conf_instance))
-    ok = false;
-
-  return ok;
+  const conf_instance_type * conf_instance) {
+  return conf_instance
+    && conf_instance_has_required_items(conf_instance)
+    && conf_instance_has_valid_mutexes(conf_instance)
+    && conf_instance_has_valid_items(conf_instance)
+    && conf_instance_has_required_sub_instances(conf_instance)
+    && conf_instance_validate_sub_instances(conf_instance);
 }
 
 

--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -135,7 +135,7 @@ extern "C" {
   model_config_type           * enkf_main_get_model_config( const enkf_main_type * );
   local_config_type           * enkf_main_get_local_config( const enkf_main_type * enkf_main );
   const config_settings_type  * enkf_main_get_plot_config( const enkf_main_type * enkf_main );
-  void                          enkf_main_load_obs( enkf_main_type * enkf_main , const char * obs_config_file , bool clear_existing);
+  bool                          enkf_main_load_obs(enkf_main_type *, const char *, bool);
   enkf_obs_type               * enkf_main_get_obs(const enkf_main_type * );
   bool                          enkf_main_have_obs( const enkf_main_type * enkf_main );
   const analysis_config_type  * enkf_main_get_analysis_config(const enkf_main_type * );
@@ -289,14 +289,14 @@ extern "C" {
   void              enkf_main_select_fs( enkf_main_type * enkf_main , const char * case_path );
   bool              enkf_main_fs_exists(const enkf_main_type * enkf_main, const char * input_case);
   const      char * enkf_main_get_mount_root( const enkf_main_type * enkf_main);
-  
+
 
   state_map_type  * enkf_main_alloc_readonly_state_map( const enkf_main_type * enkf_main , const char * case_path);
   time_map_type   * enkf_main_alloc_readonly_time_map( const enkf_main_type * enkf_main , const char * case_path );
 
   runpath_list_type    * enkf_main_get_runpath_list( const enkf_main_type * enkf_main );
   ert_run_context_type * enkf_main_alloc_ert_run_context_ENSEMBLE_EXPERIMENT(const enkf_main_type * enkf_main , enkf_fs_type * fs , bool_vector_type * iactive , int iter);
-  
+
   queue_config_type * enkf_main_get_queue_config(enkf_main_type * enkf_main );
 
 UTIL_SAFE_CAST_HEADER(enkf_main);

--- a/libenkf/include/ert/enkf/enkf_obs.h
+++ b/libenkf/include/ert/enkf/enkf_obs.h
@@ -42,7 +42,9 @@ extern "C" {
 #include <ert/enkf/local_obsdata_node.h>
 #include <ert/enkf/local_obsdata.h>
 
-  bool            enkf_obs_have_obs( const enkf_obs_type * enkf_obs );
+  bool enkf_obs_have_obs(const enkf_obs_type * enkf_obs);
+  bool enkf_obs_is_valid(const enkf_obs_type*);
+
   enkf_obs_type * enkf_obs_alloc( const history_type * history ,
                                   time_map_type * external_time_map ,
                                   const ecl_grid_type * grid ,
@@ -56,9 +58,7 @@ extern "C" {
   void enkf_obs_add_obs_vector(enkf_obs_type * enkf_obs,
                                const obs_vector_type * vector);
 
-  bool              enkf_obs_load(enkf_obs_type * enkf_obs,
-                                  const char           * config_file,
-                                  double std_cutoff);
+  void enkf_obs_load(enkf_obs_type*, const char*, double);
   void enkf_obs_clear( enkf_obs_type * enkf_obs );
 
   void enkf_obs_get_obs_and_measure_node( const enkf_obs_type      * enkf_obs,

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -284,17 +284,26 @@ void enkf_main_alloc_obs( enkf_main_type * enkf_main ) {
                                    enkf_main_get_ensemble_config(enkf_main));
 }
 
-void enkf_main_load_obs( enkf_main_type * enkf_main , const char * obs_config_file , bool clear_existing) {
+bool enkf_main_load_obs(enkf_main_type * enkf_main,
+                        const char * obs_config_file,
+                        bool clear_existing) {
   if (clear_existing)
     enkf_obs_clear( enkf_main->obs );
 
-  if (enkf_obs_load(enkf_main->obs ,
-                    obs_config_file ,
-                    analysis_config_get_std_cutoff(enkf_main_get_analysis_config(enkf_main)))) {
-    enkf_main_update_local_updates( enkf_main );
-  } else
-      fprintf(stderr,"** Warning: failed to load observation data from: %s \n",obs_config_file);
+  if (!enkf_obs_is_valid(enkf_main->obs)) {
+    fprintf(stderr,
+            "** Warning: failed to load observation data from: %s \n",
+            obs_config_file);
+    return false;
+  }
+
+  enkf_obs_load(enkf_main->obs ,
+                obs_config_file ,
+                analysis_config_get_std_cutoff(enkf_main_get_analysis_config(enkf_main)));
+  enkf_main_update_local_updates( enkf_main );
+  return true;
 }
+
 
 static void enkf_main_add_internal_subst_kw( enkf_main_type * enkf_main , const char * key , const char * value, const char * help_text) {
   subst_config_add_internal_subst_kw(enkf_main_get_subst_config(enkf_main), key, value, help_text);

--- a/libenkf/src/enkf_obs.c
+++ b/libenkf/src/enkf_obs.c
@@ -582,6 +582,159 @@ static void enkf_obs_update_keys( enkf_obs_type * enkf_obs ) {
 
 
 
+
+/*
+ *
+ * Here comes four helper functions for enkf_obs_load:
+ *
+ * * handle_history_observation(enkf_obs, enkf_conf, last_report, std_cutoff);
+ * * handle_summary_observation(enkf_obs, enkf_conf, last_report);
+ * * handle_block_observation(enkf_obs, enkf_conf);
+ * * handle_general_observation(enkf_obs, enkf_conf);
+ *
+ */
+
+
+/** Handle HISTORY_OBSERVATION instances. */
+static void handle_history_observation(enkf_obs_type * enkf_obs,
+                                       conf_instance_type * enkf_conf,
+                                       int last_report,
+                                       double std_cutoff) {
+  stringlist_type * hist_obs_keys = conf_instance_alloc_list_of_sub_instances_of_class_by_name(enkf_conf, "HISTORY_OBSERVATION");
+  int num_hist_obs = stringlist_get_size(hist_obs_keys);
+
+  for (int i = 0; i < num_hist_obs; i++) {
+    const char * obs_key = stringlist_iget(hist_obs_keys, i);
+
+    if (!enkf_obs->history) {
+      fprintf(stderr,"** Warning: no history object registered - observation:%s is ignored\n",
+              obs_key);
+      break;
+    }
+    const conf_instance_type * hist_obs_conf = conf_instance_get_sub_instance_ref(enkf_conf,
+                                                                                  obs_key);
+    obs_vector_type * obs_vector;
+    enkf_config_node_type * config_node;
+    config_node = ensemble_config_add_summary_observation(enkf_obs->ensemble_config,
+                                                          obs_key,
+                                                          LOAD_FAIL_WARN);
+    if (config_node == NULL) {
+      fprintf(stderr,"** Warning: summary:%s does not exist - observation:%s not added.\n",
+              obs_key,
+              obs_key);
+      break;
+    }
+
+    obs_vector = obs_vector_alloc(SUMMARY_OBS,
+                                  obs_key,
+                                  ensemble_config_get_node(enkf_obs->ensemble_config, obs_key),
+                                  last_report);
+    if (obs_vector != NULL) {
+      if (obs_vector_load_from_HISTORY_OBSERVATION(obs_vector,
+                                                   hist_obs_conf,
+                                                   enkf_obs->obs_time,
+                                                   enkf_obs->history,
+                                                   enkf_obs->ensemble_config,
+                                                   std_cutoff)) {
+        enkf_obs_add_obs_vector(enkf_obs, obs_vector);
+      } else {
+        fprintf(stderr,"** Could not load historical data for observation:%s - ignored\n",obs_key);
+        obs_vector_free(obs_vector);
+      }
+    }
+  }
+  stringlist_free(hist_obs_keys);
+}
+
+
+
+/** Handle SUMMARY_OBSERVATION instances. */
+static void handle_summary_observation(enkf_obs_type * enkf_obs,
+                                       conf_instance_type * enkf_conf,
+                                       int last_report) {
+  stringlist_type * sum_obs_keys = conf_instance_alloc_list_of_sub_instances_of_class_by_name(enkf_conf, "SUMMARY_OBSERVATION");
+  int num_sum_obs = stringlist_get_size(sum_obs_keys);
+
+  for(int i = 0; i < num_sum_obs; i++) {
+    const char               * obs_key      = stringlist_iget(sum_obs_keys, i);
+    const conf_instance_type * sum_obs_conf = conf_instance_get_sub_instance_ref(enkf_conf, obs_key);
+    const char               * sum_key      = conf_instance_get_item_value_ref(sum_obs_conf, "KEY");
+
+    /* check if have sum_key exists */
+     enkf_config_node_type * config_node = ensemble_config_add_summary_observation(enkf_obs->ensemble_config,
+                                                                                   sum_key,
+                                                                                   LOAD_FAIL_WARN);
+    if (config_node == NULL) {
+      fprintf(stderr,"** Warning: summary key:%s does not exist - observation key:%s not added.\n",
+              sum_key, obs_key);
+      break;
+    }
+
+    /* Check if obs_vector is alloc'd */
+    obs_vector_type * obs_vector = obs_vector_alloc(SUMMARY_OBS,
+                                                    obs_key,
+                                                    ensemble_config_get_node(enkf_obs->ensemble_config, sum_key),
+                                                    last_report);
+    if (obs_vector == NULL)
+      break;
+
+    obs_vector_load_from_SUMMARY_OBSERVATION(obs_vector,
+                                             sum_obs_conf,
+                                             enkf_obs->obs_time,
+                                             enkf_obs->ensemble_config);
+    enkf_obs_add_obs_vector(enkf_obs, obs_vector);
+  }
+  stringlist_free(sum_obs_keys);
+}
+
+
+
+/** Handle BLOCK_OBSERVATION instances. */
+static void handle_block_observation(enkf_obs_type * enkf_obs,
+                                     conf_instance_type * enkf_conf) {
+  stringlist_type * block_obs_keys = conf_instance_alloc_list_of_sub_instances_of_class_by_name(enkf_conf, "BLOCK_OBSERVATION");
+  int num_block_obs = stringlist_get_size(block_obs_keys);
+
+  for(int i = 0; i < num_block_obs; i++) {
+    const char * obs_key = stringlist_iget(block_obs_keys, i);
+    const conf_instance_type * block_obs_conf = conf_instance_get_sub_instance_ref(enkf_conf, obs_key);
+    obs_vector_type * obs_vector = obs_vector_alloc_from_BLOCK_OBSERVATION(block_obs_conf,
+                                                                           enkf_obs->grid,
+                                                                           enkf_obs->obs_time,
+                                                                           enkf_obs->refcase,
+                                                                           enkf_obs->ensemble_config);
+    if (obs_vector != NULL)
+      enkf_obs_add_obs_vector(enkf_obs, obs_vector);
+  }
+  stringlist_free(block_obs_keys);
+}
+
+
+
+/** Handle GENERAL_OBSERVATION instances. */
+static void handle_general_observation(enkf_obs_type * enkf_obs,
+                                       conf_instance_type * enkf_conf) {
+  stringlist_type * block_obs_keys = conf_instance_alloc_list_of_sub_instances_of_class_by_name(enkf_conf,
+                                                                                                "GENERAL_OBSERVATION");
+  int num_block_obs = stringlist_get_size(block_obs_keys);
+
+  for(int i = 0; i < num_block_obs; i++) {
+    const char * obs_key = stringlist_iget(block_obs_keys, i);
+    const conf_instance_type * gen_obs_conf = conf_instance_get_sub_instance_ref(enkf_conf,
+                                                                                 obs_key);
+
+    obs_vector_type * obs_vector = obs_vector_alloc_from_GENERAL_OBSERVATION(gen_obs_conf,
+                                                                             enkf_obs->obs_time,
+                                                                             enkf_obs->ensemble_config);
+    if (obs_vector != NULL)
+      enkf_obs_add_obs_vector(enkf_obs, obs_vector);
+  }
+  stringlist_free(block_obs_keys);
+}
+
+
+
+
 /**
    This function will load an observation configuration from the
    observation file @config_file.
@@ -589,130 +742,31 @@ static void enkf_obs_update_keys( enkf_obs_type * enkf_obs ) {
    If called several times during one invocation the function will
    start by clearing the current content.
 */
-
-
-
 bool enkf_obs_load(enkf_obs_type * enkf_obs ,
                    const char * config_file,
                    double std_cutoff) {
 
-  if (enkf_obs->valid) {
-    int last_report                      = enkf_obs_get_last_restart( enkf_obs );
-    conf_class_type    * enkf_conf_class = enkf_obs_get_obs_conf_class();
-    conf_instance_type * enkf_conf       = conf_instance_alloc_from_file(enkf_conf_class, "enkf_conf", config_file);
-
-    if(conf_instance_validate(enkf_conf) == false)
-      util_abort("Can not proceed with this configuration.\n");
-
-    /** Handle HISTORY_OBSERVATION instances. */
-    {
-      stringlist_type * hist_obs_keys = conf_instance_alloc_list_of_sub_instances_of_class_by_name(enkf_conf, "HISTORY_OBSERVATION");
-      int               num_hist_obs  = stringlist_get_size(hist_obs_keys);
-
-      for (int hist_obs_nr = 0; hist_obs_nr < num_hist_obs; hist_obs_nr++) {
-        const char               * obs_key       = stringlist_iget(hist_obs_keys, hist_obs_nr);
-        if (enkf_obs->history) {
-          const conf_instance_type * hist_obs_conf = conf_instance_get_sub_instance_ref(enkf_conf, obs_key);
-          obs_vector_type * obs_vector;
-          enkf_config_node_type * config_node;
-          config_node = ensemble_config_add_summary_observation( enkf_obs->ensemble_config , obs_key , LOAD_FAIL_WARN );
-          if (config_node != NULL) {
-            obs_vector = obs_vector_alloc( SUMMARY_OBS , obs_key , ensemble_config_get_node( enkf_obs->ensemble_config , obs_key ), last_report);
-            if (obs_vector != NULL) {
-              if (obs_vector_load_from_HISTORY_OBSERVATION(obs_vector ,
-                                                           hist_obs_conf ,
-                                                           enkf_obs->obs_time ,
-                                                           enkf_obs->history ,
-                                                           enkf_obs->ensemble_config,
-                                                           std_cutoff )) {
-                enkf_obs_add_obs_vector(enkf_obs, obs_vector);
-              } else {
-                fprintf(stderr,"** Could not load historical data for observation:%s - ignored\n",obs_key);
-                obs_vector_free( obs_vector );
-              }
-            }
-          } else
-            fprintf(stderr,"** Warning: summary:%s does not exist - observation:%s not added. \n", obs_key , obs_key);
-        } else
-          fprintf(stderr,"** Warning: no history object registered - observation:%s is ignored\n",obs_key);
-      }
-
-      stringlist_free(hist_obs_keys);
-    }
-
-
-
-    /** Handle SUMMARY_OBSERVATION instances. */
-    {
-      stringlist_type * sum_obs_keys = conf_instance_alloc_list_of_sub_instances_of_class_by_name(enkf_conf, "SUMMARY_OBSERVATION");
-      int               num_sum_obs  = stringlist_get_size(sum_obs_keys);
-
-
-      for(int sum_obs_nr = 0; sum_obs_nr < num_sum_obs; sum_obs_nr++) {
-        const char               * obs_key      = stringlist_iget(sum_obs_keys, sum_obs_nr);
-        const conf_instance_type * sum_obs_conf = conf_instance_get_sub_instance_ref(enkf_conf, obs_key);
-        const char               * sum_key      = conf_instance_get_item_value_ref(   sum_obs_conf , "KEY"   );
-        obs_vector_type * obs_vector;
-        enkf_config_node_type * config_node;
-
-        config_node = ensemble_config_add_summary_observation( enkf_obs->ensemble_config , sum_key , LOAD_FAIL_WARN );
-        if (config_node != NULL) {
-          obs_vector = obs_vector_alloc( SUMMARY_OBS , obs_key , ensemble_config_get_node( enkf_obs->ensemble_config , sum_key ), last_report);
-          if (obs_vector != NULL) {
-            obs_vector_load_from_SUMMARY_OBSERVATION(obs_vector , sum_obs_conf , enkf_obs->obs_time , enkf_obs->ensemble_config);
-            enkf_obs_add_obs_vector(enkf_obs, obs_vector);
-          }
-        } else
-          fprintf(stderr,"** Warning: summary key:%s does not exist - observation key:%s not added.\n", sum_key , obs_key);
-      }
-      stringlist_free(sum_obs_keys);
-    }
-
-
-    /** Handle BLOCK_OBSERVATION instances. */
-    {
-      stringlist_type * block_obs_keys = conf_instance_alloc_list_of_sub_instances_of_class_by_name(enkf_conf, "BLOCK_OBSERVATION");
-      int               num_block_obs  = stringlist_get_size(block_obs_keys);
-
-      for(int block_obs_nr = 0; block_obs_nr < num_block_obs; block_obs_nr++)
-        {
-          const char               * obs_key        = stringlist_iget(block_obs_keys, block_obs_nr);
-          const conf_instance_type * block_obs_conf = conf_instance_get_sub_instance_ref(enkf_conf, obs_key);
-          obs_vector_type * obs_vector = obs_vector_alloc_from_BLOCK_OBSERVATION(block_obs_conf , enkf_obs->grid , enkf_obs->obs_time , enkf_obs->refcase , enkf_obs->ensemble_config);
-          if (obs_vector != NULL)
-            enkf_obs_add_obs_vector(enkf_obs, obs_vector);
-        }
-      stringlist_free(block_obs_keys);
-    }
-
-
-    /** Handle GENERAL_OBSERVATION instances. */
-    {
-      stringlist_type * block_obs_keys = conf_instance_alloc_list_of_sub_instances_of_class_by_name(enkf_conf, "GENERAL_OBSERVATION");
-      int               num_block_obs  = stringlist_get_size(block_obs_keys);
-
-      for(int block_obs_nr = 0; block_obs_nr < num_block_obs; block_obs_nr++)
-        {
-          const char               * obs_key        = stringlist_iget(block_obs_keys, block_obs_nr);
-          const conf_instance_type * gen_obs_conf   = conf_instance_get_sub_instance_ref(enkf_conf, obs_key);
-
-          obs_vector_type * obs_vector = obs_vector_alloc_from_GENERAL_OBSERVATION(gen_obs_conf , enkf_obs->obs_time ,  enkf_obs->ensemble_config);
-          if (obs_vector != NULL)
-            enkf_obs_add_obs_vector(enkf_obs, obs_vector);
-        }
-      stringlist_free(block_obs_keys);
-    }
-
-
-    conf_instance_free(enkf_conf      );
-    conf_class_free(   enkf_conf_class);
-
-    enkf_obs_update_keys( enkf_obs );
-    return true;
-  } else
+  if (!enkf_obs->valid)
     return false;
-}
 
+  int last_report                      = enkf_obs_get_last_restart( enkf_obs );
+  conf_class_type    * enkf_conf_class = enkf_obs_get_obs_conf_class();
+  conf_instance_type * enkf_conf       = conf_instance_alloc_from_file(enkf_conf_class, "enkf_conf", config_file);
+
+  if(!conf_instance_validate(enkf_conf))
+    util_abort("Can not proceed with this configuration.\n");
+
+  handle_history_observation(enkf_obs, enkf_conf, last_report, std_cutoff);
+  handle_summary_observation(enkf_obs, enkf_conf, last_report);
+  handle_block_observation(  enkf_obs, enkf_conf);
+  handle_general_observation(enkf_obs, enkf_conf);
+
+  conf_instance_free(enkf_conf);
+  conf_class_free(enkf_conf_class);
+
+  enkf_obs_update_keys( enkf_obs );
+  return true;
+}
 
 
 

--- a/libenkf/src/enkf_obs.c
+++ b/libenkf/src/enkf_obs.c
@@ -749,12 +749,15 @@ bool enkf_obs_load(enkf_obs_type * enkf_obs ,
   if (!enkf_obs->valid)
     return false;
 
-  int last_report                      = enkf_obs_get_last_restart( enkf_obs );
-  conf_class_type    * enkf_conf_class = enkf_obs_get_obs_conf_class();
-  conf_instance_type * enkf_conf       = conf_instance_alloc_from_file(enkf_conf_class, "enkf_conf", config_file);
+  int last_report = enkf_obs_get_last_restart(enkf_obs);
+  conf_class_type * enkf_conf_class = enkf_obs_get_obs_conf_class();
+  conf_instance_type * enkf_conf = conf_instance_alloc_from_file(enkf_conf_class,
+                                                                 "enkf_conf",
+                                                                 config_file);
 
   if(!conf_instance_validate(enkf_conf))
-    util_abort("Can not proceed with this configuration.\n");
+    util_abort("%s: Can not proceed with this configuration: %s\n",
+               __func__, config_file);
 
   handle_history_observation(enkf_obs, enkf_conf, last_report, std_cutoff);
   handle_summary_observation(enkf_obs, enkf_conf, last_report);

--- a/libenkf/src/enkf_obs.c
+++ b/libenkf/src/enkf_obs.c
@@ -275,6 +275,9 @@ bool enkf_obs_have_obs( const enkf_obs_type * enkf_obs ) {
     return false;
 }
 
+bool enkf_obs_is_valid(const enkf_obs_type* obs) {
+  return obs->valid;
+}
 
 void enkf_obs_free(enkf_obs_type * enkf_obs) {
   hash_free(enkf_obs->obs_hash);
@@ -734,7 +737,6 @@ static void handle_general_observation(enkf_obs_type * enkf_obs,
 
 
 
-
 /**
    This function will load an observation configuration from the
    observation file @config_file.
@@ -742,12 +744,13 @@ static void handle_general_observation(enkf_obs_type * enkf_obs,
    If called several times during one invocation the function will
    start by clearing the current content.
 */
-bool enkf_obs_load(enkf_obs_type * enkf_obs ,
+void enkf_obs_load(enkf_obs_type * enkf_obs ,
                    const char * config_file,
                    double std_cutoff) {
 
-  if (!enkf_obs->valid)
-    return false;
+  if (!enkf_obs_is_valid(enkf_obs))
+    util_abort("%s cannot load invalid enkf observation config %s.\n",
+               __func__, config_file);
 
   int last_report = enkf_obs_get_last_restart(enkf_obs);
   conf_class_type * enkf_conf_class = enkf_obs_get_obs_conf_class();
@@ -768,14 +771,10 @@ bool enkf_obs_load(enkf_obs_type * enkf_obs ,
   conf_class_free(enkf_conf_class);
 
   enkf_obs_update_keys( enkf_obs );
-  return true;
 }
 
 
-
-
-
- static conf_class_type * enkf_obs_get_obs_conf_class( void ) {
+static conf_class_type * enkf_obs_get_obs_conf_class( void ) {
   const char * enkf_conf_help = "An instance of the class ENKF_CONFIG shall contain neccessary infomation to run the enkf.";
   conf_class_type * enkf_conf_class = conf_class_alloc_empty("ENKF_CONFIG", true , false , enkf_conf_help);
   conf_class_set_help(enkf_conf_class, enkf_conf_help);

--- a/python/python/res/enkf/enkf_main.py
+++ b/python/python/res/enkf/enkf_main.py
@@ -51,7 +51,7 @@ class EnKFMain(BaseCClass):
     _add_data_kw = EnkfPrototype("void enkf_main_add_data_kw(enkf_main, char*, char*)")
     _resize_ensemble = EnkfPrototype("void enkf_main_resize_ensemble(enkf_main, int)")
     _get_obs = EnkfPrototype("enkf_obs_ref enkf_main_get_obs(enkf_main)")
-    _load_obs = EnkfPrototype("void enkf_main_load_obs(enkf_main, char* , bool)")
+    _load_obs = EnkfPrototype("bool enkf_main_load_obs(enkf_main, char* , bool)")
     _get_templates = EnkfPrototype("ert_templates_ref enkf_main_get_templates(enkf_main)")
     _get_site_config_file = EnkfPrototype("char* enkf_main_get_site_config_file(enkf_main)")
     _get_history_length = EnkfPrototype("int enkf_main_get_history_length(enkf_main)")
@@ -238,7 +238,7 @@ class EnKFMain(BaseCClass):
         return self._get_obs( ).setParent(self)
 
     def loadObservations(self , obs_config_file , clear = True):
-        self._load_obs(obs_config_file , clear)
+        return self._load_obs(obs_config_file , clear)
 
     def get_templates(self):
         return self._get_templates( ).setParent(self)


### PR DESCRIPTION
The function `enkf_obs_load` was 100+ lines with several group together sections.

There should be no change in behavior due to this PR, this is only for readability and debugging purposes.

More specifically, we extract four functions:
* `handle_history_observation(enkf_obs, enkf_conf, last_report, std_cutoff);`
* `handle_summary_observation(enkf_obs, enkf_conf, last_report);`
* `handle_block_observation(enkf_obs, enkf_conf);`
* `handle_general_observation(enkf_obs, enkf_conf);`

