### PR TITLE
Automatically redirect stderr and stdout

### DIFF
--- a/libjob_queue/src/ext_job.c
+++ b/libjob_queue/src/ext_job.c
@@ -809,21 +809,20 @@ void ext_job_fprintf_config(const ext_job_type * ext_job , const char * fmt , FI
 }
 
 
-static void ext_job_set_default_stdout_file(ext_job_type * ext_job) {
-
-  char * new_std_file = util_malloc(strlen(ext_job->name) + 8);
+static char * ext_job_alloc_std_filename(ext_job_type * ext_job, char * filetype) {
+  char * new_std_file = util_malloc(strlen(ext_job->name) + strlen(filetype) + 2);
   strcpy(new_std_file, ext_job->name);
-  strcat(new_std_file, ".stdout");
-  ext_job->stdout_file = new_std_file;
+  strcat(new_std_file, ".");
+  strcat(new_std_file, filetype);
+  return new_std_file;
+}
+
+static void ext_job_set_default_stdout_file(ext_job_type * ext_job) {
+  ext_job->stdout_file = ext_job_alloc_std_filename(ext_job, EXT_JOB_STDOUT);
 }
 
 static void ext_job_set_default_stderr_file(ext_job_type * ext_job) {
-
-  char * new_std_file = util_malloc(strlen(ext_job->name) + 8);
-  strcpy(new_std_file, ext_job->name);
-  strcat(new_std_file, ".stdout");
-  strcat(new_std_file, EXT_JOB_STDERR);
-  ext_job->stderr_file = new_std_file;
+  ext_job->stderr_file = ext_job_alloc_std_filename(ext_job, EXT_JOB_STDERR);
 }
 
 
@@ -863,14 +862,12 @@ ext_job_type * ext_job_fscanf_alloc(const char * name , const char * license_roo
 
 
         if (config_content_has_item(content , "STDIN"))                 ext_job_set_stdin_file(ext_job       , config_content_iget(content  , "STDIN" , 0,0));
-        if (config_content_has_item(content , "STDOUT"))                
-             ext_job_set_stdout_file(ext_job , config_content_iget(content  , "STDOUT" , 0,0));
-        else {
-             
-             ext_job_set_default_stdout_file(ext_job);
-        }
+        if (config_content_has_item(content , "STDOUT"))                ext_job_set_stdout_file(ext_job , config_content_iget(content  , "STDOUT" , 0,0));
+           else                                                         ext_job_set_default_stdout_file(ext_job);
 
         if (config_content_has_item(content , "STDERR"))                ext_job_set_stderr_file(ext_job      , config_content_iget(content  , "STDERR" , 0,0));
+           else                                                         ext_job_set_default_stderr_file(ext_job);
+
         if (config_content_has_item(content , "ERROR_FILE"))            ext_job_set_error_file(ext_job       , config_content_iget(content  , "ERROR_FILE" , 0,0));
         if (config_content_has_item(content , "TARGET_FILE"))           ext_job_set_target_file(ext_job      , config_content_iget(content  , "TARGET_FILE" , 0,0));
         if (config_content_has_item(content , "START_FILE"))            ext_job_set_start_file(ext_job       , config_content_iget(content  , "START_FILE" , 0,0));

--- a/libjob_queue/src/ext_job.c
+++ b/libjob_queue/src/ext_job.c
@@ -523,7 +523,7 @@ const char * ext_job_get_stdin_file(const ext_job_type * ext_job) {
 }
 
 void ext_job_set_stdout_file(ext_job_type * ext_job, const char * stdout_file) {
-  if (strcmp(stdout_file, EXT_JOB_NO_STD_FILE) != 0)
+  if (!util_string_equal(stdout_file, EXT_JOB_NO_STD_FILE))
     ext_job->stdout_file = util_realloc_string_copy(ext_job->stdout_file , stdout_file);
 }
 
@@ -809,24 +809,6 @@ void ext_job_fprintf_config(const ext_job_type * ext_job , const char * fmt , FI
 }
 
 
-static char * ext_job_alloc_std_filename(ext_job_type * ext_job, const char * filetype) {
-  char * new_std_file = util_malloc(strlen(ext_job->name) + strlen(filetype) + 2);
-  strcpy(new_std_file, ext_job->name);
-  strcat(new_std_file, ".");
-  strcat(new_std_file, filetype);
-  return new_std_file;
-}
-
-static void ext_job_set_default_stdout_file(ext_job_type * ext_job) {
-  ext_job->stdout_file = ext_job_alloc_std_filename(ext_job, EXT_JOB_STDOUT);
-}
-
-static void ext_job_set_default_stderr_file(ext_job_type * ext_job) {
-  ext_job->stderr_file = ext_job_alloc_std_filename(ext_job, EXT_JOB_STDERR);
-}
-
-
-
 ext_job_type * ext_job_fscanf_alloc(const char * name , const char * license_root_path , bool private_job , const char * config_file, bool search_path) {
   {
     mode_t target_mode = S_IRUSR + S_IWUSR + S_IRGRP + S_IWGRP + S_IROTH;  /* u+rw  g+rw  o+r */
@@ -863,10 +845,10 @@ ext_job_type * ext_job_fscanf_alloc(const char * name , const char * license_roo
 
         if (config_content_has_item(content , "STDIN"))                 ext_job_set_stdin_file(ext_job       , config_content_iget(content  , "STDIN" , 0,0));
         if (config_content_has_item(content , "STDOUT"))                ext_job_set_stdout_file(ext_job , config_content_iget(content  , "STDOUT" , 0,0));
-           else                                                         ext_job_set_default_stdout_file(ext_job);
+           else                                                         ext_job->stdout_file = util_alloc_filename( NULL, ext_job->name, EXT_JOB_STDOUT);
 
         if (config_content_has_item(content , "STDERR"))                ext_job_set_stderr_file(ext_job      , config_content_iget(content  , "STDERR" , 0,0));
-           else                                                         ext_job_set_default_stderr_file(ext_job);
+           else                                                         ext_job->stderr_file = util_alloc_filename( NULL, ext_job->name, EXT_JOB_STDERR);
 
         if (config_content_has_item(content , "ERROR_FILE"))            ext_job_set_error_file(ext_job       , config_content_iget(content  , "ERROR_FILE" , 0,0));
         if (config_content_has_item(content , "TARGET_FILE"))           ext_job_set_target_file(ext_job      , config_content_iget(content  , "TARGET_FILE" , 0,0));

--- a/libjob_queue/src/ext_job.c
+++ b/libjob_queue/src/ext_job.c
@@ -696,26 +696,6 @@ static void __fprintf_python_argList(FILE * stream,
   fprintf(stream, "%s", suffix);
 }
 
-void ext_job_python_fprintf(const ext_job_type * ext_job, FILE * stream, const subst_list_type * global_args) {
-  const char * null_value = "None";
-  fprintf(stream," {");
-  {
-    __fprintf_python_string(  stream, "",   "name",                ext_job->name,                ",\n", ext_job->private_args, NULL,        null_value);
-    __fprintf_python_string(  stream, "  ", "executable",          ext_job->executable,          ",\n", ext_job->private_args, global_args, null_value);
-    __fprintf_python_string(  stream, "  ", "target_file",         ext_job->target_file,         ",\n", ext_job->private_args, global_args, null_value);
-    __fprintf_python_string(  stream, "  ", "error_file",          ext_job->error_file,          ",\n", ext_job->private_args, global_args, null_value);
-    __fprintf_python_string(  stream, "  ", "start_file",          ext_job->start_file,          ",\n", ext_job->private_args, global_args, null_value);
-    __fprintf_python_string(  stream, "  ", "stdout",              ext_job->stdout_file,         ",\n", ext_job->private_args, global_args, null_value);
-    __fprintf_python_string(  stream, "  ", "stderr",              ext_job->stderr_file,         ",\n", ext_job->private_args, global_args, null_value);
-    __fprintf_python_string(  stream, "  ", "stdin",               ext_job->stdin_file,          ",\n", ext_job->private_args, global_args, null_value);
-    __fprintf_python_argList( stream, "  ",                        ext_job,                      ",\n",                        global_args            );
-    __fprintf_python_hash(    stream, "  ", "environment",         ext_job->environment,         ",\n", ext_job->private_args, global_args, null_value);
-    __fprintf_python_string(  stream, "  ", "license_path",        ext_job->license_path,        ",\n", ext_job->private_args, global_args, null_value);
-    __fprintf_python_int(     stream, "  ", "max_running_minutes", ext_job->max_running_minutes, ",\n",                                     null_value);
-    __fprintf_python_int(     stream, "  ", "max_running",         ext_job->max_running,         ",\n",                                     null_value);
-  }
-  fprintf(stream,"}");
-}
 
 void ext_job_json_fprintf(const ext_job_type * ext_job, FILE * stream, const subst_list_type * global_args) {
   const char * null_value = "null";

--- a/libjob_queue/src/ext_job.c
+++ b/libjob_queue/src/ext_job.c
@@ -98,6 +98,9 @@ jobList = [
 
 #define EXT_JOB_TYPE_ID 763012
 
+#define EXT_JOB_STDOUT "stdout"
+#define EXT_JOB_STDERR "stderr"
+
 
 struct ext_job_struct {
   UTIL_TYPE_ID_DECLARATION;
@@ -708,6 +711,15 @@ void ext_job_json_fprintf(const ext_job_type * ext_job, FILE * stream, const sub
     __fprintf_python_string(  stream, "  ", "start_file",          ext_job->start_file,          ",\n", ext_job->private_args, global_args, null_value);
     __fprintf_python_string(  stream, "  ", "stdout",              ext_job->stdout_file,         ",\n", ext_job->private_args, global_args, null_value);
     __fprintf_python_string(  stream, "  ", "stderr",              ext_job->stderr_file,         ",\n", ext_job->private_args, global_args, null_value);
+    /*if (ext_job->stderr_file)
+      __fprintf_python_string(  stream, "  ", "stderr",            ext_job->stderr_file,              ",\n", ext_job->private_args, global_args, null_value);
+    else {
+      char stderr_filename[strlen(ext_job->name) + 7];
+      strcpy(stderr_filename, "");
+      strcat(stderr_filename, ext_job->name);
+      strcat(stderr_filename, ".stderr");
+      __fprintf_python_string(  stream, "  ", "stderr",              stderr_filename,              ",\n", ext_job->private_args, global_args, null_value);
+    }*/
     __fprintf_python_string(  stream, "  ", "stdin",               ext_job->stdin_file,          ",\n", ext_job->private_args, global_args, null_value);
     __fprintf_python_argList( stream, "  ",                        ext_job,                      ",\n",                        global_args            );
     __fprintf_python_hash(    stream, "  ", "environment",         ext_job->environment,         ",\n", ext_job->private_args, global_args, null_value);
@@ -797,7 +809,22 @@ void ext_job_fprintf_config(const ext_job_type * ext_job , const char * fmt , FI
 }
 
 
+static void ext_job_set_default_stdout_file(ext_job_type * ext_job) {
 
+  char * new_std_file = util_malloc(strlen(ext_job->name) + 8);
+  strcpy(new_std_file, ext_job->name);
+  strcat(new_std_file, ".stdout");
+  ext_job->stdout_file = new_std_file;
+}
+
+static void ext_job_set_default_stderr_file(ext_job_type * ext_job) {
+
+  char * new_std_file = util_malloc(strlen(ext_job->name) + 8);
+  strcpy(new_std_file, ext_job->name);
+  strcat(new_std_file, ".stdout");
+  strcat(new_std_file, EXT_JOB_STDERR);
+  ext_job->stderr_file = new_std_file;
+}
 
 
 
@@ -836,7 +863,13 @@ ext_job_type * ext_job_fscanf_alloc(const char * name , const char * license_roo
 
 
         if (config_content_has_item(content , "STDIN"))                 ext_job_set_stdin_file(ext_job       , config_content_iget(content  , "STDIN" , 0,0));
-        if (config_content_has_item(content , "STDOUT"))                ext_job_set_stdout_file(ext_job      , config_content_iget(content  , "STDOUT" , 0,0));
+        if (config_content_has_item(content , "STDOUT"))                
+             ext_job_set_stdout_file(ext_job , config_content_iget(content  , "STDOUT" , 0,0));
+        else {
+             
+             ext_job_set_default_stdout_file(ext_job);
+        }
+
         if (config_content_has_item(content , "STDERR"))                ext_job_set_stderr_file(ext_job      , config_content_iget(content  , "STDERR" , 0,0));
         if (config_content_has_item(content , "ERROR_FILE"))            ext_job_set_error_file(ext_job       , config_content_iget(content  , "ERROR_FILE" , 0,0));
         if (config_content_has_item(content , "TARGET_FILE"))           ext_job_set_target_file(ext_job      , config_content_iget(content  , "TARGET_FILE" , 0,0));

--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -232,10 +232,12 @@ class JobManager(object):
         for index, job in enumerate(self.job_list):
             self._job_map[job["name"]] = job
             if "stderr" in job:
-                job["stderr"] = "%s.%d" % (job["stderr"], index)
+                if job["stderr"]:
+                   job["stderr"] = "%s.%d" % (job["stderr"], index)
 
             if "stdout" in job:
-                job["stdout"] = "%s.%d" % (job["stdout"], index)
+                if job["stdout"]:
+                   job["stdout"] = "%s.%d" % (job["stdout"], index)
 
     def __contains__(self, key):
         return key in self._job_map

--- a/python/tests/res/job_queue/test_ext_job.py
+++ b/python/tests/res/job_queue/test_ext_job.py
@@ -6,6 +6,8 @@ from res.job_queue.ext_job import ExtJob
 
 def create_valid_config( config_file ):
     with open(config_file , "w") as f:
+        f.write("STDOUT null\n")
+        f.write("STDERR null\n")
         f.write("EXECUTABLE script.sh\n")
 
     with open("script.sh" , "w") as f:
@@ -43,8 +45,8 @@ class ExtJobTest(ExtendedTestCase):
             create_valid_config("CONFIG")
             job = ExtJob("CONFIG" , True)
             self.assertEqual( job.name() , "CONFIG")
-            self.assertEqual( job.get_stdout_file(), job.name() + ".stdout")
-            self.assertEqual( job.get_stderr_file(), job.name() + ".stderr")
+            self.assertEqual( job.get_stdout_file(), None)
+            self.assertEqual( job.get_stderr_file(), None)
 
             self.assertEqual( job.get_executable() , os.path.join( os.getcwd() , "script.sh"))
             self.assertTrue( os.access( job.get_executable() , os.X_OK ))

--- a/python/tests/res/job_queue/test_ext_job.py
+++ b/python/tests/res/job_queue/test_ext_job.py
@@ -43,6 +43,8 @@ class ExtJobTest(ExtendedTestCase):
             create_valid_config("CONFIG")
             job = ExtJob("CONFIG" , True)
             self.assertEqual( job.name() , "CONFIG")
+            self.assertEqual( job.get_stdout_file(), job.name() + ".stdout")
+            #self.assertEqual( job.get_stderr_file(), job.name() + ".stderr")
 
             self.assertEqual( job.get_executable() , os.path.join( os.getcwd() , "script.sh"))
             self.assertTrue( os.access( job.get_executable() , os.X_OK ))

--- a/python/tests/res/job_queue/test_ext_job.py
+++ b/python/tests/res/job_queue/test_ext_job.py
@@ -44,7 +44,7 @@ class ExtJobTest(ExtendedTestCase):
             job = ExtJob("CONFIG" , True)
             self.assertEqual( job.name() , "CONFIG")
             self.assertEqual( job.get_stdout_file(), job.name() + ".stdout")
-            #self.assertEqual( job.get_stderr_file(), job.name() + ".stderr")
+            self.assertEqual( job.get_stderr_file(), job.name() + ".stderr")
 
             self.assertEqual( job.get_executable() , os.path.join( os.getcwd() , "script.sh"))
             self.assertTrue( os.access( job.get_executable() , os.X_OK ))

--- a/python/tests/res/job_queue/test_forward_model_formatted_print.py
+++ b/python/tests/res/job_queue/test_forward_model_formatted_print.py
@@ -191,6 +191,21 @@ def load_configs(config_file):
 
     return jobs
 
+
+def create_stdout_file(config):
+    if config["stdout"]:
+        return config["stdout"]
+    else:
+        return (config["name"] + ".stdout")
+
+
+def create_stderr_file(config):
+    if config["stderr"]:
+        return config["stderr"]
+    else:
+        return (config["name"] + ".stderr")
+
+
 class ForwardModelFormattedPrintTest(ExtendedTestCase):
 
     JOBS_JSON_FILE = "jobs.json"
@@ -230,11 +245,11 @@ class ForwardModelFormattedPrintTest(ExtendedTestCase):
                 )
         self.assertEqual(
                 ext_job.get_stdout_file(),
-                ext_job_config["stdout"]
+                create_stdout_file(ext_job_config)
                 )
         self.assertEqual(
                 ext_job.get_stderr_file(),
-                ext_job_config["stderr"]
+                create_stderr_file(ext_job_config)
                 )
         self.assertEqual(
                 ext_job.get_stdin_file(),
@@ -331,7 +346,12 @@ class ForwardModelFormattedPrintTest(ExtendedTestCase):
             job["name"] = default_name_if_none(job["name"])
 
             for key in json_keywords:
-                self.assertEqual(job[key], loaded_job[key])
+                if (key == "stdout"):
+                  self.assertEqual(create_stdout_file(job), loaded_job[key])
+                elif (key == "stderr"):
+                  self.assertEqual(create_stderr_file(job), loaded_job[key])
+                else:
+                  self.assertEqual(job[key], loaded_job[key])
 
             job["argList"] = arg_list_back_up
             job["name"] = name_back_up


### PR DESCRIPTION
**Task**
ERT-1456: Automatically redirect stderr and stdout
In forward_model config file:
STDOUT/STDERR filename, directs output to filename
STDOUT/STDERR null, prints output on screeen
no STDOUT/STDERR kw, directs output to JOB_NAME.stdout/stderr.x

**Approach**
When allocating ext_job_type, if no STDOUT/STDERR kw is found, 
ext_job->stdout/stderr = name.stdout/stderr
if STDOUT/STDERR is "null"
ext_job->stdout/stderr = null
This affects how jobs.json is written. jobs.json is again used by jobmanager set output direction. 
In case stdout/stderr = null, jobmanager does not direct output to file, but screen.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

