### PR TITLE
ENSPATH, RUNPATH, DATA_ROOT - accessed as paths

### DIFF
--- a/libconfig/src/config_path_elm.c
+++ b/libconfig/src/config_path_elm.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'config_path_elm.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'config_path_elm.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 
@@ -107,16 +107,23 @@ char * config_path_elm_alloc_path(const config_path_elm_type * path_elm , const 
     /* This will be relative or absolute depending on the relative/absolute
        status of the root_path. */
     const char * input_root = config_root_path_get_input_path( path_elm->root_path );
+    char * tmp_path;
+    char * return_path;
     if (input_root == NULL)
-      return util_alloc_filename( path_elm->rel_path , path , NULL);
+      tmp_path = util_alloc_filename( path_elm->rel_path , path , NULL);
     else
-      return util_alloc_joined_string( (const char *[3]) { input_root , path_elm->rel_path , path } , 3 , UTIL_PATH_SEP_STRING );
+      tmp_path = util_alloc_joined_string( (const char *[3]) { input_root , path_elm->rel_path , path } , 3 , UTIL_PATH_SEP_STRING );
+
+    return_path = util_alloc_normal_path( tmp_path );
+    free( tmp_path );
+
+    return return_path;
   }
 }
 
 
 char * config_path_elm_alloc_relpath(const config_path_elm_type * path_elm , const char * input_path) {
-  if (util_is_abs_path( input_path )) 
+  if (util_is_abs_path( input_path ))
     return util_alloc_rel_path( config_root_path_get_rel_path( path_elm->root_path ) , input_path);
   else {
     char * abs_path = config_path_elm_alloc_abspath( path_elm , input_path );
@@ -134,6 +141,6 @@ char * config_path_elm_alloc_abspath(const config_path_elm_type * path_elm , con
     char * abs_path1 = util_alloc_filename( path_elm->abs_path , input_path , NULL );
     char * abs_path  = util_alloc_realpath__( abs_path1 );  // The util_alloc_realpath__() will work also for nonexsting paths
     free( abs_path1 );
-    return abs_path; 
+    return abs_path;
   }
 }

--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -494,7 +494,7 @@ void model_config_init(model_config_type * model_config ,
   }
 
   if (config_content_has_item( config, RUNPATH_KEY)) {
-    model_config_add_runpath( model_config , DEFAULT_RUNPATH_KEY , config_content_get_value(config , RUNPATH_KEY) );
+    model_config_add_runpath( model_config , DEFAULT_RUNPATH_KEY , config_content_get_value_as_path(config , RUNPATH_KEY) );
     model_config_select_runpath( model_config , DEFAULT_RUNPATH_KEY );
   }
 
@@ -552,10 +552,10 @@ void model_config_init(model_config_type * model_config ,
     model_config_set_case_table( model_config , ens_size , config_content_iget( config , CASE_TABLE_KEY , 0,0));
 
   if (config_content_has_item( config , ENSPATH_KEY))
-    model_config_set_enspath( model_config , config_content_get_value(config , ENSPATH_KEY));
+    model_config_set_enspath( model_config , config_content_get_value_as_path(config , ENSPATH_KEY));
 
   if (config_content_has_item( config , DATA_ROOT_KEY))
-    model_config_set_data_root( model_config , config_content_get_value(config , DATA_ROOT_KEY));
+    model_config_set_data_root( model_config , config_content_get_value_as_path(config , DATA_ROOT_KEY));
 
   if (config_content_has_item( config , JOBNAME_KEY))
     model_config_set_jobname_fmt( model_config , config_content_get_value(config , JOBNAME_KEY));
@@ -837,11 +837,9 @@ static void model_config_init_user_config(config_parser_type * config ) {
   config_schema_item_set_argc_minmax(item, 2, CONFIG_DEFAULT_ARG_MAX);
   config_schema_item_iset_type(item, 0, CONFIG_EXISTING_PATH);
 
-  config_add_key_value(config, RUNPATH_KEY, false, CONFIG_STRING);
-  config_add_key_value(config, DATA_ROOT_KEY, false, CONFIG_STRING);
-
-  item = config_add_schema_item(config, ENSPATH_KEY, false);
-  config_schema_item_set_argc_minmax(item, 1, 1);
+  config_add_key_value(config, RUNPATH_KEY, false, CONFIG_PATH);
+  config_add_key_value(config, DATA_ROOT_KEY, false, CONFIG_PATH);
+  config_add_key_value(config, ENSPATH_KEY, false, CONFIG_PATH);
 
   item = config_add_schema_item(config, JOBNAME_KEY, false);
   config_schema_item_set_argc_minmax(item, 1, 1);

--- a/python/tests/res/enkf/test_enkf.py
+++ b/python/tests/res/enkf/test_enkf.py
@@ -133,7 +133,7 @@ class EnKFTest(ExtendedTestCase):
                 self.assertEqual(observation_vector.getNode(index), summary_observation_node)
                 self.assertEqual(value, summary_observation_node.getValue())
                 values.append((index, value, std))
-            
+
 
 
             observations = main.getObservations()
@@ -144,7 +144,7 @@ class EnKFTest(ExtendedTestCase):
                 self.assertEqual( node.getValue( ) , index * 10.5 )
                 index += 1
 
-                
+
             self.assertEqual(observation_vector, test_vector)
             for index, value, std in values:
                 self.assertTrue(test_vector.isActive(index))
@@ -159,7 +159,7 @@ class EnKFTest(ExtendedTestCase):
 
             main.free()
 
-            
+
 
     def test_config( self ):
         with TestAreaContext("enkf_test") as work_area:
@@ -183,15 +183,15 @@ class EnKFTest(ExtendedTestCase):
             # self.assertIsInstance(main.iget_member_config(0), MemberConfig)
             self.assertIsInstance(main.getMemberRunningState(0), EnKFState)
 
-            self.assertEqual( "Ensemble" , main.getMountPoint())
+            self.assertEqual( "simple_config/Ensemble" , main.getMountPoint())
 
             main.free()
-            
+
     def test_enkf_create_config_file(self):
         config_file      = "test_new_config"
         dbase_type       = "BLOCK_FS"
         num_realizations = 42
-        
+
         with TestAreaContext("python/ens_condif/create_config" , store_area = True) as ta:
             EnKFMain.createNewConfig(config_file, "storage" , dbase_type, num_realizations)
             res_config = ResConfig(config_file)
@@ -210,9 +210,9 @@ class EnKFTest(ExtendedTestCase):
             iactive[0] = False
             iactive[1] = False
             run_context = main.getRunContextENSEMPLE_EXPERIMENT( fs , iactive )
-            
+
             self.assertEqual( len(run_context) , 8 )
-            
+
             with self.assertRaises(IndexError):
                 run_context[8]
 
@@ -221,19 +221,19 @@ class EnKFTest(ExtendedTestCase):
 
             run_arg = run_context[0]
             self.assertTrue( isinstance( run_arg , RunArg ))
-            
+
             with self.assertRaises(ValueError):
                 run_context.iensGet(0)
 
 
             with self.assertRaises(ValueError):
                 run_context.iensGet(1)
-                
+
             arg0 = run_context[0]
             arg2 = run_context.iensGet( 2 )
             #self.assertEqual( arg0 , arg2 )
-    
-    
+
+
     def test_run_context_from_external_folder(self):
         with TestAreaContext('enkf_test') as work_area:
             work_area.copy_directory(self.case_directory_custom_kw)
@@ -241,15 +241,15 @@ class EnKFTest(ExtendedTestCase):
             main = EnKFMain(res_config)
             fs_manager = main.getEnkfFsManager()
             fs = fs_manager.getCurrentFileSystem( )
-            
+
             mask = BoolVector(default_value = False , initial_size = 10)
             mask[0] = True
             run_context = main.getRunContextENSEMPLE_EXPERIMENT( fs , mask )
 
             self.assertEqual( len(run_context) , 1 )
-            
+
             job_queue = main.get_queue_config().create_job_queue()
             main.getEnkfSimulationRunner().createRunPath( run_context )
             num = main.getEnkfSimulationRunner().runEnsembleExperiment(job_queue, run_context)
-            
+
             self.assertEqual( num , 1 )

--- a/python/tests/res/enkf/test_enkf_runpath.py
+++ b/python/tests/res/enkf/test_enkf_runpath.py
@@ -47,10 +47,10 @@ class EnKFRunpathTest(ExtendedTestCase):
             fs = main.getEnkfFsManager().getCurrentFileSystem()
             run_context = main.getRunContextENSEMPLE_EXPERIMENT(fs, iactive)
             main.createRunpath(run_context)
-            self.assertFileExists('storage/snake_oil/runpath/realisation-0/iter-0/parameters.txt')
-            self.assertEqual(len(os.listdir('storage/snake_oil/runpath')), 1)
-            self.assertEqual(len(os.listdir('storage/snake_oil/runpath/realisation-0')), 1)
-            
+            self.assertFileExists('snake_oil_no_data/storage/snake_oil/runpath/realisation-0/iter-0/parameters.txt')
+            self.assertEqual(len(os.listdir('snake_oil_no_data/storage/snake_oil/runpath')), 1)
+            self.assertEqual(len(os.listdir('snake_oil_no_data/storage/snake_oil/runpath/realisation-0')), 1)
+
     def test_without_gen_kw(self):
         case_directory = self.createTestPath('local/snake_oil_no_data/')
         with TestAreaContext('test_enkf_runpath', store_area=True) as work_area:
@@ -62,9 +62,7 @@ class EnKFRunpathTest(ExtendedTestCase):
             fs = main.getEnkfFsManager().getCurrentFileSystem()
             run_context = main.getRunContextENSEMPLE_EXPERIMENT(fs, iactive)
             main.createRunpath(run_context)
-            self.assertDirectoryExists('storage/snake_oil_no_gen_kw/runpath/realisation-0/iter-0')
-            self.assertFileDoesNotExist('storage/snake_oil_no_gen_kw/runpath/realisation-0/iter-0/parameters.txt')
-            self.assertEqual(len(os.listdir('storage/snake_oil_no_gen_kw/runpath')), 1)
-            self.assertEqual(len(os.listdir('storage/snake_oil_no_gen_kw/runpath/realisation-0')), 1)
-        
-# eof 
+            self.assertDirectoryExists('snake_oil_no_data/storage/snake_oil_no_gen_kw/runpath/realisation-0/iter-0')
+            self.assertFileDoesNotExist('snake_oil_no_data/storage/snake_oil_no_gen_kw/runpath/realisation-0/iter-0/parameters.txt')
+            self.assertEqual(len(os.listdir('snake_oil_no_data/storage/snake_oil_no_gen_kw/runpath')), 1)
+            self.assertEqual(len(os.listdir('snake_oil_no_data/storage/snake_oil_no_gen_kw/runpath/realisation-0')), 1)

--- a/python/tests/res/enkf/test_res_config.py
+++ b/python/tests/res/enkf/test_res_config.py
@@ -207,16 +207,13 @@ class ResConfigTest(ExtendedTestCase):
                     )
 
 
-    def assert_model_config(self, model_config, config_data, working_dir):
-        self.assertEqual(
-                config_data["RUNPATH"],
-                model_config.getRunpathAsString()
-                )
+    def assert_path(self, rel_path, config_path, model_path):
+        self.assertEqual( os.path.normpath( os.path.join( rel_path , config_path )), model_path)
 
-        self.assertEqual(
-                config_data["ENSPATH"],
-                model_config.getEnspath()
-                )
+
+    def assert_model_config(self, model_config, config_data, working_dir):
+        self.assert_path( working_dir, config_data["RUNPATH"], model_config.getRunpathAsString())
+        self.assert_path( working_dir, config_data["ENSPATH"], model_config.getEnspath() )
 
         self.assertEqual(
                 config_data["JOBNAME"],
@@ -316,10 +313,6 @@ class ResConfigTest(ExtendedTestCase):
                 ecl_config.getStartDate()
                 )
 
-        self.assertEqual(
-                config_data["ECLBASE"],
-                ecl_config.getEclBase()
-                )
 
         for extension in ["SMSPEC", "UNSMRY"]:
             self.assert_same_config_file(
@@ -464,19 +457,10 @@ class ResConfigTest(ExtendedTestCase):
             run_dir = "i/ll/camp/here"
             os.makedirs(run_dir)
             os.chdir(run_dir)
-
-            rel_config_file = "/".join(
-                                   [".."] * len(run_dir.split("/")) +
-                                   [self.config_file]
-                                   )
-
-            res_config = ResConfig(rel_config_file)
-
+            inv_run_dir = "/".join([".."] * len(run_dir.split("/")))
+            rel_config_file = os.path.join( inv_run_dir, self.config_file )
             work_dir = os.path.split(rel_config_file)[0]
-            rel2workdir = lambda path : os.path.join(
-                                             work_dir,
-                                             path
-                                             )
+            res_config = ResConfig(rel_config_file)
 
             self.assert_model_config(res_config.model_config, config_data, work_dir)
             self.assert_analysis_config(res_config.analysis_config, config_data)


### PR DESCRIPTION
**Task**
The config settings ENSPATH, RUNPATH and DATA_ROOT are accessed as paths
from the config layer, implying that path translation is invoked if cwd
differs from the location of config file. The return value from
config_path_elm() will be normalized to remove superfluos '../' and './'
elements.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#232
