### PR TITLE
WIP: Job dispatch cleanup

### DIFF
--- a/bin/job_dispatch.py
+++ b/bin/job_dispatch.py
@@ -444,51 +444,6 @@ def main(argv):
                 for j in jobs.jobList:
                     print "   %s" % j["name"]
 
-#DEBUG
-def DEBUG_checkFileServerBlackList(job_manager):
-    fs_info, usage = JobManager.fsInfo( )
-    file_server = fs_info[0]
-    if file_server in FILE_SERVER_BLACKLIST:
-        msg = """************************************************************************
-You are now running a forward model simulation in a runpath directory:
-which is served from the file server:
-
-           %s
-
-This file server is not suitable for large scale FMU usage. Please use
-a different RUNPATH setting in your ert configuration file.
-
-Please contact Ketil Nummedal if you do not understand how to proceed.
-************************************************************************
-""" % job_manager.file_server
-
-        payload = {"user" : job_manager.user,
-                   "ert_job" : "FILE_SERVER_CHECK",
-                   "executable" : "/bin/???",
-                   "arg_list" : "--",
-                   "error_msg" : "Simulation started on blacklisted file_server:%s" % job_manager.file_server,
-                   "cwd" : os.getcwd(),
-                   "file_server" : job_manager.isilon_node,
-                   "node" : job_manager.node,
-                   "fs_use" : "%s / %s / %s" % job_manager.fs_use,
-                   "stderr" : "???",
-                   "stdout" : "???" }
-
-        print json.dumps(payload)
-        try:
-            stat = requests.post(LOG_URL, headers={"Content-Type" :
-                                                     "application/json"},
-                                 data=json.dumps(payload))
-            print stat.text
-        except:
-            pass
-
-        with open("WARNING-ILLEGAL-FILESERVER.txt", "w") as f:
-            f.write(msg)
-
-        if block_illegal_fileserver:
-            illegal_fileserver_exit( msg , job_manager.user )
-
 
 #################################################################
 

--- a/bin/job_dispatch.py
+++ b/bin/job_dispatch.py
@@ -398,9 +398,6 @@ def main(argv):
     max_runtime = 0
     job_manager = JobManager(error_url=LOG_URL, log_url=LOG_URL)
 
-
-    checkFileServerBlackList(job_manager)
-
     if len(sys.argv) <= 2:
         # Normal batch run.
 
@@ -447,8 +444,8 @@ def main(argv):
                 for j in jobs.jobList:
                     print "   %s" % j["name"]
 
-
-def checkFileServerBlackList(job_manager):
+#DEBUG
+def DEBUG_checkFileServerBlackList(job_manager):
     fs_info, usage = JobManager.fsInfo( )
     file_server = fs_info[0]
     if file_server in FILE_SERVER_BLACKLIST:

--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -488,31 +488,6 @@ class JobManager(object):
 
         return ('?', '?.?.?.?')
 
-    #@staticmethod
-    #def fsInfo(path = None):
-    #    if path is None:
-    #        path = os.getcwd()
-
-    #    if not os.path.isabs(path):
-    #        raise ValueError("Must have an absolute path")
-
-    #    if not os.path.exists(path):
-    #        raise ValueError("No such entry: %s" % path)
-
-    #    path_list = path.split("/")
-    #    if len(path_list) < 3:
-    #        raise ValueError("Must have at least two levels in directory name")
-
-    #    mount_point = "/%s/%s" % (path_list[1], path_list[2])
-    #    file_server, isilon_node = JobManager.mountPoint(mount_point)
-
-    #    df_stdout = subprocess.check_output(["df", "-Ph", path]).strip().split('\n')
-    #    line1 = df_stdout[1].split()
-    #    size = line1[1]
-    #    free = line1[3]
-    #    util = line1[4]
-    #    return ((file_server, isilon_node), (size, free, util))
-
 
     # This file will be read by the job_queue_node_fscanf_EXIT() function
     # in job_queue.c. Be very careful with changes in output format.

--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -142,7 +142,6 @@ class JobManager(object):
             self._loadModule(module_file)
 
         self.start_time = dt.now()
-        #((self.file_server, self.isilon_node), self.fs_use) = JobManager.fsInfo() DEBUG
         self.max_runtime = 0  # This option is currently sleeping
         self.short_sleep = 2  # Sleep between status checks
         self.node = socket.gethostname()
@@ -259,7 +258,6 @@ class JobManager(object):
 
     def initStatusFile(self):
         with open(self.STATUS_file, "a") as f:
-            #f.write("%-32s: %s/%s  file-server:%s \n" % ("Current host", self.node, os.uname()[4], self.isilon_node))  DEBUG
             f.write("%-32s: %s/%s\n" % ("Current host", self.node, os.uname()[4]))
             if "LSF_JOBID" in os.environ:
                 f.write("LSF JOBID: %s\n" % os.environ.get("LSF_JOBID"))
@@ -302,10 +300,6 @@ class JobManager(object):
     def getRuntime(self):
         rt = dt.now() - self.start_time
         return rt.total_seconds()
-
-
-    #def getFileServer(self): DEBUG
-    #    return self.isilon_node
 
 
     def execJob(self, job):

--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -142,7 +142,7 @@ class JobManager(object):
             self._loadModule(module_file)
 
         self.start_time = dt.now()
-        ((self.file_server, self.isilon_node), self.fs_use) = JobManager.fsInfo()
+        #((self.file_server, self.isilon_node), self.fs_use) = JobManager.fsInfo() DEBUG
         self.max_runtime = 0  # This option is currently sleeping
         self.short_sleep = 2  # Sleep between status checks
         self.node = socket.gethostname()
@@ -243,13 +243,10 @@ class JobManager(object):
 
     def __repr__(self):
         st = self.start_time
-        fs = self.file_server
-        is_node = self.isilon_node
-        fu = self.fs_use
         node = self.node
         us = self.user
-        cnt = 'len=%d, start=%s, file_server=%s, fs_use=%s, node=%s, isilon_node=%s, user=%s'
-        cnt = cnt % (len(self), st, fs, fu, node, is_node, us)
+        cnt = 'len=%d, start=%s, node=%s, user=%s'
+        cnt = cnt % (len(self), st, node, us)
         return 'JobManager(%s)' % cnt
 
 
@@ -262,8 +259,8 @@ class JobManager(object):
 
     def initStatusFile(self):
         with open(self.STATUS_file, "a") as f:
-            f.write("%-32s: %s/%s  file-server:%s \n" % ("Current host", self.node, os.uname()[4], self.isilon_node))
-
+            #f.write("%-32s: %s/%s  file-server:%s \n" % ("Current host", self.node, os.uname()[4], self.isilon_node))  DEBUG
+            f.write("%-32s: %s/%s\n" % ("Current host", self.node, os.uname()[4]))
             if "LSF_JOBID" in os.environ:
                 f.write("LSF JOBID: %s\n" % os.environ.get("LSF_JOBID"))
             else:
@@ -307,8 +304,8 @@ class JobManager(object):
         return rt.total_seconds()
 
 
-    def getFileServer(self):
-        return self.isilon_node
+    #def getFileServer(self): DEBUG
+    #    return self.isilon_node
 
 
     def execJob(self, job):
@@ -383,11 +380,8 @@ class JobManager(object):
                    "cwd": os.getcwd(),
                    "application": "ert",
                    "subsystem": "ert_forward_model",
-                   "file_server": self.isilon_node,
                    "node": self.node,
                    "start_time": self.start_time.isoformat(),
-                   "fs_use": "%s / %s / %s" % self.fs_use,
-                   "fs_utilization": "%s" % (self.fs_use[2])[:-1], #remove the "%"
                    "node_timestamp": dt.now().isoformat(),
                    "simulation_id": self.simulation_id,
                    "ert_pid": self.ert_pid}
@@ -500,30 +494,30 @@ class JobManager(object):
 
         return ('?', '?.?.?.?')
 
-    @staticmethod
-    def fsInfo(path = None):
-        if path is None:
-            path = os.getcwd()
+    #@staticmethod
+    #def fsInfo(path = None):
+    #    if path is None:
+    #        path = os.getcwd()
 
-        if not os.path.isabs(path):
-            raise ValueError("Must have an absolute path")
+    #    if not os.path.isabs(path):
+    #        raise ValueError("Must have an absolute path")
 
-        if not os.path.exists(path):
-            raise ValueError("No such entry: %s" % path)
+    #    if not os.path.exists(path):
+    #        raise ValueError("No such entry: %s" % path)
 
-        path_list = path.split("/")
-        if len(path_list) < 3:
-            raise ValueError("Must have at least two levels in directory name")
+    #    path_list = path.split("/")
+    #    if len(path_list) < 3:
+    #        raise ValueError("Must have at least two levels in directory name")
 
-        mount_point = "/%s/%s" % (path_list[1], path_list[2])
-        file_server, isilon_node = JobManager.mountPoint(mount_point)
+    #    mount_point = "/%s/%s" % (path_list[1], path_list[2])
+    #    file_server, isilon_node = JobManager.mountPoint(mount_point)
 
-        df_stdout = subprocess.check_output(["df", "-Ph", path]).strip().split('\n')
-        line1 = df_stdout[1].split()
-        size = line1[1]
-        free = line1[3]
-        util = line1[4]
-        return ((file_server, isilon_node), (size, free, util))
+    #    df_stdout = subprocess.check_output(["df", "-Ph", path]).strip().split('\n')
+    #    line1 = df_stdout[1].split()
+    #    size = line1[1]
+    #    free = line1[3]
+    #    util = line1[4]
+    #    return ((file_server, isilon_node), (size, free, util))
 
 
     # This file will be read by the job_queue_node_fscanf_EXIT() function

--- a/python/tests/res/job_queue/test_statoil_jobmanager.py
+++ b/python/tests/res/job_queue/test_statoil_jobmanager.py
@@ -81,30 +81,3 @@ class JobManagerStatoilTest(TestCase):
         except Exception as err:
             self.assertTrue(False, msg='On input %s: %s.' % (ip, err))  # noqa
 
-    def test_fsInfo(self):
-        self.assertEqual(('?','?.?.?.?'), JobManager.mountPoint('/no/such/path/'))
-        for mnt_point in ('/project/res', '/prog/ecl'):
-            (file_server,ip) = JobManager.mountPoint(mnt_point)
-            self.assert_ip_address(ip)
-            (file_server, isilon_addr), _ = JobManager.fsInfo(path=mnt_point)
-            self.assertEqual(ip, isilon_addr)
-
-
-    def test_mountpoint(self):
-        with TestAreaContext("mount_test"):
-            os.makedirs("path/to/test/dir")
-            with self.assertRaises(ValueError):
-                JobManager.fsInfo("path/to/test/dir")
-
-            with self.assertRaises(ValueError):
-                JobManager.fsInfo("/path/does/not/exist")
-
-            with self.assertRaises(ValueError):
-                JobManager.fsInfo("/scratch")
-
-            (server,ip),fs_use = JobManager.fsInfo("/prog/ecl")
-            self.assert_ip_address(ip)
-
-            self.assertEqual(len(fs_use), 3)
-            for t in fs_use:
-                self.assertTrue(t[0].isdigit())


### PR DESCRIPTION
**Task**
The job_dispatch.py (and job_manager.py class) script in libres has quite some crappy debug code from a time back when we were investigating cluster issues intensively. We should remove these no-longer required attributes:
Everything related to JobManager.fsinfo( ) is to be removed.


**Approach**
JobManager.fsinfo( ), reference to this function and consequences of the reference has been removed.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

