### PR TITLE
Set run id env

### DIFF
--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -177,7 +177,7 @@ class JobManager(object):
         self.update_path()
         self.information = logged_fields
 
-        
+
     def set_environment(self):
          if self.global_environment:
            data = self.global_environment
@@ -192,7 +192,7 @@ class JobManager(object):
                   os.environ[key] = data[key] + ':' + os.environ[key]
                else:
                   os.environ[key] = data[key]
-             
+
 
     def data_root(self):
         return self._data_root

--- a/python/python/res/job_queue/job_manager.py
+++ b/python/python/res/job_queue/job_manager.py
@@ -210,6 +210,7 @@ class JobManager(object):
         os.umask(int(umask, 8))
         if "run_id" in jobs_data:
             self.simulation_id = _jsonGet(jobs_data, "run_id")
+            os.environ["ERT_RUN_ID"] = self.simulation_id
         if "ert_pid" in jobs_data:
             self.ert_pid = _jsonGet(jobs_data, "ert_pid")
         if "global_environment" in jobs_data:

--- a/python/tests/res/job_queue/test_jobmanager.py
+++ b/python/tests/res/job_queue/test_jobmanager.py
@@ -375,19 +375,6 @@ class JobManagerTest(TestCase):
             self.assertNotIn( "ERT_RUN_ID", os.environ )
 
 
-    def test_blacklist(self):
-        with TestAreaContext("file_server"):
-            with open("jobs.json", "w") as f:
-                f.write(JSON_STRING)
-
-            jobm = JobManager()
-            #  TODO FILE_SERVER_BLACKLIST is moved to job_dispatch
-            # jobm.file_server = JobManager.FILE_SERVER_BLACKLIST[0]
-            # jobm.checkFileServerBlackList()
-            # self.assertTrue(os.path.isfile(""WARNING-ILLEGAL-FILESERVER.txt"))
-
-            # TODO REMOVED test_load FROM jobmanager test!  Should be in ert-statoil
-
 
     def test_get_env(self):
         with TestAreaContext("job_manager_get_env"):

--- a/python/tests/res/job_queue/test_jobmanager.py
+++ b/python/tests/res/job_queue/test_jobmanager.py
@@ -13,6 +13,7 @@ from res.job_queue import JobManager
 JSON_STRING = """
 {
   "DATA_ROOT" : "/path/to/data",
+  "run_id"    : "ERT_RUN_ID",
   "umask" : "0000",
   "jobList" : [ {"name" : "PERLIN",
   "executable" : "perlin.py",
@@ -361,6 +362,7 @@ class JobManagerTest(TestCase):
             self.assertEquals("PERLIN", jobm[0]["name"])
             self.assertEqual( "/path/to/data" , jobm.data_root( ))
             self.assertEqual( "/path/to/data" , os.environ["DATA_ROOT"])
+            self.assertEqual( "ERT_RUN_ID", os.environ["ERT_RUN_ID"])
 
     def test_data_from_forward_model_json(self):
         with TestAreaContext("json_from_forward_model_NO_DATA_ROOT"):
@@ -370,6 +372,7 @@ class JobManagerTest(TestCase):
             jobm = JobManager()
             self.assertIsNone( jobm.data_root( ))
             self.assertNotIn( "DATA_ROOT" , os.environ )
+            self.assertNotIn( "ERT_RUN_ID", os.environ )
 
 
     def test_blacklist(self):
@@ -418,5 +421,3 @@ class JobManagerTest(TestCase):
             self.assertEqual(exit_status, 0)
             exit_status, msg = jobm.runJob(jobm[1])
             self.assertEqual(exit_status, 0)
-
-


### PR DESCRIPTION
**Task**
Set environment variable `ERT_RUN_ID` for forward model jobs to pick up - if they are interested.

