### PR TITLE
Rng manager

### DIFF
--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(enkf src/active_list.c
                  src/run_arg.c
                  src/runpath_list.c
                  src/site_config.c
+                 src/rng_manager.c
                  src/res_config.c
                  src/state_map.c
                  src/state_map.c
@@ -152,6 +153,7 @@ foreach (test   enkf_active_list
                 obs_vector_tests
                 log_config_level_parse
                 value_export
+                rng_manager
     )
     add_executable(${test} tests/${test}.c)
     target_link_libraries(${test} enkf)

--- a/libenkf/include/ert/enkf/rng_config.h
+++ b/libenkf/include/ert/enkf/rng_config.h
@@ -23,27 +23,26 @@
 extern "C" {
 #endif
 
-#include <ert/util/rng.h>
-
 #include <ert/config/config_parser.h>
 #include <ert/config/config_content.h>
 
+#include <ert/enkf/rng_manager.h>
+
 typedef struct rng_config_struct rng_config_type;
 
-  void              rng_config_fprintf_config( rng_config_type * rng_config , FILE * stream );
-  void              rng_config_init(rng_config_type * rng_config, const config_content_type * config);
-  void              rng_config_set_type( rng_config_type * rng_config , rng_alg_type type);
-  rng_alg_type      rng_config_get_type(const rng_config_type * rng_config );
-  const char      * rng_config_get_seed_load_file( const rng_config_type * rng_config );
-  void              rng_config_set_seed_load_file( rng_config_type * rng_config , const char * seed_load_file);
-  const char      * rng_config_get_seed_store_file( const rng_config_type * rng_config );
-  void              rng_config_set_seed_store_file( rng_config_type * rng_config , const char * seed_store_file);
-  rng_config_type * rng_config_alloc_load_user_config(const char * user_config_file);
-  rng_config_type * rng_config_alloc(const config_content_type * config_content);
-  void              rng_config_free( rng_config_type * rng);
-  void              rng_config_add_config_items( config_parser_type * config );
-  rng_type *        rng_config_alloc_init_rng( const rng_config_type * rng_config);
-  void              rng_config_init_rng(const rng_config_type * rng_config, rng_type * rng );
+  void               rng_config_fprintf_config( rng_config_type * rng_config , FILE * stream );
+  void               rng_config_init(rng_config_type * rng_config, const config_content_type * config);
+  void               rng_config_set_type( rng_config_type * rng_config , rng_alg_type type);
+  rng_alg_type       rng_config_get_type(const rng_config_type * rng_config );
+  const char       * rng_config_get_seed_load_file( const rng_config_type * rng_config );
+  void               rng_config_set_seed_load_file( rng_config_type * rng_config , const char * seed_load_file);
+  const char       * rng_config_get_seed_store_file( const rng_config_type * rng_config );
+  void               rng_config_set_seed_store_file( rng_config_type * rng_config , const char * seed_store_file);
+  rng_config_type  * rng_config_alloc_load_user_config(const char * user_config_file);
+  rng_config_type  * rng_config_alloc(const config_content_type * config_content);
+  void               rng_config_free( rng_config_type * rng);
+  void               rng_config_add_config_items( config_parser_type * config );
+  rng_manager_type * rng_config_alloc_rng_manager( const rng_config_type * rng_config );
 
 #ifdef __cplusplus
 }

--- a/libenkf/include/ert/enkf/rng_manager.h
+++ b/libenkf/include/ert/enkf/rng_manager.h
@@ -1,0 +1,46 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   The file 'rng_manager.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#ifndef ERT_RNG_MANAGER_H
+#define ERT_RNG_MANAGER_H
+
+#include <ert/util/type_macros.h>
+#include <ert/util/rng.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct rng_manager_struct rng_manager_type;
+
+rng_manager_type * rng_manager_alloc( const char * seed_file );
+rng_manager_type * rng_manager_alloc_default( );
+rng_manager_type * rng_manager_alloc_random( );
+
+rng_type         * rng_manager_alloc_rng(rng_manager_type * rng_manager);
+rng_type         * rng_manager_iget(rng_manager_type * rng_manager, int index);
+void               rng_manager_free( rng_manager_type * rng_manager );
+void               rng_manager_save_state(const rng_manager_type * rng_manager, const char * seed_file);
+
+
+UTIL_IS_INSTANCE_HEADER( rng_manager );
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/libenkf/src/enkf_main_ensemble.c
+++ b/libenkf/src/enkf_main_ensemble.c
@@ -62,7 +62,7 @@ void enkf_main_resize_ensemble( enkf_main_type * enkf_main , int new_ens_size ) 
 
       /* Observe that due to the initialization of the rng - this function is currently NOT thread safe. */
       enkf_main->ensemble[iens] = enkf_state_alloc(iens,
-                                                   enkf_main->rng,
+                                                   rng_manager_iget( enkf_main->rng_manager, iens),
                                                    model_config_iget_casename(enkf_main_get_model_config(enkf_main), iens),
                                                    enkf_main_get_model_config(enkf_main),
                                                    enkf_main_get_ensemble_config(enkf_main),

--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -120,7 +120,7 @@ struct enkf_state_struct {
 
   shared_info_type      * shared_info;             /* Pointers to shared objects which is needed by the enkf_state object (read only). */
   member_config_type    * my_config;               /* Private config information for this member; not updated during a simulation. */
-  rng_type              * rng;
+  rng_type              * rng;                     /* This is owned and managed by the external rng_manager. */
 };
 
 /*****************************************************************/
@@ -319,7 +319,7 @@ static void enkf_state_add_nodes( enkf_state_type * enkf_state, const ensemble_c
 
 
 enkf_state_type * enkf_state_alloc(int iens,
-                                   rng_type                  * main_rng ,
+                                   rng_type                  * rng ,
                                    const char                * casename ,
                                    model_config_type         * model_config,
                                    ensemble_config_type      * ensemble_config,
@@ -337,8 +337,7 @@ enkf_state_type * enkf_state_alloc(int iens,
 
   enkf_state->node_hash         = hash_alloc();
   enkf_state->subst_list        = subst_list_alloc( subst_parent );
-  enkf_state->rng               = rng_alloc( rng_get_type( main_rng ) , INIT_DEFAULT );
-  rng_rng_init( enkf_state->rng , main_rng );  /* <- Not thread safe */
+  enkf_state->rng               = rng;
   /*
     The user MUST specify an INIT_FILE, and for the first timestep the
     <INIT> tag in the data file will be replaced by an
@@ -846,7 +845,6 @@ void * enkf_state_load_from_forward_model_mt( void * arg ) {
 
 
 void enkf_state_free(enkf_state_type *enkf_state) {
-  rng_free( enkf_state->rng );
   hash_free(enkf_state->node_hash);
   subst_list_free(enkf_state->subst_list);
   member_config_free(enkf_state->my_config);

--- a/libenkf/src/rng_manager.c
+++ b/libenkf/src/rng_manager.c
@@ -1,0 +1,110 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   The file 'rng_manager.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <stdlib.h>
+
+#include <ert/util/rng.h>
+#include <ert/util/vector.h>
+#include <ert/enkf/rng_manager.h>
+
+#define RNG_MANAGER_TYPE_ID 77250451
+
+
+struct rng_manager_struct {
+  UTIL_TYPE_ID_DECLARATION;
+  rng_alg_type  rng_alg;
+  rng_type    * internal_seed_rng;   /* This is used to seed the RNG's which are managed. */
+  rng_type    * external_seed_rng;   /* This is used to seed the RNG's which are managed by external scope. */
+  vector_type * rng_list;
+};
+
+
+UTIL_IS_INSTANCE_FUNCTION( rng_manager, RNG_MANAGER_TYPE_ID )
+
+static rng_manager_type * rng_manager_alloc__( const char * seed_file, rng_init_mode init_mode) {
+  rng_manager_type * rng_manager = util_malloc( sizeof * rng_manager );
+  UTIL_TYPE_ID_INIT( rng_manager, RNG_MANAGER_TYPE_ID );
+  rng_manager->rng_list = vector_alloc_new( );
+  rng_manager->rng_alg = MZRAN;
+  rng_manager->internal_seed_rng = rng_alloc( rng_manager->rng_alg, init_mode );
+  rng_manager->external_seed_rng = rng_alloc( rng_manager->rng_alg, init_mode );
+
+  if (seed_file) {
+    rng_load_state( rng_manager->internal_seed_rng , seed_file );
+    rng_load_state( rng_manager->external_seed_rng , seed_file );
+  }
+  rng_rng_init( rng_manager->external_seed_rng, rng_manager->external_seed_rng );
+
+  return rng_manager;
+}
+
+
+rng_manager_type * rng_manager_alloc( const char * seed_file ) {
+  if (!util_file_exists( seed_file ))
+    return NULL;
+
+  return rng_manager_alloc__( seed_file, INIT_DEFAULT );
+}
+
+rng_manager_type * rng_manager_alloc_default( ) {
+  return rng_manager_alloc__( NULL, INIT_DEFAULT );
+}
+
+rng_manager_type * rng_manager_alloc_random( ) {
+  return rng_manager_alloc__( NULL, INIT_DEV_URANDOM);
+}
+
+
+
+void rng_manager_free( rng_manager_type * rng_manager ) {
+  vector_free( rng_manager->rng_list );
+  rng_free( rng_manager->internal_seed_rng );
+  rng_free( rng_manager->external_seed_rng );
+  free( rng_manager );
+}
+
+
+static void rng_manager_grow(rng_manager_type * rng_manager, int min_size) {
+  int new_size = util_int_max( min_size, 2*vector_get_size( rng_manager->rng_list ));
+  for (int i = vector_get_size( rng_manager->rng_list ); i < new_size; i++) {
+    rng_type * rng = rng_alloc( rng_manager->rng_alg, INIT_DEFAULT );
+    rng_rng_init( rng, rng_manager->internal_seed_rng );
+    vector_append_owned_ref( rng_manager->rng_list , rng, rng_free__ );
+  }
+}
+
+
+rng_type * rng_manager_alloc_rng(rng_manager_type * rng_manager) {
+  rng_type * rng = rng_alloc( rng_manager->rng_alg, INIT_DEFAULT );
+  rng_rng_init( rng, rng_manager->external_seed_rng );
+  return rng;
+}
+
+
+rng_type * rng_manager_iget(rng_manager_type * rng_manager, int index) {
+  if (index >= vector_get_size( rng_manager->rng_list ))
+    rng_manager_grow( rng_manager, index + 1);
+
+  return vector_iget( rng_manager->rng_list , index );
+}
+
+
+
+void rng_manager_save_state(const rng_manager_type * rng_manager, const char * seed_file) {
+  rng_save_state( rng_manager->internal_seed_rng, seed_file );
+}


### PR DESCRIPTION
**Task**
When using libres functionality from everest it is important that the number of realisations can be varied dynamically; to achieve this there has been quite a lot of work aimed at reducing the static per-realization information. Each realisation has a separate RNG - with this PR those RNG instances are managed by a dedicated `rng_manager` which dynamically - *and reproducably* instantiate rng instances. 


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

