### PR TITLE
Init relative lib path

### DIFF
--- a/python/python/res/__init__.py
+++ b/python/python/res/__init__.py
@@ -1,18 +1,18 @@
-#  Copyright (C) 2011  Statoil ASA, Norway. 
-#   
-#  The file '__init__.py' is part of ERT - Ensemble based Reservoir Tool. 
-#   
-#  ERT is free software: you can redistribute it and/or modify 
-#  it under the terms of the GNU General Public License as published by 
-#  the Free Software Foundation, either version 3 of the License, or 
-#  (at your option) any later version. 
-#   
-#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-#  WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-#  FITNESS FOR A PARTICULAR PURPOSE.   
-#   
-#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-#  for more details. 
+#  Copyright (C) 2011  Statoil ASA, Norway.
+#
+#  The file '__init__.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
 """
 Ert - Ensemble Reservoir Tool - a package for reservoir modeling.
 
@@ -96,14 +96,14 @@ if env_lib_path:
         res_lib_path = os.getenv("ERT_LIBRARY_PATH")
     else:
         sys.stderr.write("Warning: Environment variable ERT_LIBRARY_PATH points to nonexisting directory:%s - ignored" % env_lib_path)
-        
+
 
 # Check that the final ert_lib_path setting corresponds to an existing
 # directory.
 if res_lib_path:
     if not os.path.isdir( res_lib_path ):
         res_lib_path = None
-        
+
 
 if sys.hexversion < required_version_hex:
     raise Exception("ERT Python requires Python 2.7")

--- a/python/python/res/__init__.py
+++ b/python/python/res/__init__.py
@@ -101,6 +101,9 @@ if env_lib_path:
 # Check that the final ert_lib_path setting corresponds to an existing
 # directory.
 if res_lib_path:
+    if not os.path.isabs(res_lib_path):
+        res_lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), res_lib_path))
+
     if not os.path.isdir( res_lib_path ):
         res_lib_path = None
 

--- a/python/python/res/res_lib_info_install.py.in
+++ b/python/python/res/res_lib_info_install.py.in
@@ -1,3 +1,3 @@
-lib_path = "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+lib_path = "../../../../${CMAKE_INSTALL_LIBDIR}"
 so_version = ".${RES_VERSION_MAJOR}.${RES_VERSION_MINOR}"
 __version__ = "${RES_VERSION_MAJOR}.${RES_VERSION_MINOR}.${RES_VERSION_MICRO}"


### PR DESCRIPTION
**Task**
The hardlinking between `res/__init__.py` and so files should work with relative paths.

