### PR TITLE
Replace <CASE_NAME> in path with batch id

### DIFF
--- a/python/python/res/simulator/batch_simulator.py
+++ b/python/python/res/simulator/batch_simulator.py
@@ -3,6 +3,10 @@ from ecl.util import BoolVector
 from res.enkf import ResConfig, ErtRunContext, EnKFMain, EnkfConfigNode, EnkfNode, NodeId
 from .batch_simulator_context import BatchContext
 
+def _slug(entity):
+    entity = ' '.join(str(entity).split())
+    return ''.join([x if x.isalnum() else '_' for x in entity.strip()])
+
 class BatchSimulator(object):
 
     def __init__(self, res_config, controls, results):
@@ -95,6 +99,7 @@ class BatchSimulator(object):
         batch complete before you start a new batch.
         """
         ens_config = self.res_config.ensemble_config
+        self.ert.addDataKW("<CASE_NAME>", _slug(case_name))
         fsm = self.ert.getEnkfFsManager( )
         fs = fsm.getFileSystem(case_name)
 

--- a/python/tests/res/simulator/test_batch_sim.py
+++ b/python/tests/res/simulator/test_batch_sim.py
@@ -114,13 +114,21 @@ class BatchSimulatorTest(ResTest):
                                     "WELL_ON_OFF" : ["W1","W2", "W3"]},
                                    ["ORDER", "ON_OFF"])
 
+            case_name = 'MyCaseName_123'
             # Starting a simulation which should actually run through.
-            ctx = rsim.start("case", [(2, {"WELL_ORDER" : [1, 2, 3], "WELL_ON_OFF" : [4,5,6]}),
-                                      (1, {"WELL_ORDER" : [7, 8, 9], "WELL_ON_OFF" : [10,11,12]})])
+            ctx = rsim.start(case_name, [(2, {
+                "WELL_ORDER": [1, 2, 3],
+                "WELL_ON_OFF": [4, 5, 6]
+            }), (1, {
+                "WELL_ORDER": [7, 8, 9],
+                "WELL_ON_OFF": [10, 11, 12]
+            })])
             ctx.stop()
             status = ctx.status
             self.assertEqual(status.complete, 0)
             self.assertEqual(status.running, 0)
+            runpath = 'storage/batch_sim/runpath/%s/realisation-0' % case_name
+            self.assertTrue(os.path.exists(runpath))
 
 
 if __name__ == "__main__":

--- a/test-data/local/batch_sim/batch_sim.ert
+++ b/test-data/local/batch_sim/batch_sim.ert
@@ -5,7 +5,7 @@ NUM_REALIZATIONS 25
 
 DEFINE <STORAGE> storage/<CONFIG_FILE_BASE>
 
-RUNPATH <STORAGE>/runpath/realisation-%d/iter-%d
+RUNPATH <STORAGE>/runpath/<CASE_NAME>/realisation-%d/iter-%d
 ENSPATH <STORAGE>/ensemble
 JOBNAME SNAKE_OIL_FIELD
 


### PR DESCRIPTION
Make the BatchSimulator replace occurrences of `<CASE_NAME>` in paths with actual case names.

We slugify the paths in case they should contain slashes.