### PR TITLE
Python tests - source folder set by CMake

### DIFF
--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(TEST_SOURCES
-    __init__.py
     ctest_import.py
     ctest_run.py
     import_tester.py
@@ -9,6 +8,11 @@ set(TEST_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 set(INSTALL_DIRECTORY ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX})
 
 add_python_package("python.tests" "${PYTHON_INSTALL_PREFIX}/tests" "${TEST_SOURCES}" False)
+configure_file(
+   __init__.py 
+   "${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/tests/__init__.py"
+   @ONLY
+)
 
 add_subdirectory(global)
 add_subdirectory(res)

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -3,12 +3,19 @@ from ecl.test import ExtendedTestCase
 
 
 def source_root():
+    src = '@CMAKE_CURRENT_SOURCE_DIR@/../..'
+    if os.path.isdir(src):
+        return os.path.realpath(src)
+
+    # If the file was not correctly configured by cmake, look for the source
+    # folder, assuming the build folder is inside the source folder.
     path_list = os.path.dirname(os.path.abspath(__file__)).split("/")
-    while True:
+    while len(path_list) > 0:
         git_path = os.path.join(os.sep, "/".join(path_list), ".git")
         if os.path.isdir(git_path):
             return os.path.join(os.sep, *path_list)
         path_list.pop()
+    raise RuntimeError('Cannot find the source folder')
 
 
 class ResTest(ExtendedTestCase):


### PR DESCRIPTION
**Task**
The previous method to detect the source folder worked only if the build
directory was inside the source directory

**Approach**
use cmake `configure_file`

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps
