### PR TITLE
Set GEO_ID immediately and resolve it consistently

### DIFF
--- a/libenkf/include/ert/enkf/run_arg.h
+++ b/libenkf/include/ert/enkf/run_arg.h
@@ -36,9 +36,29 @@ UTIL_SAFE_CAST_HEADER( run_arg );
 UTIL_IS_INSTANCE_HEADER( run_arg );
 
 
-  run_arg_type * run_arg_alloc_ENSEMBLE_EXPERIMENT(const char * run_id, enkf_fs_type * sim_fs, int iens , int iter , const char * runpath, const char * job_name);
-  run_arg_type * run_arg_alloc_INIT_ONLY(const char * run_id, enkf_fs_type * sim_fs , int iens , int iter , const char * runpath);
-  run_arg_type * run_arg_alloc_SMOOTHER_RUN(const char * run_id , enkf_fs_type * sim_fs , enkf_fs_type * update_target_fs , int iens , int iter , const char * runpath, const char * job_name);
+  run_arg_type * run_arg_alloc_ENSEMBLE_EXPERIMENT(const char * run_id,
+                                                   enkf_fs_type * sim_fs,
+                                                   int iens,
+                                                   int iter,
+                                                   const char * runpath,
+                                                   const char * job_name,
+                                                   const subst_list_type * subst_list);
+
+  run_arg_type * run_arg_alloc_INIT_ONLY(const char * run_id,
+                                         enkf_fs_type * sim_fs,
+                                         int iens,
+                                         int iter,
+                                         const char * runpath,
+                                         const subst_list_type * subst_list);
+
+  run_arg_type * run_arg_alloc_SMOOTHER_RUN(const char * run_id,
+                                            enkf_fs_type * sim_fs,
+                                            enkf_fs_type * update_target_fs,
+                                            int iens,
+                                            int iter,
+                                            const char * runpath,
+                                            const char * job_name,
+                                            const subst_list_type * subst_list);
 
   int            run_arg_get_step1( const run_arg_type * run_arg );
   int            run_arg_get_step2( const run_arg_type * run_arg );
@@ -70,6 +90,8 @@ UTIL_IS_INSTANCE_HEADER( run_arg );
 
   void run_arg_set_geo_id( run_arg_type * run_arg , int geo_id);
   int run_arg_get_geo_id( const run_arg_type * run_arg);
+
+  const subst_list_type * run_arg_get_subst_list(const run_arg_type * run_arg);
 
 #ifdef __cplusplus
 }

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1411,16 +1411,6 @@ void * enkf_main_isubmit_job__( void * arg ) {
   run_arg_type * run_arg = run_arg_safe_cast( arg_pack_iget_ptr( arg_pack , 1));
   job_queue_type * job_queue = job_queue_safe_cast( arg_pack_iget_ptr( arg_pack , 2));
 
-  /*
-    If this is called from wpro the arg_pack has an additional third
-    integer argument corresponding to the geo_id. That is retrofitted
-    to the run_arg argument.
-  */
-  if (arg_pack_size( arg_pack ) > 3) {
-    int geo_id = arg_pack_iget_int( arg_pack , 3);
-    run_arg_set_geo_id( run_arg, geo_id );
-  }
-
   enkf_main_isubmit_job( enkf_main , run_arg , job_queue);
   return NULL;
 }

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1376,16 +1376,7 @@ static void * enkf_main_create_run_path__( enkf_main_type * enkf_main,
 }
 
 void enkf_main_create_run_path(enkf_main_type * enkf_main , const ert_run_context_type * run_context) {
-  init_mode_type init_mode = ert_run_context_get_init_mode( run_context );
-
-  enkf_main_init_internalization(enkf_main , init_mode);
-  {
-    stringlist_type * param_list = ensemble_config_alloc_keylist_from_var_type(enkf_main_get_ensemble_config(enkf_main), PARAMETER );
-    enkf_main_initialize_from_scratch(enkf_main ,
-                                      param_list ,
-                                      run_context);
-    stringlist_free( param_list );
-  }
+  enkf_main_init_run(enkf_main, run_context);
 
   enkf_main_create_run_path__( enkf_main , run_context );
 

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1358,6 +1358,9 @@ void * enkf_main_icreate_run_path( enkf_main_type * enkf_main, run_arg_type * ru
 
   enkf_state_init_eclipse( enkf_main->res_config,
                            run_arg );
+
+  runpath_list_type * runpath_list = enkf_main_get_runpath_list(enkf_main);
+  runpath_list_fprintf( runpath_list );
   return NULL;
 }
 
@@ -1377,21 +1380,7 @@ static void * enkf_main_create_run_path__( enkf_main_type * enkf_main,
 
 void enkf_main_create_run_path(enkf_main_type * enkf_main , const ert_run_context_type * run_context) {
   enkf_main_init_run(enkf_main, run_context);
-
   enkf_main_create_run_path__( enkf_main , run_context );
-
-  /*
-    The runpath_list is written to disk here, when all the simulation
-    folders have been created and filled with content. The
-    runpath_list instance is owned and managed by the hook manager;
-    could say that the responsability for writing that data should be
-    with the hook_manager?
-  */
-
-  {
-    runpath_list_type * runpath_list = enkf_main_get_runpath_list(enkf_main);
-    runpath_list_fprintf( runpath_list );
-  }
 }
 
 

--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -793,7 +793,7 @@ void enkf_state_init_eclipse(const res_config_type * res_config,
       free( iens_str );
     }
 
-    if (run_arg_get_geo_id( run_arg ) > 0) {
+    if (run_arg_get_geo_id( run_arg ) >= 0) {
       char * geo_id_str = util_alloc_sprintf("%d" , run_arg_get_geo_id( run_arg ));
       subst_list_append_copy( subst_list , "<GEO_ID>", geo_id_str, NULL);
     }

--- a/libenkf/src/ert_run_context.c
+++ b/libenkf/src/ert_run_context.c
@@ -168,7 +168,8 @@ ert_run_context_type * ert_run_context_alloc_ENSEMBLE_EXPERIMENT(enkf_fs_type * 
 								iens,
 								iter,
 								stringlist_iget( runpath_list , iens),
-								stringlist_iget( jobname_list, iens));
+								stringlist_iget( jobname_list, iens),
+                                subst_list);
         vector_append_owned_ref( context->run_args , arg , run_arg_free__);
       } else
         vector_append_ref( context->run_args, NULL );
@@ -191,7 +192,12 @@ ert_run_context_type * ert_run_context_alloc_INIT_ONLY(enkf_fs_type * sim_fs,
     stringlist_type * runpath_list = ert_run_context_alloc_runpath_list( iactive , runpath_fmt , subst_list , iter );
     for (int iens = 0; iens < bool_vector_size( iactive ); iens++) {
       if (bool_vector_iget( iactive , iens )) {
-        run_arg_type * arg = run_arg_alloc_INIT_ONLY( context->run_id, sim_fs , iens , iter , stringlist_iget( runpath_list , iens));
+        run_arg_type * arg = run_arg_alloc_INIT_ONLY(context->run_id,
+                                                     sim_fs,
+                                                     iens,
+                                                     iter,
+                                                     stringlist_iget(runpath_list, iens),
+                                                     subst_list);
         vector_append_owned_ref( context->run_args , arg , run_arg_free__);
       } else
         vector_append_ref( context->run_args, NULL );
@@ -222,7 +228,8 @@ ert_run_context_type * ert_run_context_alloc_SMOOTHER_RUN(enkf_fs_type * sim_fs 
 							 iens,
 							 iter,
 							 stringlist_iget( runpath_list , iens),
-							 stringlist_iget( jobname_list , iens));
+							 stringlist_iget( jobname_list , iens),
+                             subst_list);
         vector_append_owned_ref( context->run_args , arg , run_arg_free__);
       } else
         vector_append_ref( context->run_args, NULL );

--- a/libenkf/tests/enkf_export_inactive_cells.c
+++ b/libenkf/tests/enkf_export_inactive_cells.c
@@ -121,11 +121,11 @@ void check_exported_data(const char * exported_file,
 
 void forward_initialize_node(enkf_main_type * enkf_main, const char * init_file, enkf_node_type * field_node) {
   enkf_fs_type * fs           =  enkf_main_get_fs(enkf_main);
+  subst_list_type * subst_list = subst_list_alloc(NULL);
   {
     const int ens_size          = enkf_main_get_ensemble_size( enkf_main );
     bool_vector_type * iactive  = bool_vector_alloc(ens_size, true);
     const path_fmt_type * runpath_fmt = model_config_get_runpath_fmt( enkf_main_get_model_config( enkf_main ));
-    const subst_list_type * subst_list = NULL;
     ert_run_context_type * run_context = ert_run_context_alloc_INIT_ONLY( fs, INIT_CONDITIONAL , iactive, runpath_fmt, subst_list , 0 );
 
     enkf_main_create_run_path(enkf_main , run_context );
@@ -136,10 +136,13 @@ void forward_initialize_node(enkf_main_type * enkf_main, const char * init_file,
   {
     int iens                = 0;
     enkf_state_type * state = enkf_main_iget_state( enkf_main , iens );
-    run_arg_type  * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "RUN_ID", fs , 0 ,0 , "simulations/run0", "path");
+
+    run_arg_type  * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "RUN_ID", fs , 0 ,0 , "simulations/run0", "path", subst_list);
 
     ensemble_config_forward_init( enkf_state_get_ensemble_config( state ) , run_arg);
   }
+
+  subst_list_free(subst_list);
 }
 
 

--- a/libenkf/tests/enkf_forward_init_FIELD.c
+++ b/libenkf/tests/enkf_forward_init_FIELD.c
@@ -36,7 +36,7 @@ void create_runpath(enkf_main_type * enkf_main, int iter) {
   const int ens_size         = enkf_main_get_ensemble_size( enkf_main );
   bool_vector_type * iactive = bool_vector_alloc(ens_size,true);
   const path_fmt_type * runpath_fmt = model_config_get_runpath_fmt( enkf_main_get_model_config( enkf_main ));
-  const subst_list_type * subst_list = NULL;
+  const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
   enkf_fs_type * fs           =  enkf_main_get_fs(enkf_main);
   ert_run_context_type * run_context = ert_run_context_alloc_INIT_ONLY( fs, INIT_CONDITIONAL, iactive, runpath_fmt, subst_list , 0 );
 
@@ -96,7 +96,8 @@ int main(int argc , char ** argv) {
       const enkf_config_node_type * field_config_node = ensemble_config_get_node( ens_config , "PORO" );
       enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
       enkf_node_type * field_node = enkf_node_alloc( field_config_node );
-      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs, 0 ,0 , "simulations/run0", "BASE");
+      const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
+      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs, 0 ,0 , "simulations/run0", "BASE", subst_list);
       node_id_type node_id = {.report_step = 0 ,
                               .iens = 0 };
 

--- a/libenkf/tests/enkf_forward_init_GEN_KW.c
+++ b/libenkf/tests/enkf_forward_init_GEN_KW.c
@@ -28,6 +28,7 @@
 #include <ert/util/thread_pool.h>
 #include <ert/util/arg_pack.h>
 
+#include <ert/res_util/subst_list.h>
 #include <ert/enkf/enkf_main.h>
 #include <ert/enkf/run_arg.h>
 
@@ -36,7 +37,7 @@ void create_runpath(enkf_main_type * enkf_main, int iter ) {
   const int ens_size         = enkf_main_get_ensemble_size( enkf_main );
   bool_vector_type * iactive = bool_vector_alloc(ens_size,true);
   const path_fmt_type * runpath_fmt = model_config_get_runpath_fmt( enkf_main_get_model_config( enkf_main ));
-  const subst_list_type * subst_list = NULL;
+  const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));;
   enkf_fs_type * fs           =  enkf_main_get_fs(enkf_main);
   ert_run_context_type * run_context = ert_run_context_alloc_INIT_ONLY( fs, INIT_CONDITIONAL, iactive, runpath_fmt, subst_list , iter );
 
@@ -92,7 +93,8 @@ int main(int argc , char ** argv) {
       const ensemble_config_type * ens_config = enkf_main_get_ensemble_config( enkf_main );
       enkf_state_type * state   = enkf_main_iget_state( enkf_main , 0 );
       enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
-      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs , 0 , 0 , "simulations/run0", "BASE");
+      const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
+      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", fs , 0 , 0 , "simulations/run0", "BASE", subst_list);
       const enkf_config_node_type * gen_kw_config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ), "MULTFLT");
       enkf_node_type * gen_kw_node = enkf_node_alloc( gen_kw_config_node );
       node_id_type node_id = {.report_step = 0 ,

--- a/libenkf/tests/enkf_forward_init_GEN_PARAM.c
+++ b/libenkf/tests/enkf_forward_init_GEN_PARAM.c
@@ -37,7 +37,7 @@ void create_runpath(enkf_main_type * enkf_main, int iter ) {
   const int ens_size         = enkf_main_get_ensemble_size( enkf_main );
   bool_vector_type * iactive = bool_vector_alloc(ens_size, true);
   const path_fmt_type * runpath_fmt = model_config_get_runpath_fmt( enkf_main_get_model_config( enkf_main ));
-  const subst_list_type * subst_list = NULL;
+  const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
   enkf_fs_type * fs           =  enkf_main_get_fs(enkf_main);
   ert_run_context_type * run_context = ert_run_context_alloc_INIT_ONLY( fs, INIT_CONDITIONAL, iactive, runpath_fmt, subst_list , iter );
 
@@ -96,7 +96,8 @@ int main(int argc , char ** argv) {
       const enkf_config_node_type * config_node = ensemble_config_get_node( enkf_main_get_ensemble_config( enkf_main ) , "PARAM" );
       enkf_node_type * gen_param_node = enkf_node_alloc( config_node );
       enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
-      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs , 0 , 0 , "simulations/run0", "BASE");
+      const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
+      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs , 0 , 0 , "simulations/run0", "BASE", subst_list);
 
       node_id_type node_id = {.report_step = 0 ,
                               .iens = 0};

--- a/libenkf/tests/enkf_forward_init_SURFACE.c
+++ b/libenkf/tests/enkf_forward_init_SURFACE.c
@@ -36,7 +36,7 @@ void create_runpath(enkf_main_type * enkf_main, int iter  ) {
   const int ens_size         = enkf_main_get_ensemble_size( enkf_main );
   bool_vector_type * iactive = bool_vector_alloc(ens_size, true);
   const path_fmt_type * runpath_fmt = model_config_get_runpath_fmt( enkf_main_get_model_config( enkf_main ));
-  const subst_list_type * subst_list = NULL;
+  const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
   enkf_fs_type * fs           =  enkf_main_get_fs(enkf_main);
   ert_run_context_type * run_context = ert_run_context_alloc_INIT_ONLY( fs, INIT_CONDITIONAL, iactive, runpath_fmt, subst_list , iter );
 
@@ -96,7 +96,8 @@ int main(int argc , char ** argv) {
       const enkf_config_node_type * config_node = ensemble_config_get_node( ens_config , "SURFACE");
       enkf_state_type * state   = enkf_main_iget_state( enkf_main , 0 );
       enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
-      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs , 0 ,0 , "simulations/run0", "BASE");
+      const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
+      run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs , 0 ,0 , "simulations/run0", "BASE", subst_list);
       enkf_node_type * surface_node = enkf_node_alloc( config_node );
       node_id_type node_id = {.report_step = 0 ,
                               .iens = 0 };

--- a/libenkf/tests/enkf_forward_init_transform.c
+++ b/libenkf/tests/enkf_forward_init_transform.c
@@ -40,7 +40,7 @@ void create_runpath(enkf_main_type * enkf_main, int iter ) {
   const int ens_size         = enkf_main_get_ensemble_size( enkf_main );
   bool_vector_type * iactive = bool_vector_alloc(ens_size, true);
   const path_fmt_type * runpath_fmt = model_config_get_runpath_fmt( enkf_main_get_model_config( enkf_main ));
-  const subst_list_type * subst_list = NULL;
+  const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
   enkf_fs_type * fs           =  enkf_main_get_fs(enkf_main);
   ert_run_context_type * run_context = ert_run_context_alloc_INIT_ONLY( fs, INIT_CONDITIONAL, iactive, runpath_fmt, subst_list , iter );
 
@@ -86,7 +86,8 @@ int main(int argc , char ** argv) {
   enkf_main_type * enkf_main = enkf_main_alloc(res_config, strict, true);
   ensemble_config_type * ens_config = enkf_main_get_ensemble_config( enkf_main );
   enkf_fs_type * init_fs = enkf_main_get_fs(enkf_main);
-  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", init_fs , 0 ,0 , "simulations/run0", "base");
+  const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
+  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", init_fs , 0 ,0 , "simulations/run0", "base", subst_list);
   enkf_config_node_type * config_node = ensemble_config_get_node( ens_config , "PORO");
   enkf_node_type * field_node = enkf_node_alloc( config_node );
 

--- a/libenkf/tests/enkf_forward_load_context.c
+++ b/libenkf/tests/enkf_forward_load_context.c
@@ -48,7 +48,8 @@ void test_create() {
 }
 
 void test_load_restart1() {
-  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", NULL, 0 , 0 , "run", "BASE");
+  subst_list_type * subst_list = subst_list_alloc(NULL);
+  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", NULL, 0 , 0 , "run", "BASE", subst_list);
   ecl_config_type * ecl_config = ecl_config_alloc(NULL);
 
   forward_load_context_type * load_context = forward_load_context_alloc( run_arg , false , ecl_config , NULL );
@@ -58,6 +59,7 @@ void test_load_restart1() {
   forward_load_context_free( load_context );
   ecl_config_free( ecl_config );
   run_arg_free( run_arg );
+  subst_list_free(subst_list);
 }
 
 
@@ -74,7 +76,8 @@ void make_restart_mock( const char * path , const char * eclbase , int report_st
 void test_load_restart2() {
   test_work_area_type * work_area = test_work_area_alloc("forward_load");
   {
-    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", NULL , 0 , 0 , "run", "BASE");
+    subst_list_type * subst_list = subst_list_alloc(NULL);
+    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", NULL , 0 , 0 , "run", "BASE", subst_list);
     ecl_config_type * ecl_config = ecl_config_alloc(NULL);
     forward_load_context_type * load_context = forward_load_context_alloc( run_arg , false , ecl_config , NULL );
     util_make_path("run");
@@ -89,6 +92,7 @@ void test_load_restart2() {
     forward_load_context_free( load_context );
     ecl_config_free( ecl_config );
     run_arg_free( run_arg );
+    subst_list_free(subst_list);
   }
   test_work_area_free( work_area );
 }

--- a/libenkf/tests/enkf_gen_data_config.c
+++ b/libenkf/tests/enkf_gen_data_config.c
@@ -88,7 +88,8 @@ void test_gendata_fload(const char * filename) {
 
   const char * cwd = test_work_area_get_cwd(work_area);
   enkf_fs_type * write_fs = enkf_fs_create_fs(cwd, BLOCK_FS_DRIVER_ID, NULL , true);
-  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", write_fs, 0,0,"path", "base");
+  subst_list_type * subst_list = subst_list_alloc(NULL);
+  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", write_fs, 0,0,"path", "base", subst_list);
   forward_load_context_type * load_context = forward_load_context_alloc( run_arg , false , NULL , NULL);
   forward_load_context_select_step(load_context , 0 );
   gen_data_fload_with_report_step(gen_data, filename , load_context);
@@ -100,6 +101,7 @@ void test_gendata_fload(const char * filename) {
   gen_data_config_free( config );
   test_work_area_free(work_area);
   run_arg_free( run_arg );
+  subst_list_free(subst_list);
   forward_load_context_free( load_context );
 }
 
@@ -110,7 +112,8 @@ void test_gendata_fload_empty_file(const char * filename) {
   gen_data_type * gen_data = gen_data_alloc(config);
   const char * cwd = test_work_area_get_cwd(work_area);
   enkf_fs_type * write_fs = enkf_fs_create_fs(cwd, BLOCK_FS_DRIVER_ID, NULL , true);
-  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", write_fs, 0,0,"path", "base");
+  subst_list_type * subst_list = subst_list_alloc(NULL);
+  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", write_fs, 0,0,"path", "base", subst_list);
   forward_load_context_type * load_context = forward_load_context_alloc( run_arg , false , NULL , NULL);
 
   forward_load_context_select_step(load_context , 0 );
@@ -123,6 +126,7 @@ void test_gendata_fload_empty_file(const char * filename) {
   gen_data_config_free( config );
   test_work_area_free(work_area);
   run_arg_free( run_arg );
+  subst_list_free(subst_list);
   forward_load_context_free( load_context );
 }
 

--- a/libenkf/tests/enkf_run_arg.c
+++ b/libenkf/tests/enkf_run_arg.c
@@ -42,7 +42,8 @@ void test_queue_index() {
   test_work_area_type * test_area = test_work_area_alloc("run_arg/ENS");
   {
     enkf_fs_type * fs   = enkf_fs_create_fs("sim" , BLOCK_FS_DRIVER_ID , NULL , true);
-    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", fs , 0 , 6 , "path", "base");
+    subst_list_type * subst_list = subst_list_alloc(NULL);
+    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", fs , 0 , 6 , "path", "base", subst_list);
 
     test_assert_false( run_arg_is_submitted( run_arg ) );
     test_assert_util_abort("run_arg_get_queue_index" , call_get_queue_index , run_arg );
@@ -53,6 +54,7 @@ void test_queue_index() {
 
     test_assert_util_abort("run_arg_set_queue_index" , call_set_queue_index , run_arg );
     run_arg_free( run_arg );
+    subst_list_free(subst_list);
     enkf_fs_decref( fs );
   }
   test_work_area_free( test_area );
@@ -76,11 +78,13 @@ void test_SMOOTHER_RUN( ) {
   {
     enkf_fs_type * sim_fs    = enkf_fs_create_fs("sim" , BLOCK_FS_DRIVER_ID , NULL , true);
     enkf_fs_type * target_fs = enkf_fs_create_fs("target" , BLOCK_FS_DRIVER_ID , NULL , true);
-    run_arg_type * run_arg = run_arg_alloc_SMOOTHER_RUN("run_id", sim_fs , target_fs , 0 , 6 , "path", "BASE");
+    subst_list_type * subst_list = subst_list_alloc(NULL);
+    run_arg_type * run_arg = run_arg_alloc_SMOOTHER_RUN("run_id", sim_fs , target_fs , 0 , 6 , "path", "BASE", subst_list);
     test_assert_true( run_arg_is_instance( run_arg ));
     test_assert_ptr_equal( run_arg_get_sim_fs( run_arg ) , sim_fs );
     test_assert_ptr_equal( run_arg_get_update_target_fs( run_arg ) , target_fs );
     run_arg_free( run_arg );
+    subst_list_free(subst_list);
 
     enkf_fs_decref( sim_fs );
     enkf_fs_decref( target_fs );
@@ -93,8 +97,10 @@ void alloc_invalid_run_arg(void *arg) {
   test_work_area_type * test_area = test_work_area_alloc("run_arg/invalid");
   {
     enkf_fs_type * fs    = enkf_fs_create_fs("fs" , BLOCK_FS_DRIVER_ID , NULL , true);
-    run_arg_type * run_arg = run_arg_alloc_SMOOTHER_RUN("run_id", fs , fs , 0 , 6 , "path", "BASE"); // This should explode ...
+    subst_list_type * subst_list = subst_list_alloc(NULL);
+    run_arg_type * run_arg = run_arg_alloc_SMOOTHER_RUN("run_id", fs , fs , 0 , 6 , "path", "BASE", subst_list); // This should explode ...
     run_arg_free( run_arg );
+    subst_list_free(subst_list);
     enkf_fs_decref( fs );
   }
   test_work_area_free( test_area );
@@ -111,12 +117,14 @@ void test_INIT_ONLY( ) {
   {
     enkf_fs_type * init_fs   = enkf_fs_create_fs("sim" , BLOCK_FS_DRIVER_ID , NULL , true);
 
-    run_arg_type * run_arg = run_arg_alloc_INIT_ONLY("run_id", init_fs , 0 , 6 , "path");
+    subst_list_type * subst_list = subst_list_alloc(NULL);
+    run_arg_type * run_arg = run_arg_alloc_INIT_ONLY("run_id", init_fs , 0 , 6 , "path", subst_list);
     test_assert_true( run_arg_is_instance( run_arg ));
     test_assert_ptr_equal( run_arg_get_sim_fs( run_arg ) , init_fs );
 
     test_assert_util_abort( "run_arg_get_update_target_fs" , call_get_update_target_fs , run_arg );
     run_arg_free( run_arg );
+    subst_list_free(subst_list);
 
     enkf_fs_decref( init_fs );
   }
@@ -129,7 +137,8 @@ void test_ENSEMBLE_EXPERIMENT( ) {
   {
     enkf_fs_type * fs   = enkf_fs_create_fs("sim" , BLOCK_FS_DRIVER_ID , NULL , true);
 
-    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", fs , 0 , 6 , "path", "BASE");
+    subst_list_type * subst_list = subst_list_alloc(NULL);
+    run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", fs , 0 , 6 , "path", "BASE", subst_list);
     test_assert_true( run_arg_is_instance( run_arg ));
 
     test_assert_ptr_equal( run_arg_get_sim_fs( run_arg ) , fs );
@@ -137,11 +146,13 @@ void test_ENSEMBLE_EXPERIMENT( ) {
 
     test_assert_string_equal( run_arg_get_run_id( run_arg ) , "run_id");
     run_arg_free( run_arg );
+    subst_list_free(subst_list);
     enkf_fs_decref( fs );
   }
   test_work_area_free( test_area );
 }
 
+// TODO: Write tests for the new functionality
 
 int main(int argc , char ** argv) {
   test_queue_index();

--- a/libenkf/tests/enkf_state_manual_load_test.c
+++ b/libenkf/tests/enkf_state_manual_load_test.c
@@ -40,7 +40,14 @@ int test_load_manually_to_new_case(enkf_main_type * enkf_main) {
 
 
   enkf_fs_type * fs = enkf_main_get_fs( enkf_main );
-  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", fs, iens , iter , "simulations/run0", job_name);
+  const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
+  run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id",
+                                                             fs,
+                                                             iens,
+                                                             iter,
+                                                             "simulations/run0",
+                                                             job_name,
+                                                             subst_list);
   {
     arg_pack_type * arg_pack = arg_pack_alloc();
     arg_pack_append_ptr( arg_pack , enkf_main_iget_state(enkf_main, 0));

--- a/libenkf/tests/enkf_state_report_step_compatible.c
+++ b/libenkf/tests/enkf_state_report_step_compatible.c
@@ -35,7 +35,15 @@ bool check_ecl_sum_compatible(const enkf_main_type * enkf_main)
   enkf_state_type * state    = enkf_main_iget_state( enkf_main , 0 );
   enkf_fs_type    * fs       = enkf_main_get_fs( enkf_main );
   char * job_name            = model_config_alloc_jobname( enkf_main_get_model_config( enkf_main ), 0);
-  run_arg_type * run_arg     = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", fs , 0 , 0 , "simulations/run0", job_name);
+  const subst_list_type * subst_list =  subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
+
+  run_arg_type * run_arg     = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id",
+                                                                 fs,
+                                                                 0,
+                                                                 0,
+                                                                 "simulations/run0",
+                                                                 job_name,
+                                                                 subst_list);
 
   state_map_type * state_map = enkf_fs_get_state_map(fs);
   state_map_iset(state_map, 0, STATE_INITIALIZED);

--- a/libenkf/tests/enkf_state_skip_summary_load_test.c
+++ b/libenkf/tests/enkf_state_skip_summary_load_test.c
@@ -34,9 +34,10 @@ bool check_ecl_sum_loaded(const enkf_main_type * enkf_main)
   stringlist_type * msg_list = stringlist_alloc_new();
   enkf_state_type * state1   = enkf_main_iget_state( enkf_main , 0 );
   char * job_name            = model_config_alloc_jobname( enkf_main_get_model_config( enkf_main ), 0);
-  run_arg_type * run_arg1    = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs, 0 , 0 , "simulations/run0", job_name);
+  const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
+  run_arg_type * run_arg1    = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs, 0 , 0 , "simulations/run0", job_name, subst_list);
   enkf_state_type * state2   = enkf_main_iget_state( enkf_main , 1 );
-  run_arg_type * run_arg2    = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs, 0 , 0 , "simulations/run1", job_name);
+  run_arg_type * run_arg2    = run_arg_alloc_ENSEMBLE_EXPERIMENT( "run_id", fs, 0 , 0 , "simulations/run1", job_name, subst_list);
 
 
   state_map_type * state_map = enkf_fs_get_state_map(fs);

--- a/libenkf/tests/gen_kw_logarithmic_test.c
+++ b/libenkf/tests/gen_kw_logarithmic_test.c
@@ -88,7 +88,8 @@ void test_write_gen_kw_export_file(enkf_main_type * enkf_main) {
   }
 
   {
-    run_arg_type * run_arg = run_arg_alloc_INIT_ONLY( "run_id", init_fs , 0 ,0 , "simulations/run0");
+    const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
+    run_arg_type * run_arg = run_arg_alloc_INIT_ONLY( "run_id", init_fs , 0 ,0 , "simulations/run0", subst_list);
     enkf_state_ecl_write( enkf_main_get_ensemble_config( enkf_main ),
                           enkf_main_get_model_config( enkf_main ),
                           run_arg ,

--- a/libenkf/tests/gen_kw_test.c
+++ b/libenkf/tests/gen_kw_test.c
@@ -44,7 +44,8 @@ void test_write_gen_kw_export_file(enkf_main_type * enkf_main)
   stringlist_type * key_list = ensemble_config_alloc_keylist_from_var_type( enkf_main_get_ensemble_config( enkf_main ) , PARAMETER );
   enkf_state_type * state = enkf_main_iget_state( enkf_main , 0 );
   enkf_fs_type * init_fs = enkf_main_get_fs( enkf_main );
-  run_arg_type * run_arg = run_arg_alloc_INIT_ONLY( "run_id", init_fs , 0 ,0 , "simulations/run0");
+  const subst_list_type * subst_list = subst_config_get_subst_list(enkf_main_get_subst_config(enkf_main));
+  run_arg_type * run_arg = run_arg_alloc_INIT_ONLY( "run_id", init_fs , 0 ,0 , "simulations/run0", subst_list);
   rng_manager_type * rng_manager = enkf_main_get_rng_manager( enkf_main );
   rng_type * rng = rng_manager_iget( rng_manager, run_arg_get_iens( run_arg ));
 

--- a/python/python/res/enkf/enkf_main.py
+++ b/python/python/res/enkf/enkf_main.py
@@ -72,6 +72,7 @@ class EnKFMain(BaseCClass):
     _get_runpath_list = EnkfPrototype("runpath_list_ref enkf_main_get_runpath_list(enkf_main)")
     _add_node = EnkfPrototype("void enkf_main_add_node(enkf_main, enkf_config_node)")
     _get_res_config = EnkfPrototype("res_config_ref enkf_main_get_res_config(enkf_main)")
+    _init_run = EnkfPrototype("void enkf_main_init_run(enkf_main, ert_run_context)")
 
 
     def __init__(self, config, strict=True, verbose=True):
@@ -306,6 +307,9 @@ class EnKFMain(BaseCClass):
     def loadFromForwardModel(self, realization, iteration, fs):
         """Returns the number of loaded realizations"""
         return self._load_from_forward_model(iteration, realization, fs)
+
+    def initRun(self, run_context):
+        self._init_run(run_context)
 
     def createRunpath(self , run_context, iens = None):
         if iens is None:

--- a/python/python/res/enkf/res_config.py
+++ b/python/python/res/enkf/res_config.py
@@ -421,7 +421,7 @@ class ResConfig(BaseCClass):
 
     @property
     def subst_config(self):
-        return self._subst_config( )
+        return self._subst_config().setParent(self)
 
     @property
     def model_config(self):

--- a/python/python/res/enkf/run_arg.py
+++ b/python/python/res/enkf/run_arg.py
@@ -25,6 +25,8 @@ class RunArg(BaseCClass):
     _get_queue_index           = EnkfPrototype("int  run_arg_get_queue_index(run_arg)")
     _is_submitted              = EnkfPrototype("bool run_arg_is_submitted(run_arg)")
     _get_run_id                = EnkfPrototype("char* run_arg_get_run_id(run_arg)")
+    _get_geo_id                = EnkfPrototype("int run_arg_get_geo_id(run_arg)")
+    _set_geo_id                = EnkfPrototype("void run_arg_set_geo_id(run_arg, int)")
 
     def __init__(self):
         raise NotImplementedError("Cannot instantiat RunArg directly!")
@@ -55,3 +57,11 @@ class RunArg(BaseCClass):
 
     def get_run_id(self):
         return self._get_run_id( )
+
+    @property
+    def geo_id(self):
+        return self._get_geo_id()
+
+    @geo_id.setter
+    def geo_id(self, value):
+        self._set_geo_id(value)

--- a/python/python/res/enkf/run_arg.py
+++ b/python/python/res/enkf/run_arg.py
@@ -20,7 +20,7 @@ from res.enkf import EnkfPrototype
 class RunArg(BaseCClass):
     TYPE_NAME = "run_arg"
 
-    _alloc_ENSEMBLE_EXPERIMENT = EnkfPrototype("run_arg_obj run_arg_alloc_ENSEMBLE_EXPERIMENT(char*, enkf_fs, int, int, char*)", bind = False)
+    _alloc_ENSEMBLE_EXPERIMENT = EnkfPrototype("run_arg_obj run_arg_alloc_ENSEMBLE_EXPERIMENT(char*, enkf_fs, int, int, char*, char*, subst_list)", bind = False)
     _free                      = EnkfPrototype("void run_arg_free(run_arg)")
     _get_queue_index           = EnkfPrototype("int  run_arg_get_queue_index(run_arg)")
     _is_submitted              = EnkfPrototype("bool run_arg_is_submitted(run_arg)")
@@ -32,8 +32,8 @@ class RunArg(BaseCClass):
         raise NotImplementedError("Cannot instantiat RunArg directly!")
 
     @classmethod
-    def createEnsembleExperimentRunArg(cls, run_id, fs, iens, runpath, iter=0):
-        return cls._alloc_ENSEMBLE_EXPERIMENT(run_id, fs, iens, iter, runpath)
+    def createEnsembleExperimentRunArg(cls, run_id, fs, iens, runpath, jobname, subst_list, iter=0):
+        return cls._alloc_ENSEMBLE_EXPERIMENT(run_id, fs, iens, iter, runpath, jobname, subst_list)
 
     def free(self):
         self._free()

--- a/python/python/res/enkf/subst_config.py
+++ b/python/python/res/enkf/subst_config.py
@@ -37,4 +37,4 @@ class SubstConfig(BaseCClass):
 
     @property
     def subst_list(self):
-        return self._get_subst_list()
+        return self._get_subst_list().setParent(self)

--- a/python/python/res/enkf/subst_config.py
+++ b/python/python/res/enkf/subst_config.py
@@ -34,3 +34,7 @@ class SubstConfig(BaseCClass):
     def __iter__(self):
         subst_list = self._get_subst_list( )
         return iter(subst_list)
+
+    @property
+    def subst_list(self):
+        return self._get_subst_list()

--- a/python/python/res/server/ertrpcserver.py
+++ b/python/python/res/server/ertrpcserver.py
@@ -181,10 +181,6 @@ class ErtRPCServer(SimpleXMLRPCServer):
                 self._session.batch_number += 1
 
 
-
-
-
-
     def addSimulation(self, geo_id, pert_id, iens, keywords):
         if not self.isRunning():
             raise createFault(UserWarning, "The server is not ready to receive simulations. Have you called startSimulationBatch() first?")
@@ -194,7 +190,7 @@ class ErtRPCServer(SimpleXMLRPCServer):
 
         sim_fs = self._session.simulation_context.get_sim_fs( )
         self._initializeRealization(sim_fs, geo_id, iens, keywords)
-        self.ert.createRunpath( self._session.simulation_context.get_run_context( ) , iens = iens)
+
         self._session.simulation_context.addSimulation(iens, geo_id)
 
 

--- a/python/python/res/server/simulation_context.py
+++ b/python/python/res/server/simulation_context.py
@@ -28,7 +28,7 @@ class SimulationContext(object):
         path_fmt = self._ert.getModelConfig().getRunpathFormat()
         jobname_fmt = self._ert.getModelConfig().getJobnameFormat()
         self._run_context = ErtRunContext( EnkfRunType.ENSEMBLE_EXPERIMENT, sim_fs, None, mask, path_fmt, jobname_fmt, subst_list, itr)
-        self._ert.createRunpath( self._run_context )
+        self._ert.initRun(self._run_context)
 
 
     def __len__(self):

--- a/python/python/res/server/simulation_context.py
+++ b/python/python/res/server/simulation_context.py
@@ -34,6 +34,7 @@ class SimulationContext(object):
     def __len__(self):
         return self._mask.count()
 
+
     def addSimulation(self, iens, geo_id):
         if not (0 <= iens < len(self._run_context)):
             raise UserWarning("Realization number out of range: %d >= %d" % (iens, len(self._run_context)))
@@ -45,9 +46,13 @@ class SimulationContext(object):
             raise UserWarning("Realization number: '%d' already queued" % iens)
 
         run_arg = self._run_context[iens]
-        queue = self._queue_manager.get_job_queue()
+        run_arg.geo_id = geo_id
         self._run_args[iens] = run_arg
-        self._thread_pool.submitJob(ArgPack(self._ert, run_arg, queue, geo_id))
+
+        self._ert.createRunpath(self._run_context, iens=iens)
+
+        queue = self._queue_manager.get_job_queue()
+        self._thread_pool.submitJob(ArgPack(self._ert, run_arg, queue))
 
 
     def isRunning(self):

--- a/python/python/res/simulator/batch_simulator.py
+++ b/python/python/res/simulator/batch_simulator.py
@@ -1,7 +1,6 @@
 from ecl.util import BoolVector
 
 from res.enkf import ResConfig, ErtRunContext, EnKFMain, EnkfConfigNode, EnkfNode, NodeId
-from res.server import SimulationContext
 from .batch_simulator_context import BatchContext
 
 class BatchSimulator(object):

--- a/python/python/res/util/substitution_list.py
+++ b/python/python/res/util/substitution_list.py
@@ -17,8 +17,12 @@ class SubstitutionList(BaseCClass):
 
 
     def __init__(self):
-        c_ptr = self._alloc(0)
-        super(SubstitutionList, self).__init__(c_ptr)
+        c_ptr = self._alloc(None)
+
+        if c_ptr:
+            super(SubstitutionList, self).__init__(c_ptr)
+        else:
+            raise ValueError('Failed to construct subst_list instance.')
 
     def __len__(self):
         return self._size()

--- a/python/tests/res/enkf/CMakeLists.txt
+++ b/python/tests/res/enkf/CMakeLists.txt
@@ -46,6 +46,7 @@ set(TEST_SOURCES
     test_res_config.py
     test_log_config.py
     test_run_context.py
+    test_runpath_list_dump.py
     test_data_kw_define.py
     test_programmatic_res_config.py
 )
@@ -81,6 +82,7 @@ addPythonTest(tests.res.enkf.test_field_config.FieldConfigTest)
 addPythonTest(tests.res.enkf.test_queue_config.QueueConfigTest)
 addPythonTest(tests.res.enkf.test_log_config.LogConfigTest)
 addPythonTest(tests.res.enkf.test_run_context.ErtRunContextTest)
+addPythonTest(tests.res.enkf.test_runpath_list_dump.RunpathListDumpTest)
 addPythonTest(tests.res.enkf.test_enkf_runpath.EnKFRunpathTest)
 addPythonTest(tests.res.enkf.test_programmatic_res_config.ProgrammaticResConfigTest)
 addPythonTest(tests.res.enkf.test_enkf.EnKFTest)

--- a/python/tests/res/enkf/data/test_gen_data_config.py
+++ b/python/tests/res/enkf/data/test_gen_data_config.py
@@ -12,7 +12,6 @@ from res.enkf import ForwardLoadContext
 class GenDataConfigTest(ExtendedTestCase):
     _get_active_mask    = EnkfPrototype("bool_vector_ref gen_data_config_get_active_mask( gen_data_config )", bind = False)
     _update_active_mask = EnkfPrototype("void gen_data_config_update_active( gen_data_config, forward_load_context , bool_vector)", bind = False)
-    _alloc_run_arg      = EnkfPrototype("run_arg_obj run_arg_alloc_ENSEMBLE_EXPERIMENT( char*, enkf_fs , int , int , char*) ", bind = False)
 
     def setUp(self):
         self.config_file = self.createTestPath("Statoil/config/with_GEN_DATA/config")
@@ -20,6 +19,7 @@ class GenDataConfigTest(ExtendedTestCase):
     def load_active_masks(self, case1, case2 ):
         with ErtTestContext("gen_data_config_test", self.config_file) as test_context:
             ert = test_context.getErt()
+            subst_list = ert.resConfig().subst_config.subst_list
 
             fs1 =  ert.getEnkfFsManager().getFileSystem(case1)
             config_node = ert.ensembleConfig().getNode("TIMESHIFT")
@@ -44,7 +44,7 @@ class GenDataConfigTest(ExtendedTestCase):
             active_mask_modified = active_mask.copy()
             active_mask_modified[10] = False
 
-            self.updateMask(config_node.getDataModelConfig(),  60, fs2 , active_mask_modified)
+            self.updateMask(config_node.getDataModelConfig(),  60, fs2 , active_mask_modified, subst_list)
             active_mask = self._get_active_mask( config_node.getDataModelConfig() )
             self.assertFalse(active_mask[10])
 
@@ -69,7 +69,7 @@ class GenDataConfigTest(ExtendedTestCase):
     def test_create(self):
         conf = GenDataConfig("KEY")
 
-    def updateMask(self, gen_data_config , report_step , fs, active_mask):
-        run_arg = RunArg.createEnsembleExperimentRunArg("run_id", fs , 0, "Path")
+    def updateMask(self, gen_data_config , report_step , fs, active_mask, subst_list):
+        run_arg = RunArg.createEnsembleExperimentRunArg("run_id", fs , 0, "Path", "jobname", subst_list)
         load_context = ForwardLoadContext( run_arg = run_arg , report_step = report_step )
         self._update_active_mask( gen_data_config , load_context , active_mask )

--- a/python/tests/res/enkf/test_runpath_list_dump.py
+++ b/python/tests/res/enkf/test_runpath_list_dump.py
@@ -1,0 +1,105 @@
+import unittest, os
+
+from ecl.test import ExtendedTestCase, TestAreaContext
+from res.test import ErtTestContext
+
+from ecl.util import BoolVector, PathFormat
+
+from res.enkf import ResConfig, EnKFMain, EnkfFs, ErtRunContext
+from res.enkf.enums import EnKFFSType, EnkfRunType
+
+class RunpathListDumpTest(ExtendedTestCase):
+
+    def setUp(self):
+        self.config_rel_path = "local/snake_oil_no_data/snake_oil_GEO_ID.ert"
+        self.config_path = self.createTestPath(self.config_rel_path)
+
+    def test_add_all(self):
+        with ErtTestContext("add_all_runpath_dump", model_config=self.config_path) as ctx:
+            res = ctx.getErt()
+            fs_manager = res.getEnkfFsManager()
+            sim_fs = fs_manager.getFileSystem("sim_fs")
+
+            num_realizations = 25
+            mask = BoolVector(initial_size=num_realizations, default_value=True)
+            mask[13] = False
+
+            runpath_fmt = "simulations/<GEO_ID>/realisation-%d/iter-%d"
+            jobname_fmt = "SNAKE_OIL_%d"
+
+            itr = 0
+            subst_list = res.resConfig().subst_config.subst_list
+            run_context = ErtRunContext.ensemble_experiment(sim_fs, mask, PathFormat(runpath_fmt), jobname_fmt, subst_list, itr)
+
+            res.initRun(run_context)
+
+            for i, run_arg in enumerate(run_context):
+                if mask[i]:
+                    run_arg.geo_id = 10*i
+
+            res.createRunpath(run_context)
+
+            for i, run_arg in enumerate(run_context):
+                if not mask[i]:
+                    continue
+
+                self.assertTrue(os.path.isdir("simulations/%d" % run_arg.geo_id))
+
+            runpath_list_path = ".ert_runpath_list"
+            self.assertTrue(os.path.isfile(runpath_list_path))
+
+            exp_runpaths = [
+                             runpath_fmt.replace("<GEO_ID>", str(run_arg.geo_id)) % (iens, itr)
+                             for iens, run_arg in enumerate(run_context) if mask[iens]
+                           ]
+            exp_runpaths = map(os.path.realpath, exp_runpaths)
+
+            with open(runpath_list_path, 'r') as f:
+                dumped_runpaths = zip(*[line.split() for line in f.readlines()])[1]
+
+            self.assertEqual(list(exp_runpaths), list(dumped_runpaths))
+
+
+    def test_add_one_by_one(self):
+        with ErtTestContext("add_one_by_one_runpath_dump", model_config=self.config_path) as ctx:
+            res = ctx.getErt()
+            fs_manager = res.getEnkfFsManager()
+            sim_fs = fs_manager.getFileSystem("sim_fs")
+
+            num_realizations = 25
+            mask = BoolVector(initial_size=num_realizations, default_value=True)
+            mask[13] = False
+
+            runpath_fmt = "simulations/<GEO_ID>/realisation-%d/iter-%d"
+            jobname_fmt = "SNAKE_OIL_%d"
+
+            itr = 0
+            subst_list = res.resConfig().subst_config.subst_list
+            run_context = ErtRunContext.ensemble_experiment(sim_fs, mask, PathFormat(runpath_fmt), jobname_fmt, subst_list, itr)
+
+            res.initRun(run_context)
+
+            for i, run_arg in enumerate(run_context):
+                if mask[i]:
+                    run_arg.geo_id = 10*i
+                    res.createRunpath(run_context, i)
+
+            for i, run_arg in enumerate(run_context):
+                if not mask[i]:
+                    continue
+
+                self.assertTrue(os.path.isdir("simulations/%d" % run_arg.geo_id))
+
+            runpath_list_path = ".ert_runpath_list"
+            self.assertTrue(os.path.isfile(runpath_list_path))
+
+            exp_runpaths = [
+                             runpath_fmt.replace("<GEO_ID>", str(run_arg.geo_id)) % (iens, itr)
+                             for iens, run_arg in enumerate(run_context) if mask[iens]
+                           ]
+            exp_runpaths = map(os.path.realpath, exp_runpaths)
+
+            with open(runpath_list_path, 'r') as f:
+                dumped_runpaths = zip(*[line.split() for line in f.readlines()])[1]
+
+            self.assertEqual(list(exp_runpaths), list(dumped_runpaths))

--- a/python/tests/res/server/test_rpc_service.py
+++ b/python/tests/res/server/test_rpc_service.py
@@ -177,7 +177,8 @@ class RPCServiceTest(ExtendedTestCase):
                 server.addSimulation(geo_id, 0, 0, keywords)
 
                 resolved_path = runpath_root_fmt % geo_id
-                self.assertTrue(os.path.isdir(resolved_path))
+                self.assertTrue(os.path.isdir(resolved_path),
+                                "Runpath '%s/..' not created" % resolved_path)
 
                 # TODO: This fails currently due to runpath creation both by
                 # init of simulation_context and when adding simulation to the

--- a/python/tests/res/server/test_rpc_service.py
+++ b/python/tests/res/server/test_rpc_service.py
@@ -160,3 +160,27 @@ class RPCServiceTest(ExtendedTestCase):
                 thread.join()
 
             self.assertTrue(all(success for success in thread_success_state.values()))
+
+
+    def test_runtime_geoid(self):
+        config_rel_path = "local/snake_oil_no_data/snake_oil_GEO_ID.ert"
+        geoid_config_path = self.createTestPath(config_rel_path)
+
+        runpath_root_fmt = "simulations/%s"
+        for geo_id in range(3):
+            with RPCServiceContext("ert/server/rpc/geoid", geoid_config_path, store_area=True) as server:
+                server.startSimulationBatch("testing_geoid_%d" % geo_id,
+                                            "results_geoid_%d" % geo_id,
+                                            1)
+
+                keywords = {"SNAKE_OIL_PARAM" : 10*[0.5]}
+                server.addSimulation(geo_id, 0, 0, keywords)
+
+                resolved_path = runpath_root_fmt % geo_id
+                self.assertTrue(os.path.isdir(resolved_path))
+
+                # TODO: This fails currently due to runpath creation both by
+                # init of simulation_context and when adding simulation to the
+                # ertrpcserver. Its the first one that is problematic
+                #unresolved_path = runpath_root_fmt % '<GEO_ID>'
+                #self.assertFalse(os.path.isdir(unresolved_path))


### PR DESCRIPTION
**Task**
_Using `<GEO_ID>` in job arguments or the runpath fails due to setting `run_arg->geo_id` too late after f234eea807d5681cd20337553cdc96ff5f0d693b._


**Approach**
This PR does two things:
 - Set the `geo_id` immediately when adding a simulation and hence recognize the stated relation between the given `iens` and `geo_id` as early as possible.
- Let `run_arg` have responsibility for a substitution lists that contains all keys relevant for that specific run. Use this one consistently when initializing the runpath.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps
