### PR TITLE
Add print newline, make WARNING into INFO and refactor

### DIFF
--- a/libenkf/src/enkf_state.c
+++ b/libenkf/src/enkf_state.c
@@ -526,10 +526,14 @@ static void enkf_state_internalize_GEN_DATA(const ensemble_config_type * ens_con
   stringlist_type * keylist_GEN_DATA = ensemble_config_alloc_keylist_from_impl_type(ens_config, GEN_DATA);
 
 
-  if (stringlist_get_size( keylist_GEN_DATA) > 0)
+  if (stringlist_get_size(keylist_GEN_DATA) > 0)
     if (last_report <= 0)
-      res_log_warning("Trying to load GEN_DATA without properly "
-                      "set last_report - will only look for step 0 data.");
+      res_log_fwarning("Trying to load GEN_DATA %s without properly "
+                       "set last_report (was %d) - will only look for step 0 data: %s",
+                       ensemble_config_get_gen_kw_format(ens_config),
+                       last_report,
+                       stringlist_iget(keylist_GEN_DATA, 0)
+        );
 
   const run_arg_type * run_arg            = forward_load_context_get_run_arg( load_context );
   enkf_fs_type * sim_fs                   = run_arg_get_sim_fs( run_arg );

--- a/libenkf/src/gen_data.c
+++ b/libenkf/src/gen_data.c
@@ -276,7 +276,7 @@ static bool gen_data_fload_active__(gen_data_type * gen_data, const char * filen
         res_log_finfo("GEN_DATA(%s): active information loaded from:%s.",
                       gen_data_get_key(gen_data), active_file);
       } else
-        res_log_fwarning("GEN_DATA(%s): active information NOT loaded.",
+        res_log_finfo("GEN_DATA(%s): active information NOT loaded.",
                          gen_data_get_key(gen_data));
       free( active_file );
     }

--- a/libenkf/src/rng_manager.c
+++ b/libenkf/src/rng_manager.c
@@ -145,8 +145,8 @@ void rng_manager_log_state(const rng_manager_type * rng_manager) {
   }
   free(uint_fmt);
 
-  printf("To repeat this experiment, add the following random seed to your config file:");
-  printf("RANDOM_SEED %s", random_seed_str);
+  printf("\nTo repeat this experiment, add the following random seed to your config file:\n");
+  printf("RANDOM_SEED %s\n", random_seed_str);
   res_log_info("To repeat this experiment, add the following random seed to your config file:");
   res_log_finfo("RANDOM_SEED %s", random_seed_str);
 }

--- a/libjob_queue/src/ext_job.c
+++ b/libjob_queue/src/ext_job.c
@@ -289,12 +289,6 @@ ext_job_type * ext_job_alloc_copy(const ext_job_type * src_job) {
   return new_job;
 }
 
-//This function is deprecated
-static void ext_job_transfer_deprecated_argv( ext_job_type * ext_job) {
-  stringlist_deep_copy( ext_job->argv , ext_job->deprecated_argv );
-}
-
-
 
 void ext_job_free(ext_job_type * ext_job) {
   free(ext_job->name);
@@ -742,7 +736,7 @@ static void __fprintf_python_int(FILE * stream,
 
 static void __fprintf_python_argList(FILE * stream,
                                      const char * prefix,
-                                     ext_job_type * ext_job,
+                                     const ext_job_type * ext_job,
                                      const char * suffix,
                                      const subst_list_type * global_args) {
 


### PR DESCRIPTION
4 minor changes:

1. add a newline terminator in two print statements
2. make a warning into a message ("active information loaded from...")
3. add some more detail in a _warning_ to better debug the issue
4. fix a const and remove an unused static function in `ext_job`