### PR TITLE
Give random seed in config file

### DIFF
--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -154,6 +154,7 @@ foreach (test   enkf_active_list
                 log_config_level_parse
                 value_export
                 rng_manager
+                rng_config
                 trans_func
     )
     add_executable(${test} tests/${test}.c)

--- a/libenkf/include/ert/enkf/config_keys.h
+++ b/libenkf/include/ert/enkf/config_keys.h
@@ -143,6 +143,7 @@ extern "C" {
 #define  UPDATE_PATH_KEY                   "UPDATE_PATH"
 #define  SINGLE_NODE_UPDATE_KEY            "SINGLE_NODE_UPDATE"
 #define  STORE_SEED_KEY                    "STORE_SEED"
+#define  RANDOM_SEED_KEY                   "RANDOM_SEED"
 #define  UMASK_KEY                         "UMASK"
 #define  WORKFLOW_JOB_DIRECTORY_KEY        "WORKFLOW_JOB_DIRECTORY"
 #define  LOAD_WORKFLOW_KEY                 "LOAD_WORKFLOW"

--- a/libenkf/include/ert/enkf/rng_config.h
+++ b/libenkf/include/ert/enkf/rng_config.h
@@ -35,6 +35,7 @@ typedef struct rng_config_struct rng_config_type;
   void               rng_config_set_type( rng_config_type * rng_config , rng_alg_type type);
   rng_alg_type       rng_config_get_type(const rng_config_type * rng_config );
   const char       * rng_config_get_seed_load_file( const rng_config_type * rng_config );
+  const char       * rng_config_get_random_seed(const rng_config_type * rng_config);
   void               rng_config_set_seed_load_file( rng_config_type * rng_config , const char * seed_load_file);
   const char       * rng_config_get_seed_store_file( const rng_config_type * rng_config );
   void               rng_config_set_seed_store_file( rng_config_type * rng_config , const char * seed_store_file);

--- a/libenkf/include/ert/enkf/rng_manager.h
+++ b/libenkf/include/ert/enkf/rng_manager.h
@@ -28,7 +28,8 @@ extern "C" {
 
 typedef struct rng_manager_struct rng_manager_type;
 
-rng_manager_type * rng_manager_alloc( const char * seed_file );
+rng_manager_type * rng_manager_alloc(const char * random_seed);
+rng_manager_type * rng_manager_alloc_load( const char * seed_file );
 rng_manager_type * rng_manager_alloc_default( );
 rng_manager_type * rng_manager_alloc_random( );
 

--- a/libenkf/include/ert/enkf/rng_manager.h
+++ b/libenkf/include/ert/enkf/rng_manager.h
@@ -26,6 +26,20 @@
 extern "C" {
 #endif
 
+/*
+ * The number of unsigned int's necessary to represent the state of the rng
+ * algorithm. Since the current algorithm used is mzran, this value is set to
+ * 4.
+ */
+#define RNG_STATE_SIZE 4
+
+/**
+ * The number of digits used to print each unigned int representing the rng
+ * state.
+ */
+#define RNG_STATE_DIGITS 10
+
+
 typedef struct rng_manager_struct rng_manager_type;
 
 rng_manager_type * rng_manager_alloc(const char * random_seed);
@@ -37,6 +51,7 @@ rng_type         * rng_manager_alloc_rng(rng_manager_type * rng_manager);
 rng_type         * rng_manager_iget(rng_manager_type * rng_manager, int index);
 void               rng_manager_free( rng_manager_type * rng_manager );
 void               rng_manager_save_state(const rng_manager_type * rng_manager, const char * seed_file);
+void               rng_manager_log_state(const rng_manager_type * rng_manager);
 
 
 UTIL_IS_INSTANCE_HEADER( rng_manager );

--- a/libenkf/src/enkf_main.c
+++ b/libenkf/src/enkf_main.c
@@ -2019,9 +2019,9 @@ enkf_main_type * enkf_main_alloc(const res_config_type * res_config, bool strict
   enkf_main_type * enkf_main = enkf_main_alloc_empty();
   enkf_main->res_config = res_config;
 
-  enkf_main_rng_init(enkf_main);
   enkf_main_set_verbose(enkf_main, verbose);
   enkf_main_init_log(enkf_main);
+  enkf_main_rng_init(enkf_main);
   enkf_main_user_select_initial_fs(enkf_main);
   enkf_main_init_obs(enkf_main);
   enkf_main_add_ensemble_members(enkf_main);

--- a/libenkf/src/rng_config.c
+++ b/libenkf/src/rng_config.c
@@ -125,7 +125,7 @@ rng_manager_type * rng_config_alloc_rng_manager( const rng_config_type * rng_con
   rng_manager_type * rng_manager;
 
   if (seed_load && util_file_exists( seed_load ))
-    rng_manager = rng_manager_alloc( seed_load );
+    rng_manager = rng_manager_alloc_load( seed_load );
   else
     rng_manager = rng_manager_alloc_random( );
 

--- a/libenkf/src/rng_manager.c
+++ b/libenkf/src/rng_manager.c
@@ -21,6 +21,7 @@
 #include <ert/util/rng.h>
 #include <ert/util/vector.h>
 #include <ert/enkf/rng_manager.h>
+#include <ert/res_util/res_log.h>
 
 #define RNG_MANAGER_TYPE_ID 77250451
 
@@ -124,7 +125,26 @@ rng_type * rng_manager_iget(rng_manager_type * rng_manager, int index) {
 }
 
 
-
 void rng_manager_save_state(const rng_manager_type * rng_manager, const char * seed_file) {
   rng_save_state( rng_manager->internal_seed_rng, seed_file );
+}
+
+
+void rng_manager_log_state(const rng_manager_type * rng_manager) {
+  unsigned int random_seed [RNG_STATE_SIZE];
+  rng_get_state(rng_manager->internal_seed_rng, (char *) random_seed);
+
+  char random_seed_str[RNG_STATE_DIGITS*RNG_STATE_SIZE+1];
+  random_seed_str[0] = '\0';
+  char * uint_fmt = util_alloc_sprintf("%%0%du", RNG_STATE_DIGITS);
+
+  for(int i = 0; i < RNG_STATE_SIZE; ++i) {
+    char * elem = util_alloc_sprintf(uint_fmt, random_seed[i]);
+    strcat(random_seed_str, elem);
+    free(elem);
+  }
+  free(uint_fmt);
+
+  res_log_add_fmt_message(LOG_CRITICAL, stdout, "To repeat this experiment, add the following random seed to your config file:");
+  res_log_add_fmt_message(LOG_CRITICAL, stdout, "RANDOM_SEED %s", random_seed_str);
 }

--- a/libenkf/tests/rng_config.c
+++ b/libenkf/tests/rng_config.c
@@ -1,0 +1,139 @@
+/*
+   Copyright (C) 2017  Statoil ASA, Norway.
+
+   The file 'rng_config.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <ert/util/test_util.h>
+#include <ert/util/test_work_area.h>
+
+#include <ert/enkf/rng_config.h>
+
+#define MAX_INT 999999
+
+static void create_config(
+        const char * user_config_file,
+        const char * random_seed)
+{
+  FILE * stream = util_fopen(user_config_file, "w");
+  fprintf(stream, "NUM_REALIZATIONS 17\n");
+  if(random_seed)
+    fprintf(stream, "RANDOM_SEED %s\n", random_seed);
+  fclose(stream);
+}
+
+static char * alloc_read_random_seed(const char * log_file)
+{
+  FILE * stream = util_fopen(log_file, "r");
+  char word [256];
+  char random_seed [256];
+  while(fscanf(stream, "%s", word) == 1)
+    if (strcmp("RANDOM_SEED", word) == 0)
+      fscanf(stream, "%s", random_seed);
+
+  fclose(stream);
+
+  return util_alloc_string_copy(random_seed);
+}
+
+void test_init()
+{
+  test_work_area_type * work_area = test_work_area_alloc("rng_config");
+  res_log_init_log_default(true);
+
+  const char * config_file = "my_rng_config";
+  const char * random_seed = "13371338";
+
+  create_config(config_file, random_seed);
+
+  rng_config_type * rng_config = rng_config_alloc_load_user_config(config_file);
+  test_assert_string_equal(random_seed, rng_config_get_random_seed(rng_config));
+
+  // To get the random seed written to the log
+  rng_manager_free(rng_config_alloc_rng_manager(rng_config));
+
+  char * logged_random_seed = alloc_read_random_seed("log");
+  test_assert_true(strlen(logged_random_seed) > 0);
+
+  free(logged_random_seed);
+  free(rng_config);
+  free(work_area);
+}
+
+static void alloc_reproduced_rng_config(
+        const char * random_seed,
+        rng_config_type ** orig_rng_config,
+        rng_config_type ** rep_rng_config,
+        rng_manager_type ** orig_rng_man,
+        rng_manager_type ** rep_rng_man)
+{
+  test_work_area_type * work_area = test_work_area_alloc("rng_config");
+  res_log_init_log_default(true);
+
+  const char * config_file = "my_rng_config";
+  create_config(config_file, random_seed);
+  *orig_rng_config = rng_config_alloc_load_user_config(config_file);
+
+  rng_manager_type * rng_man = rng_config_alloc_rng_manager(*orig_rng_config);
+  if(orig_rng_man)
+    *orig_rng_man = rng_man;
+  else
+    rng_manager_free(rng_man);
+
+  const char * rep_config_file = "rep_config";
+  char * logged_random_seed = alloc_read_random_seed("log");
+  create_config(rep_config_file, logged_random_seed);
+  *rep_rng_config = rng_config_alloc_load_user_config(rep_config_file);
+
+  if(rep_rng_man)
+    *rep_rng_man = rng_config_alloc_rng_manager(*rep_rng_config);
+
+  free(logged_random_seed);
+  free(work_area);
+}
+
+void test_reproducibility(char * random_seed)
+{
+
+  rng_config_type * orig_rng_config;
+  rng_config_type * rep_rng_config;
+
+  rng_manager_type * orig_rng_man;
+  rng_manager_type * rep_rng_man;
+
+  alloc_reproduced_rng_config(random_seed,
+                              &orig_rng_config, &rep_rng_config,
+                              &orig_rng_man, &rep_rng_man);
+
+  test_assert_not_NULL(orig_rng_man);
+  test_assert_not_NULL(rep_rng_man);
+
+  rng_type * orig_rng_0   = rng_manager_iget(orig_rng_man, 0);
+  rng_type * orig_rng_100 = rng_manager_iget(orig_rng_man, 100);
+
+  rng_type * rep_rng_0   = rng_manager_iget(rep_rng_man, 0);
+  rng_type * rep_rng_100 = rng_manager_iget(rep_rng_man, 100);
+
+  test_assert_int_equal(rng_get_int(orig_rng_0, MAX_INT), rng_get_int(rep_rng_0, MAX_INT));
+  test_assert_int_equal(rng_get_int(orig_rng_100, MAX_INT), rng_get_int(rep_rng_100, MAX_INT));
+}
+
+int main(int argc , char ** argv) {
+  test_init();
+  test_reproducibility(NULL); // Random seed
+  test_reproducibility("42");
+  test_reproducibility("423543854372895743289507289532");
+  test_reproducibility("423543854372895743289507289532423543854372895743289507289532");
+}

--- a/libenkf/tests/rng_manager.c
+++ b/libenkf/tests/rng_manager.c
@@ -156,8 +156,6 @@ static void test_alloc() {
   rng_manager_type * rng_man1 = rng_manager_alloc(random_seed1);
   rng_manager_type * rng_man_odd = rng_manager_alloc(random_seed2);
 
-  test_assert_not_NULL(rng_man0);
-
   rng_type * rng0_0  = rng_manager_iget(rng_man0, 0);
   rng_type * rng0_42 = rng_manager_iget(rng_man0, 42);
 

--- a/libenkf/tests/rng_manager.c
+++ b/libenkf/tests/rng_manager.c
@@ -28,7 +28,7 @@
 #define MAX_INT 999999
 
 void test_create() {
-  rng_manager_type * rng_manager = rng_manager_alloc("file/does/not/exist");
+  rng_manager_type * rng_manager = rng_manager_alloc_load("file/does/not/exist");
   test_assert_NULL( rng_manager );
 
   rng_manager = rng_manager_alloc_default( );
@@ -82,8 +82,8 @@ void test_state( ) {
   rng_manager_save_state( rng_manager , "seed.txt");
   test_assert_true( util_file_exists( "seed.txt" ));
   {
-    rng_manager_type * rng_manager1 = rng_manager_alloc( "seed.txt");
-    rng_manager_type * rng_manager2 = rng_manager_alloc( "seed.txt");
+    rng_manager_type * rng_manager1 = rng_manager_alloc_load( "seed.txt");
+    rng_manager_type * rng_manager2 = rng_manager_alloc_load( "seed.txt");
 
     rng_type * rng1_0   = rng_manager_iget( rng_manager1, 0 );
     rng_type * rng1_100 = rng_manager_iget( rng_manager1, 100 );
@@ -107,7 +107,7 @@ void test_state_restore( ) {
   rng_manager_save_state( rng_manager1 , "seed.txt");
   rng_type * rng1 = rng_manager_alloc_rng( rng_manager1 );
   {
-    rng_manager_type * rng_manager2 = rng_manager_alloc("seed.txt");
+    rng_manager_type * rng_manager2 = rng_manager_alloc_load("seed.txt");
 
     rng_type * rng1_0   = rng_manager_iget( rng_manager1, 0 );
     rng_type * rng1_100 = rng_manager_iget( rng_manager1, 100 );
@@ -148,7 +148,39 @@ void test_random( ) {
 }
 
 
+static void test_alloc() {
+  const char * random_seed1 = "apekatterbesting";
+  const char * random_seed2 = "apekatterbesxing";
+
+  rng_manager_type * rng_man0 = rng_manager_alloc(random_seed1);
+  rng_manager_type * rng_man1 = rng_manager_alloc(random_seed1);
+  rng_manager_type * rng_man_odd = rng_manager_alloc(random_seed2);
+
+  test_assert_not_NULL(rng_man0);
+
+  rng_type * rng0_0  = rng_manager_iget(rng_man0, 0);
+  rng_type * rng0_42 = rng_manager_iget(rng_man0, 42);
+
+  rng_type * rng1_0  = rng_manager_iget(rng_man1, 0);
+  rng_type * rng1_42 = rng_manager_iget(rng_man1, 42);
+
+  rng_type * rng_odd_0  = rng_manager_iget(rng_man_odd, 0);
+  rng_type * rng_odd_42 = rng_manager_iget(rng_man_odd, 42);
+
+  test_assert_int_equal(rng_get_int(rng0_0, MAX_INT), rng_get_int(rng1_0, MAX_INT));
+  test_assert_int_equal(rng_get_int(rng0_42, MAX_INT), rng_get_int(rng1_42, MAX_INT));
+
+  test_assert_int_not_equal(rng_get_int(rng0_0, MAX_INT), rng_get_int(rng_odd_0, MAX_INT));
+  test_assert_int_not_equal(rng_get_int(rng0_42, MAX_INT), rng_get_int(rng_odd_42, MAX_INT));
+
+  rng_manager_free(rng_man0);
+  rng_manager_free(rng_man1);
+  rng_manager_free(rng_man_odd);
+}
+
+
 int main(int argc , char ** argv) {
+  test_alloc();
   test_create();
   test_default();
   test_state();

--- a/python/python/res/enkf/rng_config.py
+++ b/python/python/res/enkf/rng_config.py
@@ -28,6 +28,7 @@ class RNGConfig(BaseCClass):
     _rng_alg_type = EnkfPrototype("rng_alg_type_enum rng_config_get_type(rng_config)")
     _load_file    = EnkfPrototype("char* rng_config_get_seed_load_file(rng_config)")
     _store_file   = EnkfPrototype("char* rng_config_get_seed_store_file(rng_config)")
+    _random_seed  = EnkfPrototype("char* rng_config_get_random_seed(rng_config)")
 
     def __init__(self, user_config_file):
         raise NotImplementedError(
@@ -46,3 +47,7 @@ class RNGConfig(BaseCClass):
     @property
     def store_filename(self):
         return self._store_file()
+
+    @property
+    def random_seed(self):
+        return self._random_seed()

--- a/python/tests/res/enkf/CMakeLists.txt
+++ b/python/tests/res/enkf/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TEST_SOURCES
     test_runpath_list_dump.py
     test_data_kw_define.py
     test_programmatic_res_config.py
+    test_rng_config.py
 )
 
 add_python_package("python.tests.res.enkf" ${PYTHON_INSTALL_PREFIX}/tests/res/enkf "${TEST_SOURCES}" False)
@@ -86,6 +87,7 @@ addPythonTest(tests.res.enkf.test_run_context.ErtRunContextTest)
 addPythonTest(tests.res.enkf.test_runpath_list_dump.RunpathListDumpTest)
 addPythonTest(tests.res.enkf.test_enkf_runpath.EnKFRunpathTest)
 addPythonTest(tests.res.enkf.test_programmatic_res_config.ProgrammaticResConfigTest)
+addPythonTest(tests.res.enkf.test_rng_config.RNGConfigTest)
 addPythonTest(tests.res.enkf.test_enkf.EnKFTest)
 addPythonTest(tests.res.enkf.test_enkf_transfer_env.EnKFTestTransferEnv)
 addPythonTest(tests.res.enkf.test_enkf_sim_model.EnKFTestSimModel)

--- a/python/tests/res/enkf/test_programmatic_res_config.py
+++ b/python/tests/res/enkf/test_programmatic_res_config.py
@@ -544,4 +544,3 @@ class ProgrammaticResConfigTest(ResTest):
             # Create minimum config in cwd:
             with ErtTestContext( "dict_test", config_dict = self.minimum_config_cwd, store_area = True):
                 pass
-

--- a/python/tests/res/enkf/test_rng_config.py
+++ b/python/tests/res/enkf/test_rng_config.py
@@ -1,0 +1,108 @@
+#  Copyright (C) 2017  Statoil ASA, Norway.
+#
+#  The file 'test_rng_config.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+import os
+from ecl.test import TestAreaContext
+from tests import ResTest
+
+from res.enkf import ResConfig, EnKFMain, RNGConfig, ConfigKeys
+
+class RNGConfigTest(ResTest):
+
+
+    def create_base_config(self):
+        return {
+                 "INTERNALS" :
+                 {
+                   "CONFIG_DIRECTORY" : "simple_config",
+                 },
+
+                 "SIMULATION" :
+                 {
+                   "QUEUE_SYSTEM" :
+                   {
+                     "JOBNAME" : "Job%d",
+                   },
+
+                   "RUNPATH"            : "/tmp/simulations/run%d",
+                   "NUM_REALIZATIONS"   : 1,
+                   "JOB_SCRIPT"         : "script.sh",
+                   "ENSPATH"            : "Ensemble",
+                   "LOGGING" : { "LOG_LEVEL" : "DEBUG" }
+                 }
+               }
+
+
+    def test_load_seed(self):
+        config = self.create_base_config()
+
+        seed_store = "../input/rng/SEED_STORE"
+        seed_load = "../input/rng/SEED"
+        config["SIMULATION"]["SEED"] = { "STORE_SEED" : seed_store,
+                                         "LOAD_SEED"  : seed_load }
+
+        case_directory = self.createTestPath("local/simple_config")
+        with TestAreaContext("rng_config") as work_area:
+            work_area.copy_directory(case_directory)
+            res_config = ResConfig(config=config)
+
+            self.assertEqual(seed_load,
+                             res_config.rng_config.load_filename)
+
+            self.assertEqual(seed_store,
+                             res_config.rng_config.store_filename)
+
+            self.assertIsNone(res_config.rng_config.random_seed)
+
+
+    def test_random_seed(self):
+        config = self.create_base_config()
+
+        random_seed = "abcdefghijklmnop"
+        config["SIMULATION"]["SEED"] = { "RANDOM_SEED" : random_seed }
+
+        case_directory = self.createTestPath("local/simple_config")
+        with TestAreaContext("rng_config") as work_area:
+            work_area.copy_directory(case_directory)
+            res_config = ResConfig(config=config)
+
+            self.assertIsNone(res_config.rng_config.load_filename)
+            self.assertIsNone(res_config.rng_config.store_filename)
+
+            self.assertEqual(random_seed,
+                             res_config.rng_config.random_seed)
+
+
+    def test_seed_conflict(self):
+        config = self.create_base_config()
+
+        seed_store = "../input/rng/SEED_STORE"
+        seed_load = "../input/rng/SEED"
+        random_seed = "abcdefghijklmnop"
+        config["SIMULATION"]["SEED"] = { "STORE_SEED" : seed_store,
+                                         "LOAD_SEED"  : seed_load,
+                                         "RANDOM_SEED" : random_seed }
+
+        case_directory = self.createTestPath("local/simple_config")
+        with TestAreaContext("rng_config") as work_area:
+            work_area.copy_directory(case_directory)
+            res_config = ResConfig(config=config)
+
+            self.assertIsNone(res_config.rng_config.load_filename)
+            self.assertIsNone(res_config.rng_config.store_filename)
+
+            self.assertEqual(random_seed,
+                             res_config.rng_config.random_seed)


### PR DESCRIPTION
**Task**
_Functionality for providing the random seed directly in the configuration file._


**Approach**
- Support keyword `RANDOM_SEED` in configuration file and configuration dict.
- If both `RANDOM_SEED` and `LOAD_SEED` is provided, `RANDOM_SEED` takes precedence.
- The `RANDOM_SEED` is written to the log when `enkf_main` is instantiated, so that one can replicate the current results if wanted.

**Remarks**
Do we want to deprecate `LOAD_SEED` and `STORE_SEED` or should both possibilities live side by side? Both are feasible solutions. The later is the current status, but deprecation is only a log-message away..

Note that most of the diff is new tests. 

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps