### PR TITLE
Changes in string validation and conversion:

### DIFF
--- a/libconfig/include/ert/config/config_schema_item.h
+++ b/libconfig/include/ert/config/config_schema_item.h
@@ -101,7 +101,7 @@ typedef enum {
   bool                      config_schema_item_is_deprecated( const config_schema_item_type * item);
   const char              * config_schema_item_get_deprecate_msg( const config_schema_item_type * item);
   void                      config_schema_item_set_deprecated( config_schema_item_type * item , const char * msg);
-  bool                      config_schema_item_valid_string(config_item_types value_type , const char * value);
+  bool                      config_schema_item_valid_string(config_item_types value_type , const char * value, bool runtime);
 
 #ifdef __cplusplus
 }

--- a/libconfig/src/config_schema_item.c
+++ b/libconfig/src/config_schema_item.c
@@ -227,7 +227,7 @@ config_schema_item_type * config_schema_item_alloc(const char * kw , bool requir
   return item;
 }
 
-bool config_schema_item_valid_string(config_item_types value_type , const char * value)
+bool config_schema_item_valid_string(config_item_types value_type , const char * value, bool runtime)
 {
   switch(value_type) {
   case(CONFIG_ISODATE):

--- a/libconfig/src/config_settings.c
+++ b/libconfig/src/config_settings.c
@@ -55,7 +55,7 @@ static void setting_node_assert_type( const setting_node_type * node , config_it
 UTIL_SAFE_CAST_FUNCTION( setting_node , SETTING_NODE_TYPE_ID )
 
 static setting_node_type * setting_node_alloc( const char * key, config_item_types value_type, const char * initial_value) {
-  if (!config_schema_item_valid_string( value_type , initial_value))
+  if (!config_schema_item_valid_string( value_type , initial_value, false))
     return NULL;
 
   {
@@ -83,7 +83,7 @@ static void setting_node_free__( void * arg ) {
 
 
 static bool setting_node_set_value( setting_node_type * node, const char * value) {
-  if (config_schema_item_valid_string(node->value_type , value)) {
+  if (config_schema_item_valid_string(node->value_type , value, false)) {
     node->string_value = util_realloc_string_copy( node->string_value , value );
     return true;
   } else

--- a/python/python/res/config/schema_item.py
+++ b/python/python/res/config/schema_item.py
@@ -30,38 +30,13 @@ class SchemaItem(BaseCClass):
     _set_argc_minmax = ConfigPrototype("void config_schema_item_set_argc_minmax( schema_item , int , int)")
     _add_alternative = ConfigPrototype("void config_schema_item_add_indexed_alternative(schema_item , int , char*)")
     _set_deprecated = ConfigPrototype("void config_schema_item_set_deprecated(schema_item ,  char*)")
-    _valid_string = ConfigPrototype("bool config_schema_item_valid_string(config_content_type_enum ,  char*)", bind = False)
-    _sscanf_bool = EclPrototype("bool util_sscanf_bool( char* , bool*)", bind = False)
-    
+
+
     def __init__(self, keyword, required=False):
         c_ptr = self._alloc(keyword, required)
         super(SchemaItem, self).__init__(c_ptr)
 
-    @classmethod
-    def validString(cls , value_type, value):
-        return cls._valid_string( value_type , value )
 
-        
-    
-    @classmethod
-    def convert(cls, value_type, value_string):
-        if cls.validString(value_type , value_string):
-            if value_type == ContentTypeEnum.CONFIG_INT:
-                return int(value_string)
-
-            if value_type == ContentTypeEnum.CONFIG_FLOAT:
-                return float(value_string)
-
-            if value_type == ContentTypeEnum.CONFIG_BOOL:
-                value = ctypes.c_bool()
-                SchemaItem._sscanf_bool( value_string , ctypes.byref( value ))
-                return value.value
-
-            return value_string
-        else:
-            raise ValueError("Invalid string value: %s" % value_string)
-
-        
 
     def iget_type( self, index):
         """ @rtype: ContentTypeEnum """
@@ -82,7 +57,7 @@ class SchemaItem(BaseCClass):
         for alt in alternatives:
             self.addAlternative( index , alt )
 
-            
+
     def addAlternative(self , index , alt):
         self._add_alternative( index , alt )
 
@@ -94,7 +69,7 @@ class SchemaItem(BaseCClass):
         object,
         """
         self._set_deprecated( msg )
-        
-        
+
+
     def free(self):
         self._free()

--- a/python/tests/res/config/test_config.py
+++ b/python/tests/res/config/test_config.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #  Copyright (C) 2012  Statoil ASA, Norway.
 #
 #  The file 'test_config.py' is part of ERT - Ensemble based Reservoir Tool.
@@ -288,13 +287,6 @@ class ConfigTest(ExtendedTestCase):
         self.assertEqual(schema_item.iget_type(0), ContentTypeEnum.CONFIG_INT)
         schema_item.set_argc_minmax(3, 6)
 
-        self.assertTrue(SchemaItem.validString(ContentTypeEnum.CONFIG_INT, "100"))
-        self.assertFalse(SchemaItem.validString(ContentTypeEnum.CONFIG_INT, "100.99"))
-        self.assertTrue(SchemaItem.validString(ContentTypeEnum.CONFIG_FLOAT, "100.99"))
-        self.assertFalse(SchemaItem.validString(ContentTypeEnum.CONFIG_FLOAT, "100.99X"))
-        self.assertTrue(SchemaItem.validString(ContentTypeEnum.CONFIG_STRING, "100.99XX"))
-        self.assertTrue(SchemaItem.validString(ContentTypeEnum.CONFIG_PATH, "100.99XX"))
-
 
         del schema_item
 
@@ -403,3 +395,25 @@ class ConfigTest(ExtendedTestCase):
         self.assertEqual(len(nodeB), 4)
 
         self.assertEqual(len(content), 4)
+
+
+    def test_valid_string(self):
+        self.assertTrue(ContentTypeEnum.CONFIG_FLOAT.valid_string("1.25"))
+        self.assertTrue(ContentTypeEnum.CONFIG_FLOAT.valid_string("1.125", runtime = True))
+        self.assertEqual(ContentTypeEnum.CONFIG_FLOAT.convert_string("1.25"), 1.25)
+        self.assertEqual(ContentTypeEnum.CONFIG_INT.convert_string("100"), 100)
+
+        with self.assertRaises(ValueError):
+            ContentTypeEnum.CONFIG_INT.convert_string("100x")
+
+        with self.assertRaises(ValueError):
+            ContentTypeEnum.CONFIG_FLOAT.convert_string("100X")
+
+        with self.assertRaises(ValueError):
+            ContentTypeEnum.CONFIG_BOOL.convert_string("WHAT_THE_FUCK")
+
+        self.assertTrue( ContentTypeEnum.CONFIG_BOOL.convert_string("TRUE"))
+        self.assertTrue( ContentTypeEnum.CONFIG_BOOL.convert_string("True"))
+        self.assertFalse( ContentTypeEnum.CONFIG_BOOL.convert_string("False"))
+        self.assertFalse( ContentTypeEnum.CONFIG_BOOL.convert_string("F"))
+


### PR DESCRIPTION
**Task**
This is a preparation/groundwork for #190 and validation of forward models in everest.

**Approach**
Changes to the conversion between strings and various types:

- Added boolean flag 'runtime'.
- Removed python classmethods SchemaItem.validString and
  SchemaItem.convertString.
- Added convert_string() and valid_string() methods to the ContentTypeEnum

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

