### PR TITLE
Revert test that was changed due to git issues

### DIFF
--- a/python/tests/res/enkf/data/test_enkf_config_node.py
+++ b/python/tests/res/enkf/data/test_enkf_config_node.py
@@ -17,7 +17,7 @@ class EnkfConfigNodeTest(ExtendedTestCase):
         self.assertIsInstance( config_node, EnkfConfigNode )
         gen_data = config_node.getModelConfig( )
         self.assertEqual( 1, gen_data.getNumReportStep( ) )
-        self.assertEqual( 1, gen_data.getReportStep(0) )
+        self.assertEqual( 0, gen_data.getReportStep(0) )
 
         config_node = EnkfConfigNode.create_gen_data( "KEY", "FILE%d" , report_steps = [10,20,30])
         self.assertIsInstance( config_node, EnkfConfigNode )


### PR DESCRIPTION
Fixes broken master.

A test was changed (to fix a failing test) due to some strange github/Travis interaction.

Now that all PRs are merged, it looks like the test was correct in the first place, so this reverts the test.

