### PR TITLE
Default lsf submit method should be LOCAL SHELL if no lsf lib.

### DIFF
--- a/libjob_queue/tests/job_lsf_test.c
+++ b/libjob_queue/tests/job_lsf_test.c
@@ -107,7 +107,11 @@ void test_cmd(void) {
 
 void test_submit_method() {
   lsf_driver_type * driver = lsf_driver_alloc();
+#ifdef HAVE_LSF_LIBRARY
   test_assert_int_not_equal( lsf_driver_get_submit_method(driver), LSF_SUBMIT_INVALID);
+#else
+  test_assert_int_equal(lsf_driver_get_submit_method(driver), LSF_SUBMIT_LOCAL_SHELL);
+#endif
   lsf_driver_free(driver);
 }
 


### PR DESCRIPTION
**Task**
Will check that the default lsf submit method equals `LOCAL_SHELL` when the lsf library is *not* available.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

