### PR TITLE
When instantiation SIMULATION_JOB we allow missing ARGLIST.

### DIFF
--- a/python/python/res/enkf/res_config.py
+++ b/python/python/res/enkf/res_config.py
@@ -200,27 +200,24 @@ class ResConfig(BaseCClass):
         ic = config[ConfigKeys.SIMULATION_JOB]
         simulation_job = []
         for job in ic:
-            job_options = [ConfigKeys.NAME, ConfigKeys.ARGLIST]
-
-            self._assert_keys(ConfigKeys.SIMULATION_JOB, job_options, job.keys())
-            arglist = []
-            for arg in job[ConfigKeys.ARGLIST]:
-              arglist.append(str(arg))
-            value = [job[ConfigKeys.NAME]] + arglist
-            simulation_job.append((ConfigKeys.SIMULATION_JOB, value))
+            arglist = [ job[ConfigKeys.NAME] ]
+            if ConfigKeys.ARGLIST in job:
+                for arg in job[ConfigKeys.ARGLIST]:
+                    arglist.append(str(arg))
+            simulation_job.append((ConfigKeys.SIMULATION_JOB, arglist))
 
         return simulation_job
 
-   
+
     def _extract_forward_model(self, config):
         if ConfigKeys.FORWARD_MODEL not in config:
             return []
-        
+
         ic = config[ConfigKeys.FORWARD_MODEL]
         forward_model_job = []
         for job in ic:
             forward_model_job.append((ConfigKeys.FORWARD_MODEL, job))
-        
+
         return forward_model_job
 
 
@@ -327,11 +324,11 @@ class ResConfig(BaseCClass):
 
         # Extract forward_model
         sim_filter.append(ConfigKeys.FORWARD_MODEL)
-        simulation_config += self._extract_forward_model(sc)      
+        simulation_config += self._extract_forward_model(sc)
 
         # Extract simulation_job
         sim_filter.append(ConfigKeys.SIMULATION_JOB)
-        simulation_config += self._extract_simulation_job(sc)     
+        simulation_config += self._extract_simulation_job(sc)
 
         # Extract logging
         sim_filter.append(ConfigKeys.LOGGING)
@@ -400,7 +397,7 @@ class ResConfig(BaseCClass):
         # Insert key values
         if not os.path.exists( config_dir ):
             raise IOError("The configuration direcetory: %s does not exist" % config_dir)
-        
+
         path_elm = config_content.create_path_elm(config_dir)
         add_key_value = lambda key, value : config_parser.add_key_value(
                                                             config_content,

--- a/python/tests/res/enkf/test_programmatic_res_config.py
+++ b/python/tests/res/enkf/test_programmatic_res_config.py
@@ -86,9 +86,13 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
                                     {
                                       "NAME" : "NEW_JOB_B",
                                       "PATH" : "simulation_model/jobs/NEW_TYPE_B"
-                                    }
-                                  ],
-                                  "SIMULATION_JOB" : 
+                                    },
+                                    {
+                                        "NAME" : "NEW_JOB_C",
+                                        "PATH" : "simulation_model/jobs/NEW_TYPE_C"
+                                      }
+                                   ],
+                                  "SIMULATION_JOB" :
                                   [
                                     {
                                       "NAME"    : "NEW_JOB_A",
@@ -97,12 +101,12 @@ class ProgrammaticResConfigTest(ExtendedTestCase):
                                     {
                                       "NAME"    : "NEW_JOB_B",
                                       "ARGLIST" : ["word"]
-                                    }
+                                    },
                                   ]
-                                  
+
 
                                 }
-                                
+
                              }
 
 

--- a/test-data/local/simulation_model/jobs/NEW_TYPE_C
+++ b/test-data/local/simulation_model/jobs/NEW_TYPE_C
@@ -1,0 +1,1 @@
+EXECUTABLE echo


### PR DESCRIPTION
**Task**
When instantiation forward model component with `SIMULATION_JOB` we use a dictionary which looks like:
```python
{"NAME" : name_of_job,
 "ARGLIST" : [arg1,arg2]}
```
with this PR the `ARGLIST` key is optional.


**NB: As part of this work it became clear that the the forward_model part of the programmatic res_config is not really tested.**