### PR TITLE
Using decorator to skip python tests which require internal data.

### DIFF
--- a/python/tests/res/enkf/test_ert_context.py
+++ b/python/tests/res/enkf/test_ert_context.py
@@ -1,8 +1,8 @@
-from tests import ResTest
+from tests import ResTest, statoil_test
 from res.test import ErtTestContext
 
 
-
+@statoil_test()
 class ErtTestContextTest(ResTest):
     def setUp(self):
         self.config = self.createTestPath("Statoil/config/with_data/config")


### PR DESCRIPTION
**Task**
Minor refactor to harmonize with testing in libecl. Python tests which require internal testdata are disabled using a decorator instead of cmake `IF ( )`. 


**Approach**
Copiy & paste of decorator from libecl

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps


