### PR TITLE
Runpath list load

### DIFF
--- a/libenkf/include/ert/enkf/enkf_main.h
+++ b/libenkf/include/ert/enkf/enkf_main.h
@@ -291,6 +291,7 @@ extern "C" {
   state_map_type  * enkf_main_alloc_readonly_state_map( const enkf_main_type * enkf_main , const char * case_path);
   time_map_type   * enkf_main_alloc_readonly_time_map( const enkf_main_type * enkf_main , const char * case_path );
 
+  runpath_list_type    * enkf_main_alloc_runpath_list(const enkf_main_type * enkf_main);
   runpath_list_type    * enkf_main_get_runpath_list( const enkf_main_type * enkf_main );
   ert_run_context_type * enkf_main_alloc_ert_run_context_ENSEMBLE_EXPERIMENT(const enkf_main_type * enkf_main , enkf_fs_type * fs , bool_vector_type * iactive , int iter);
 

--- a/libenkf/include/ert/enkf/hook_manager.h
+++ b/libenkf/include/ert/enkf/hook_manager.h
@@ -42,7 +42,6 @@ extern "C" {
 
   runpath_list_type   * hook_manager_get_runpath_list(const hook_manager_type * hook_manager);
   void                  hook_manager_export_runpath_list( const hook_manager_type * hook_manager );
-  void                  hook_manager_set_runpath_list_file( hook_manager_type * hook_manager , const char * path, const char * filename);
   const char          * hook_manager_get_runpath_list_file(const hook_manager_type * hook_manager);
   void                  hook_manager_run_workflows( const hook_manager_type * hook_manager , hook_run_mode_enum run_mode , void * self);
 

--- a/libenkf/include/ert/enkf/runpath_list.h
+++ b/libenkf/include/ert/enkf/runpath_list.h
@@ -42,7 +42,7 @@ extern "C" {
   void                runpath_list_fprintf( runpath_list_type * list);
   const char *        runpath_list_get_export_file( const runpath_list_type * list );
   void                runpath_list_set_export_file( runpath_list_type * list , const char * export_file );
-
+  bool                runpath_list_load(runpath_list_type * list); 
 
 
 #ifdef __cplusplus

--- a/libenkf/include/ert/enkf/runpath_list.h
+++ b/libenkf/include/ert/enkf/runpath_list.h
@@ -1,18 +1,18 @@
 /*
-   Copyright (C) 2013  Statoil ASA, Norway. 
-   The file 'runpath_list.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-   
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2013  Statoil ASA, Norway.
+   The file 'runpath_list.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef ERT_RUNPATH_LIST_H
@@ -43,7 +43,7 @@ extern "C" {
   const char *        runpath_list_get_export_file( const runpath_list_type * list );
   void                runpath_list_set_export_file( runpath_list_type * list , const char * export_file );
 
-  
+
 
 #ifdef __cplusplus
 }

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -1907,6 +1907,10 @@ runpath_list_type * enkf_main_get_runpath_list(const enkf_main_type * enkf_main)
 }
 
 
+runpath_list_type * enkf_main_alloc_runpath_list(const enkf_main_type * enkf_main) {
+  return runpath_list_alloc( hook_manager_get_runpath_list_file(enkf_main_get_hook_manager(enkf_main)));
+}
+
 
 void enkf_main_add_node(enkf_main_type * enkf_main, enkf_config_node_type * enkf_config_node) {
     for (int iens = 0; iens < enkf_main_get_ensemble_size(enkf_main); iens++) {

--- a/python/python/res/enkf/enkf_main.py
+++ b/python/python/res/enkf/enkf_main.py
@@ -70,6 +70,7 @@ class EnKFMain(BaseCClass):
     _submit_simulation = EnkfPrototype("void enkf_main_isubmit_job(enkf_main , run_arg, job_queue)")
     _alloc_run_context_ENSEMBLE_EXPERIMENT= EnkfPrototype("ert_run_context_obj enkf_main_alloc_ert_run_context_ENSEMBLE_EXPERIMENT( enkf_main , enkf_fs , bool_vector , int)")
     _get_runpath_list = EnkfPrototype("runpath_list_ref enkf_main_get_runpath_list(enkf_main)")
+    _create_runpath_list = EnkfPrototype("runpath_list_obj enkf_main_alloc_runpath_list(enkf_main)")
     _add_node = EnkfPrototype("void enkf_main_add_node(enkf_main, enkf_config_node)")
     _get_res_config = EnkfPrototype("res_config_ref enkf_main_get_res_config(enkf_main)")
     _init_run = EnkfPrototype("void enkf_main_init_run(enkf_main, ert_run_context)")
@@ -325,6 +326,8 @@ class EnKFMain(BaseCClass):
     def getRunContextENSEMPLE_EXPERIMENT(self , fs , iactive , iteration = 0):
         return self._alloc_run_context_ENSEMBLE_EXPERIMENT( fs , iactive , iteration )
 
+    def create_runpath_list(self):
+        return self._create_runpath_list()
 
     def getRunpathList(self):
         return self._get_runpath_list( )

--- a/python/python/res/enkf/runpath_list.py
+++ b/python/python/res/enkf/runpath_list.py
@@ -16,6 +16,7 @@ class RunpathList(BaseCClass):
     _runpath   = EnkfPrototype("char* runpath_list_iget_runpath(runpath_list, int)")
     _basename  = EnkfPrototype("char* runpath_list_iget_basename(runpath_list, int)")
     _export    = EnkfPrototype("void  runpath_list_fprintf(runpath_list)")
+    _load      = EnkfPrototype("bool  runpath_list_load(runpath_list)")
 
     _get_export_file = EnkfPrototype("char* runpath_list_get_export_file(runpath_list)")
     _set_export_file = EnkfPrototype("void runpath_list_set_export_file(runpath_list, char*)")
@@ -25,7 +26,7 @@ class RunpathList(BaseCClass):
         if c_ptr:
             super(RunpathList , self).__init__(c_ptr)
         else:
-            raise ValueError('Could not construct RunpathList with export_file "%s".' % export_file)
+            raise IOError('Could not construct RunpathList with export_file "%s".' % export_file)
 
     def __len__(self):
         return self._size( )
@@ -84,3 +85,8 @@ class RunpathList(BaseCClass):
 
     def export(self):
         self._export( )
+
+
+    def load(self):
+        if not self._load():
+            raise IOError("Could not load from:%s" % self._get_export_file())

--- a/python/tests/res/enkf/test_enkf_runpath.py
+++ b/python/tests/res/enkf/test_enkf_runpath.py
@@ -51,6 +51,10 @@ class EnKFRunpathTest(ExtendedTestCase):
             self.assertEqual(len(os.listdir('snake_oil_no_data/storage/snake_oil/runpath')), 1)
             self.assertEqual(len(os.listdir('snake_oil_no_data/storage/snake_oil/runpath/realisation-0')), 1)
 
+            rp = main.create_runpath_list( )
+            self.assertEqual(len(rp), 0)
+            rp.load()
+            self.assertEqual(len(rp), 1)
 
     def test_without_gen_kw(self):
         case_directory = self.createTestPath('local/snake_oil_no_data/')

--- a/python/tests/res/enkf/test_runpath_list.py
+++ b/python/tests/res/enkf/test_runpath_list.py
@@ -1,4 +1,6 @@
 import unittest
+import os.path
+
 from ecl.test import ExtendedTestCase, TestAreaContext
 from res.test import ErtTestContext
 
@@ -18,8 +20,41 @@ def base(idx):
 
 class RunpathListTest(ExtendedTestCase):
 
+    def test_load(self):
+        with TestAreaContext("runpath_list"):
+            with self.assertRaises(IOError):
+               rp = RunpathList("")
+
+            node0 = RunpathNode(0,0,"path0","base0")
+            node1 = RunpathNode(1,1,"path1","base1")
+
+            runpath_list = RunpathList("filex.list")
+            with self.assertRaises(IOError):
+                runpath_list.load( )
+
+            with open("invalid_file","w") as f:
+                f.write("X X X X\n")
+
+            rp = RunpathList("invalid_file")
+            with self.assertRaises(IOError):
+                rp.load()
+
+            rp = RunpathList("list.txt")
+            rp.add(node0.realization, node0.iteration, node0.runpath, node0.basename)
+            rp.add(node1.realization, node1.iteration, node1.runpath, node1.basename)
+            rp.export()
+            self.assertTrue(os.path.isfile("list.txt"))
+
+            rp2 = RunpathList("list.txt")
+            rp2.load()
+            self.assertEqual(len(rp2), 2)
+            self.assertEqual(rp2[0], node0)
+            self.assertEqual(rp2[1], node1)
+
+
+
     def test_runpath_list(self):
-        runpath_list = RunpathList('')
+        runpath_list = RunpathList('file')
 
         self.assertEqual(len(runpath_list), 0)
 


### PR DESCRIPTION
**Task**
The `runpath_list` implementation is mainly used to export a list of simulation directories to a file; with this PR it can also load from the same file.

**Approach**
Added quite basic load function.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps


