### PR TITLE
Respect PATH in JOB_SCRIPT, now an EXECUTABLE

### DIFF
--- a/libconfig/include/ert/config/config_content.h
+++ b/libconfig/include/ert/config/config_content.h
@@ -60,6 +60,7 @@ typedef struct config_content_struct config_content_type;
   const char * config_content_get_value_as_path( const config_content_type * config , const char * kw);
   const char * config_content_get_value_as_abspath( const config_content_type * config , const char * kw);
   const char * config_content_get_value_as_relpath( const config_content_type * config , const char * kw);
+  const char * config_content_get_value_as_executable( const config_content_type * config , const char * kw);
   const char * config_content_get_value(const config_content_type * config , const char * kw);
   char * config_content_alloc_joined_string(const config_content_type * content , const char * kw, const char * sep);
   stringlist_type * config_content_alloc_complete_stringlist(const config_content_type * content , const char * kw);

--- a/libconfig/include/ert/config/config_content_node.h
+++ b/libconfig/include/ert/config/config_content_node.h
@@ -46,6 +46,7 @@ typedef struct config_content_node_struct config_content_node_type;
          const char *                 config_content_node_iget_as_path(config_content_node_type * node , int index);
          const char *                 config_content_node_iget_as_abspath( config_content_node_type * node , int index);
          const char *                 config_content_node_iget_as_relpath( config_content_node_type * node , int index);
+         const char *                 config_content_node_iget_as_executable( config_content_node_type * node , int index);
          time_t                       config_content_node_iget_as_isodate(const config_content_node_type * node , int index);
          const stringlist_type      * config_content_node_get_stringlist( const config_content_node_type * node );
          const char                 * config_content_node_safe_iget(const config_content_node_type * node , int index);

--- a/libconfig/src/config_content.c
+++ b/libconfig/src/config_content.c
@@ -325,6 +325,10 @@ const char * config_content_get_value_as_relpath( const config_content_type * co
   return config_content_node_iget_as_relpath(node , 0);
 }
 
+const char * config_content_get_value_as_executable( const config_content_type * config , const char * kw) {
+  config_content_node_type * node = config_content_get_value_node__( config , kw );
+  return config_content_node_iget_as_executable(node , 0);
+}
 
 const char * config_content_get_value(const config_content_type * config , const char * kw) {
   config_content_node_type * node = config_content_get_value_node__( config , kw );

--- a/libconfig/src/config_content_node.c
+++ b/libconfig/src/config_content_node.c
@@ -186,6 +186,24 @@ const char * config_content_node_iget_as_relpath( config_content_node_type * nod
   }
 }
 
+const char * config_content_node_iget_as_executable( config_content_node_type * node, int index ) {
+  config_schema_item_assure_type(node->schema, index,
+        CONFIG_PATH + CONFIG_EXISTING_PATH + CONFIG_EXECUTABLE );
+  {
+    const char * config_value = config_content_node_iget(node , index);
+
+    char* path_value = NULL;
+    if( !util_file_exists( config_value ) )
+        path_value = util_alloc_PATH_executable( config_value );
+
+    if( !path_value )
+        path_value = config_path_elm_alloc_abspath( node->cwd , config_value );
+
+    config_content_node_push_string( node , path_value );
+    return path_value;
+  }
+}
+
 
 const stringlist_type * config_content_node_get_stringlist( const config_content_node_type * node ) {
   return node->stringlist;

--- a/libconfig/src/config_schema_item.c
+++ b/libconfig/src/config_schema_item.c
@@ -227,19 +227,6 @@ config_schema_item_type * config_schema_item_alloc(const char * kw , bool requir
   return item;
 }
 
-
-
-static char * __alloc_relocated__(const config_path_elm_type * path_elm , const char * value) {
-  char * file;
-
-  if (util_is_abs_path(value))
-    file = util_alloc_string_copy( value );
-  else
-    file = util_alloc_filename(config_path_elm_get_relpath( path_elm ) , value , NULL);
-
-  return file;
-}
-
 bool config_schema_item_valid_string(config_item_types value_type , const char * value)
 {
   switch(value_type) {
@@ -375,8 +362,8 @@ bool config_schema_item_validate_set(const config_schema_item_type * item , stri
                  b. Else - try if the util_alloc_PATH_executable() exists.
             */
             if (!util_is_abs_path( value )) {
-              char * relocated  = __alloc_relocated__(path_elm , value);
-              char * path_exe   = util_alloc_PATH_executable( value );
+              char * relocated = config_path_elm_alloc_abspath( path_elm , value );
+              char * path_exe  = util_alloc_PATH_executable( value );
 
               if (util_file_exists(relocated)) {
                 if (util_is_executable(relocated))

--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -168,6 +168,10 @@ function( add_config_test name command )
     set_property( TEST ${name} PROPERTY ENVIRONMENT "ERT_ROOT=${ERT_ROOT}")
 endfunction()
 
+add_executable(enkf_executable_path tests/enkf_executable_path)
+target_link_libraries(enkf_executable_path enkf)
+add_test(NAME enkf_executable_path COMMAND enkf_executable_path)
+
 add_executable(enkf_queue_config tests/enkf_queue_config.c)
 target_link_libraries(enkf_queue_config enkf)
 add_config_test(enkf_queue_config

--- a/libenkf/src/queue_config.c
+++ b/libenkf/src/queue_config.c
@@ -258,7 +258,7 @@ static bool queue_config_init(queue_config_type * queue_config, const config_con
 
 
   if (config_content_has_item(config_content, JOB_SCRIPT_KEY))
-    queue_config_set_job_script(queue_config, config_content_get_value_as_abspath(config_content, JOB_SCRIPT_KEY));
+    queue_config_set_job_script(queue_config, config_content_get_value_as_executable(config_content, JOB_SCRIPT_KEY));
 
   if (config_content_has_item(config_content, MAX_SUBMIT_KEY))
     queue_config->max_submit = config_content_get_value_as_int(config_content, MAX_SUBMIT_KEY);
@@ -318,6 +318,6 @@ void queue_config_add_config_items(config_parser_type * parser, bool site_mode) 
   {
     config_schema_item_type * item = config_add_schema_item(parser, JOB_SCRIPT_KEY, false);
     config_schema_item_set_argc_minmax(item, 1, 1);
-    config_schema_item_iset_type(item, 0, CONFIG_EXISTING_PATH);
+    config_schema_item_iset_type(item, 0, CONFIG_EXECUTABLE);
   }
 }

--- a/libenkf/tests/enkf_executable_path.c
+++ b/libenkf/tests/enkf_executable_path.c
@@ -1,0 +1,28 @@
+#include <ert/util/util.h>
+#include <ert/util/test_util.h>
+#include <ert/util/test_work_area.h>
+
+#include <ert/enkf/config_keys.h>
+#include <ert/enkf/queue_config.h>
+
+int main() {
+    util_install_signals();
+
+    test_work_area_type * work_area = test_work_area_alloc("enkf_executable_path");
+    const char * user_config_file = "path.txt";
+
+    config_parser_type * parser = config_alloc( );
+    queue_config_add_config_items( parser, true );
+    test_assert_true( config_has_schema_item( parser , JOB_SCRIPT_KEY ) );
+
+    FILE* stream = util_fopen(user_config_file, "w");
+    fprintf(stream, "NUM_REALIZATIONS 14\n");
+    fprintf(stream, "JOB_SCRIPT  ls\n");
+    fclose(stream);
+
+    queue_config_alloc_load( user_config_file );
+
+    test_work_area_free( work_area );
+
+    return 0;
+}

--- a/libjob_queue/src/ext_job.c
+++ b/libjob_queue/src/ext_job.c
@@ -866,7 +866,7 @@ ext_job_type * ext_job_fscanf_alloc(const char * name , const char * license_roo
 
 
         {
-          const char * executable     = config_content_get_value_as_abspath(content  , "EXECUTABLE");
+          const char * executable     = config_content_get_value_as_executable(content  , "EXECUTABLE");
           const char * executable_raw = config_content_iget(content  , "EXECUTABLE" , 0,0);
           ext_job_set_executable(ext_job , executable, executable_raw, search_path);
         }

--- a/libjob_queue/src/workflow_job.c
+++ b/libjob_queue/src/workflow_job.c
@@ -101,7 +101,7 @@ config_parser_type * workflow_job_alloc_config() {
     /*****************************************************************/
     item = config_add_schema_item( config , EXECUTABLE_KEY , false );
     config_schema_item_set_argc_minmax( item , 1 , 1 );
-    config_schema_item_iset_type( item , 0 , CONFIG_PATH );
+    config_schema_item_iset_type( item , 0 , CONFIG_EXECUTABLE );
 
     /*****************************************************************/
     item = config_add_schema_item( config , SCRIPT_KEY , false );
@@ -332,7 +332,7 @@ workflow_job_type * workflow_job_config_alloc( const char * name , config_parser
         workflow_job_set_function( workflow_job , config_content_get_value( content , FUNCTION_KEY));
 
       if (config_content_has_item( content , EXECUTABLE_KEY))
-        workflow_job_set_executable( workflow_job , config_content_get_value_as_abspath( content , EXECUTABLE_KEY));
+        workflow_job_set_executable( workflow_job , config_content_get_value_as_executable( content , EXECUTABLE_KEY));
 
       if (config_content_has_item( content , SCRIPT_KEY)) {
         workflow_job_set_internal_script( workflow_job , config_content_get_value_as_abspath( content , SCRIPT_KEY));


### PR DESCRIPTION
Disclaimer: this is a ROUGH outline and not a portable, merge-ready implementation yet, it just outlines the idea.

Make job script an EXECUTABLE type key, and extend the notion of
EXECUTABLE to not only include absolute paths with an executable flag
set, but also system executables from the PATH variable.

Benefits:
* System provided JOB_SCRIPTS and other executables are more robust for
  relocations on the same system
* Jobs are more portable if they use this feature
* site-configs can use some system installed executable, rather than
  relying on some absolute path in a shared site-config
* Executable lookups follow system-wide logic, allowing users to easily
  select their own, full path to some executable, rather than being
  limited by $ERT_ROOT or other vars

Drawbacks:
* Some debugging scenarions might be harder when the wrong executable is
  accidently picked up (can be mitigated by falling back to absolute
  path)

**Task**
_Short description of the task_


**Approach**
_Short description of the approach_


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
