### PR TITLE
ext_job: writing arg specs to jobs.json

### DIFF
--- a/libjob_queue/src/ext_job.c
+++ b/libjob_queue/src/ext_job.c
@@ -761,7 +761,7 @@ static void __fprintf_python_arg_types(FILE * stream,
     for (i = 0; i < ext_job->max_arg; i++) {
 
       char * arg_type;
-      int type = int_vector_iget(ext_job->arg_types, i);
+      int type = int_vector_safe_iget(ext_job->arg_types, i);
       switch(type) {
         case CONFIG_INT:    arg_type = JOB_INT_TYPE; break;
         case CONFIG_FLOAT:  arg_type = JOB_FLOAT_TYPE; break;

--- a/python/python/res/job_queue/ext_job.py
+++ b/python/python/res/job_queue/ext_job.py
@@ -143,17 +143,19 @@ class ExtJob(BaseCClass):
     def set_max_running_minutes(self, min_value):
         self._set_max_running_minutes(min_value)
 
-    def minimumArgumentCount(self):
+    @property
+    def min_arg(self):
         return self._min_arg()
-
-    def maximumArgumentCount(self):
+    
+    @property
+    def max_arg(self):
         return self._max_arg()
 
-    def argumentTypes(self):
+    def get_argument_types(self):
         """ @rtype: list of type """
 
         result = []
-        for index in range(self.maximumArgumentCount()):
+        for index in range(self.max_arg):
             t = self._arg_type(index)
             if t == ContentTypeEnum.CONFIG_BOOL:
                 result.append(bool)
@@ -164,7 +166,7 @@ class ExtJob(BaseCClass):
             elif t == ContentTypeEnum.CONFIG_STRING:
                 result.append(str)
             else:
-                result.append(None)
+                result.append(NoneType)
 
         return result
 

--- a/python/python/res/job_queue/ext_job.py
+++ b/python/python/res/job_queue/ext_job.py
@@ -151,7 +151,8 @@ class ExtJob(BaseCClass):
     def max_arg(self):
         return self._max_arg()
 
-    def get_argument_types(self):
+    @property
+    def arg_types(self):
         """ @rtype: list of type """
 
         result = []

--- a/python/python/res/job_queue/workflow_job.py
+++ b/python/python/res/job_queue/workflow_job.py
@@ -111,7 +111,7 @@ class WorkflowJob(BaseCClass):
             elif t == ContentTypeEnum.CONFIG_STRING:
                 result.append(str)
             else:
-                result.append(None)
+                result.append(NoneType)
 
         return result
 

--- a/python/tests/res/job_queue/test_ext_job.py
+++ b/python/tests/res/job_queue/test_ext_job.py
@@ -63,7 +63,7 @@ class ExtJobTest(ExtendedTestCase):
             self.assertEqual( job.get_executable() , os.path.join( os.getcwd() , "script.sh"))
             self.assertTrue( os.access( job.get_executable() , os.X_OK ))
 
-            self.assertEqual( job.minimumArgumentCount(), -1)
+            self.assertEqual( job.min_arg, -1)
 
             job = ExtJob("CONFIG" , True , name = "Job")
             self.assertEqual( job.name() , "Job")
@@ -73,9 +73,9 @@ class ExtJobTest(ExtendedTestCase):
         with TestAreaContext("python/job_queue/forward_model1a"):
             create_upgraded_valid_config("CONFIG")
             job = ExtJob("CONFIG" , True)
-            self.assertEqual( job.minimumArgumentCount(), 2 )
-            self.assertEqual( job.maximumArgumentCount(), 4 )
-            argTypes = job.argumentTypes()
+            self.assertEqual( job.min_arg, 2 )
+            self.assertEqual( job.max_arg, 4 )
+            argTypes = job.get_argument_types()
             self.assertEqual( argTypes , [int, float , str, bool] )
 
 

--- a/python/tests/res/job_queue/test_ext_job.py
+++ b/python/tests/res/job_queue/test_ext_job.py
@@ -75,7 +75,7 @@ class ExtJobTest(ExtendedTestCase):
             job = ExtJob("CONFIG" , True)
             self.assertEqual( job.min_arg, 2 )
             self.assertEqual( job.max_arg, 4 )
-            argTypes = job.get_argument_types()
+            argTypes = job.arg_types
             self.assertEqual( argTypes , [int, float , str, bool] )
 
 

--- a/python/tests/res/job_queue/test_ext_job.py
+++ b/python/tests/res/job_queue/test_ext_job.py
@@ -17,7 +17,7 @@ def create_upgraded_valid_config( config_file ):
     with open(config_file , "w") as f:
         f.write("EXECUTABLE script.sh\n")
         f.write("MIN_ARG 2\n")
-        f.write("MAX_ARG 4\n")
+        f.write("MAX_ARG 5\n")
         f.write("ARG_TYPE 0 INT\n")
         f.write("ARG_TYPE 1 FLOAT\n")
         f.write("ARG_TYPE 2 STRING\n")
@@ -74,9 +74,9 @@ class ExtJobTest(ExtendedTestCase):
             create_upgraded_valid_config("CONFIG")
             job = ExtJob("CONFIG" , True)
             self.assertEqual( job.min_arg, 2 )
-            self.assertEqual( job.max_arg, 4 )
+            self.assertEqual( job.max_arg, 5 )
             argTypes = job.arg_types
-            self.assertEqual( argTypes , [int, float , str, bool] )
+            self.assertEqual( argTypes , [int, float , str, bool, str] )
 
 
         with TestAreaContext("python/job_queue/forward_model2"):


### PR DESCRIPTION
**Task**
 ext_job: writing arg specs to jobs.json: The following needs to be written to jobs.json:
arg min
arg max
arg_types (int, str etc.)


**Approach**
Changes is ext_job_json_fprintf.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

