### PR TITLE
Added stop method to SimualtionContext

### DIFF
--- a/libjob_queue/include/ert/job_queue/job_queue_manager.h
+++ b/libjob_queue/include/ert/job_queue/job_queue_manager.h
@@ -31,6 +31,7 @@ typedef struct job_queue_manager_struct job_queue_manager_type;
   job_queue_manager_type * job_queue_manager_alloc( job_queue_type * job_queue );
   void job_queue_manager_free( job_queue_manager_type * manager );
   void job_queue_manager_start_queue( job_queue_manager_type * manager , int num_total_run , bool verbose);
+  void job_queue_manager_stop_queue(const job_queue_manager_type * manager);
   bool job_queue_manager_try_wait( job_queue_manager_type * manager , int timeout_seconds);
   void job_queue_manager_wait( job_queue_manager_type * manager);
   int  job_queue_manager_get_num_running( const job_queue_manager_type * manager);

--- a/libjob_queue/src/job_queue_manager.c
+++ b/libjob_queue/src/job_queue_manager.c
@@ -183,3 +183,10 @@ job_status_type job_queue_manager_iget_job_status(const job_queue_manager_type *
     return job_queue_iget_job_status(manager->job_queue, job_index);
 }
 
+
+void job_queue_manager_stop_queue(const job_queue_manager_type * manager) {
+  job_queue_start_user_exit(manager->job_queue);
+
+  while(job_queue_is_running(manager->job_queue))
+    usleep(100000);
+}

--- a/python/python/res/job_queue/job_queue_manager.py
+++ b/python/python/res/job_queue/job_queue_manager.py
@@ -25,6 +25,7 @@ class JobQueueManager(BaseCClass):
     _alloc           = QueuePrototype("void* job_queue_manager_alloc( job_queue)", bind = False)
     _free            = QueuePrototype("void job_queue_manager_free( job_queue_manager )")
     _start_queue     = QueuePrototype("void job_queue_manager_start_queue( job_queue_manager , int , bool)")
+    _stop_queue      = QueuePrototype("void job_queue_manager_stop_queue(job_queue_manager)")
     _get_num_waiting = QueuePrototype("int job_queue_manager_get_num_waiting( job_queue_manager )")
     _get_num_pending = QueuePrototype("int job_queue_manager_get_num_pending( job_queue_manager )")
     _get_num_running = QueuePrototype("int job_queue_manager_get_num_running( job_queue_manager )")
@@ -54,6 +55,9 @@ class JobQueueManager(BaseCClass):
 
     def get_job_queue(self):
         return self.queue
+
+    def stop_queue(self):
+        self._stop_queue( )
 
     def startQueue(self , total_size , verbose = False ):
         self._start_queue( total_size , verbose )

--- a/python/python/res/job_queue/job_queue_manager.py
+++ b/python/python/res/job_queue/job_queue_manager.py
@@ -1,18 +1,18 @@
-#  Copyright (C) 2014  Statoil ASA, Norway. 
-#   
-#  The file 'job_queue_manager.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-#  for more details. 
+#  Copyright (C) 2014  Statoil ASA, Norway.
+#
+#  The file 'job_queue_manager.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
 """
 Module implementing a queue for managing external jobs.
 
@@ -33,12 +33,12 @@ class JobQueueManager(BaseCClass):
     _is_running      = QueuePrototype("bool job_queue_manager_is_running( job_queue_manager )")
     _job_complete    = QueuePrototype("bool job_queue_manager_job_complete( job_queue_manager , int)")
     _job_running     = QueuePrototype("bool job_queue_manager_job_running( job_queue_manager , int)")
-    
-    # Note, even if all realizations have finished, they need not all be failed or successes. 
+
+    # Note, even if all realizations have finished, they need not all be failed or successes.
     # That is how Ert report things. They can be "killed", which is neither success nor failure.
-    _job_failed      = QueuePrototype("bool job_queue_manager_job_failed( job_queue_manager , int)") 
+    _job_failed      = QueuePrototype("bool job_queue_manager_job_failed( job_queue_manager , int)")
     _job_waiting     = QueuePrototype("bool job_queue_manager_job_waiting( job_queue_manager , int)")
-    _job_success     = QueuePrototype("bool job_queue_manager_job_success( job_queue_manager , int)") 
+    _job_success     = QueuePrototype("bool job_queue_manager_job_success( job_queue_manager , int)")
 
     # The return type of the job_queue_manager_iget_job_status should
     # really be the enum job_status_type_enum, but I just did not
@@ -73,7 +73,7 @@ class JobQueueManager(BaseCClass):
 
     def getNumFailed(self):
         return self._get_num_failed(  )
-    
+
     def isRunning(self):
         return self._is_running( )
 
@@ -101,7 +101,7 @@ class JobQueueManager(BaseCClass):
         """ @rtype: res.job_queue.job_status_type_enum.JobStatusType """
         int_status = self._job_status(job_index)
         return JobStatusType( int_status )
-        
+
 
     def __repr__(self):
         nw = self._get_num_waiting()

--- a/python/python/res/job_queue/queue.py
+++ b/python/python/res/job_queue/queue.py
@@ -1,18 +1,18 @@
-#  Copyright (C) 2011  Statoil ASA, Norway. 
-#   
-#  The file 'job_queue.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-#  for more details. 
+#  Copyright (C) 2011  Statoil ASA, Norway.
+#
+#  The file 'job_queue.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
 """
 Module implementing a queue for managing external jobs.
 
@@ -56,7 +56,7 @@ class JobQueue(BaseCClass):
     _run_jobs             = QueuePrototype("void job_queue_run_jobs_threaded(job_queue , int , bool)")
     _sim_start            = QueuePrototype("time_t job_queue_iget_sim_start( job_queue , int)")
     _iget_driver_data     = QueuePrototype("void* job_queue_iget_driver_data( job_queue , int)")
-    
+
     _num_running          = QueuePrototype("int  job_queue_get_num_running( job_queue )")
     _num_complete         = QueuePrototype("int  job_queue_get_num_complete( job_queue )")
     _num_waiting          = QueuePrototype("int  job_queue_get_num_waiting( job_queue )")
@@ -89,17 +89,17 @@ class JobQueue(BaseCClass):
     def __init__(self, driver , max_submit=1, size=0):
         """
         Short doc...
-        
+
         The @size argument is used to say how many jobs the queue will
         run, in total.
-    
+
               size = 0: That means that you do not tell the queue in
                 advance how many jobs you have. The queue will just run
                 all the jobs you add, but you have to inform the queue in
                 some way that all jobs have been submitted. To achieve
                 this you should call the submit_complete() method when all
                 jobs have been submitted.#
-    
+
               size > 0: The queue will know exactly how many jobs to run,
                 and will continue until this number of jobs have completed
                 - it is not necessary to call the submit_complete() method
@@ -117,7 +117,7 @@ class JobQueue(BaseCClass):
         self.driver = driver
         self._set_driver(driver.from_param(driver))
         self.start( blocking=False )
-            
+
 
     def kill_job(self, queue_index):
         """
@@ -125,7 +125,7 @@ class JobQueue(BaseCClass):
         """
         self._kill_job( queue_index )
 
-        
+
     def start( self, blocking=False):
         verbose = False
         self._run_jobs(self.size, verbose)
@@ -245,7 +245,7 @@ class JobQueue(BaseCClass):
 
     def igetSimStart(self, job_index):
         return self._iget_sim_start( self , job_index )
-        
+
 
     def getUserExit(self):
         # Will check if a user_exit has been initated on the job. The
@@ -276,4 +276,4 @@ class JobQueue(BaseCClass):
 
 
 
-    
+

--- a/python/python/res/server/ertrpcserver.py
+++ b/python/python/res/server/ertrpcserver.py
@@ -123,7 +123,7 @@ class ErtRPCServer(SimpleXMLRPCServer):
     def stop(self):
         if self._session.simulation_context is not None:
             if self._session.simulation_context.isRunning():
-                self._session.simulation_context._queue_manager.get_job_queue().killAllJobs()
+                self._session.simulation_context._queue_manager.stop_queue()
         self.shutdown()
         self.server_close()
         self._enkf_main = None

--- a/python/python/res/server/simulation_context.py
+++ b/python/python/res/server/simulation_context.py
@@ -119,3 +119,5 @@ class SimulationContext(object):
         return self._run_context
 
 
+    def stop(self):
+        self._queue_manager.stop_queue( )

--- a/python/python/res/simulator/batch_simulator_context.py
+++ b/python/python/res/simulator/batch_simulator_context.py
@@ -43,8 +43,12 @@ class BatchContext(SimulationContext):
     def results(self):
         """Will return the results of the simulations.
 
-        This property will first block until all simulations have completed,
-        and then it will return all the results which were configured with the
+        Observe that this function will raise RuntimeError if the simulations
+        have not been completed. To be certain that the simulations have
+        completed you can call the join() method which will block until all
+        simulations have completed.
+
+        The function will return all the results which were configured with the
         @results when the simulator was created. The results will come as a
         list of dictionaries of arrays of double values, i.e. if the @results
         argument was:

--- a/python/tests/res/simulator/test_batch_sim.py
+++ b/python/tests/res/simulator/test_batch_sim.py
@@ -19,8 +19,7 @@ class BatchSimulatorTest(ExtendedTestCase):
 
     def test_create_simulator(self):
         config_file = self.createTestPath("local/batch_sim/batch_sim.ert")
-        with TestAreaContext("batch_sim", store_area = True) as ta:
-            sys.stderr.write("cwd:%s " % os.getcwd())
+        with TestAreaContext("batch_sim") as ta:
             ta.copy_parent_content( config_file )
 
             # Not valid ResConfig instance as first argument
@@ -102,6 +101,25 @@ class BatchSimulatorTest(ExtendedTestCase):
             on_off1 = res1["ON_OFF"]
             for i,x in enumerate(range(10,13)):
                 self.assertEqual(on_off1[i], x*x)
+
+
+    def test_stop_sim(self):
+        config_file = self.createTestPath("local/batch_sim/batch_sim.ert")
+        with TestAreaContext("batch_sim_stop") as ta:
+            ta.copy_parent_content( config_file )
+            res_config = ResConfig( user_config_file = os.path.basename( config_file ))
+            rsim = BatchSimulator( res_config,
+                                   {"WELL_ORDER" : ["W1", "W2", "W3"],
+                                    "WELL_ON_OFF" : ["W1","W2", "W3"]},
+                                   ["ORDER", "ON_OFF"])
+
+            # Starting a simulation which should actually run through.
+            ctx = rsim.start("case", [(2, {"WELL_ORDER" : [1, 2, 3], "WELL_ON_OFF" : [4,5,6]}),
+                                      (1, {"WELL_ORDER" : [7, 8, 9], "WELL_ON_OFF" : [10,11,12]})])
+            ctx.stop()
+            status = ctx.status
+            self.assertEqual(status.complete, 0)
+            self.assertEqual(status.running, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Task**
Batch simulator had incorrect documentation string - fixed that.

Added `stop( )`method to `SimulationContext`


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

