### PR TITLE
Conservatively consult PATH

### DIFF
--- a/libconfig/src/config_content_node.c
+++ b/libconfig/src/config_content_node.c
@@ -203,7 +203,6 @@ const char * config_content_node_iget_as_executable( config_content_node_type * 
     }
 
     config_content_node_push_string( node , path_value );
-    printf( "%s ===> %s\n", config_value, path_value );
     return path_value;
   }
 }


### PR DESCRIPTION
The PATH consultation aborts whenever it constructs a path with a
non-existant directory, and should be consulted more conservatively. To
accomplish that, the alloc_relocate helper function returns absolute
paths, not relative, as they quickly contain to many back-references to
form a completely valid path.

The POSIX stat function considers ../../../usr/bin an invalid path,
where the shells resolve it to /usr/bin

**Task**
_Short description of the task_


**Approach**
_Short description of the approach_


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
