### PR TITLE
Remove warning for default Python configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 #-----------------------------------------------------------------
 
 option( BUILD_TESTS         "Should the tests be built"             OFF)
-option( BUILD_PYTHON        "Run py_compile on the python wrappers" ON )
+option( BUILD_PYTHON        "Run py_compile on the python wrappers" OFF)
 option( ENABLE_PYTHON       "Enable the python wrappers"            ON )
 option( RST_DOC             "Build RST documentation"               OFF)
 option( USE_RPATH           "Should we embed path to libraries"     ON )


### PR DESCRIPTION
**Task**
_When utilizing the standard Python setup (or specifically configuring `-DENABLE_PYTHON=ON`) cmake spits out a deprecation warning regarding `BUILD_PYTHON`._


**Approach**
_Default `BUILD_PYTHON` to `OFF`._


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps
