### PR TITLE
Remove const, unuse, uninit warnings

### DIFF
--- a/libconfig/include/ert/config/config_content_node.h
+++ b/libconfig/include/ert/config/config_content_node.h
@@ -38,7 +38,8 @@ typedef struct config_content_node_struct config_content_node_type;
          char                       * config_content_node_alloc_joined_string(const config_content_node_type * node, const char * sep);
          void                         config_content_node_free(config_content_node_type * node);
          void                         config_content_node_free__(void * arg);
-         const char                 * config_content_node_get_full_string( config_content_node_type * node , const char * sep );
+         const char                 * config_content_node_get_full_string(const config_content_node_type * node,
+                                                                          const char * sep);
          const char                 * config_content_node_iget(const config_content_node_type * node , int index);
          bool                         config_content_node_iget_as_bool(const config_content_node_type * node , int index);
          int                          config_content_node_iget_as_int(const config_content_node_type * node , int index);

--- a/libconfig/src/config_content_node.c
+++ b/libconfig/src/config_content_node.c
@@ -92,9 +92,12 @@ static void config_content_node_push_string( config_content_node_type * node , c
   stringlist_append_owned_ref( node->string_storage , string );
 }
 
-const char * config_content_node_get_full_string( config_content_node_type * node , const char * sep ) {
+const char * config_content_node_get_full_string(const config_content_node_type * node,
+                                                 const char * sep) {
   char * full_string = stringlist_alloc_joined_string(node->stringlist , sep);
-  config_content_node_push_string( node , full_string );
+
+  // casting node to non-const, just to take ownership of full_string
+  config_content_node_push_string((config_content_node_type *)node, full_string );
   return full_string;
 }
 

--- a/libenkf/src/field_config.c
+++ b/libenkf/src/field_config.c
@@ -172,32 +172,6 @@ void field_config_set_ecl_data_type(field_config_type * config , ecl_data_type d
 }
 
 
-
-static const char * field_config_file_type_string(field_file_format_type file_type) {
-  switch (file_type) {
-  case(RMS_ROFF_FILE):
-    return "Binary ROFF file from RMS";
-    break;
-  case(ECL_KW_FILE):
-    return "ECLIPSE file in restart format";
-    break;
-  case(ECL_KW_FILE_ALL_CELLS):
-    return "ECLIPSE file in restart format (all cells)";
-    break;
-  case(ECL_KW_FILE_ACTIVE_CELLS):
-    return "ECLIPSE file in restart format (active cells)";
-    break;
-  case(ECL_GRDECL_FILE):
-    return "ECLIPSE file in grdecl format";
-    break;
-  default:
-    fprintf(stderr,"%s: invalid file type \n",__func__);
-    abort();
-  }
-}
-
-
-
 /**
    This function takes a field_file_format_type variable, and returns
    a string containing a default extension for files of this type. For
@@ -227,22 +201,6 @@ const char * field_config_default_extension(field_file_format_type file_type, bo
     return NULL;
 }
 
-
-
-
-static bool field_config_valid_file_type(field_file_format_type file_type, bool import) {
-  if (import) {
-    if (file_type == RMS_ROFF_FILE || file_type == ECL_KW_FILE || file_type == ECL_GRDECL_FILE)
-      return true;
-    else
-      return false;
-  } else {
-    if (file_type == RMS_ROFF_FILE || file_type == ECL_KW_FILE_ACTIVE_CELLS || file_type == ECL_KW_FILE_ALL_CELLS || file_type == ECL_GRDECL_FILE)
-      return true;
-    else
-      return false;
-  }
-}
 
 
 field_file_format_type field_config_default_export_format(const char * filename) {

--- a/libenkf/src/model_config.c
+++ b/libenkf/src/model_config.c
@@ -451,14 +451,15 @@ void model_config_init(model_config_type * model_config ,
     model_config->num_realizations = config_content_get_value_as_int(config, NUM_REALIZATIONS_KEY);
   
   for (int i = 0; i < config_content_get_size(config); i++) {
-     config_content_node_type * node = config_content_iget_node( config , i);
-     if (util_string_equal(config_content_node_get_kw(node), SIMULATION_JOB_KEY) ) 
-       forward_model_parse_job_args( model_config->forward_model , config_content_node_get_stringlist(node) );
-     
-     if (util_string_equal(config_content_node_get_kw(node), FORWARD_MODEL_KEY) ) {
-       const char * arg = config_content_node_get_full_string(node, "");
-       forward_model_parse_job_deprecated_args( model_config->forward_model , arg );
-     }
+    const config_content_node_type * node = config_content_iget_node( config , i);
+    if (util_string_equal(config_content_node_get_kw(node), SIMULATION_JOB_KEY))
+      forward_model_parse_job_args(model_config->forward_model,
+                                   config_content_node_get_stringlist(node));
+
+    if (util_string_equal(config_content_node_get_kw(node), FORWARD_MODEL_KEY) ) {
+      const char * arg = config_content_node_get_full_string(node, "");
+      forward_model_parse_job_deprecated_args( model_config->forward_model , arg );
+    }
   }
 
 
@@ -467,23 +468,21 @@ void model_config_init(model_config_type * model_config ,
     model_config_select_runpath( model_config , DEFAULT_RUNPATH_KEY );
   }
 
-  {
-    history_source_type source_type = DEFAULT_HISTORY_SOURCE;
+  history_source_type source_type = DEFAULT_HISTORY_SOURCE;
 
-    if (config_content_has_item( config , HISTORY_SOURCE_KEY)) {
-      const char * history_source = config_content_iget(config , HISTORY_SOURCE_KEY, 0,0);
-      source_type = history_get_source_type( history_source );
-    }
-
-    if (!model_config_select_history( model_config , source_type , sched_file , refcase ))
-      if (!model_config_select_history( model_config , DEFAULT_HISTORY_SOURCE , sched_file , refcase )) {
-        model_config_select_any_history( model_config , sched_file , refcase);
-        /* If even the last call return false, it means the configuration does not have any of
-         * these keys: HISTORY_SOURCE, SCHEDULE, REFCASE.
-         * History matching won't be supported for this configuration.
-         */
-      }
+  if (config_content_has_item( config , HISTORY_SOURCE_KEY)) {
+    const char * history_source = config_content_iget(config , HISTORY_SOURCE_KEY, 0,0);
+    source_type = history_get_source_type( history_source );
   }
+
+  if (!model_config_select_history( model_config , source_type , sched_file , refcase ))
+    if (!model_config_select_history( model_config , DEFAULT_HISTORY_SOURCE , sched_file , refcase )) {
+      model_config_select_any_history( model_config , sched_file , refcase);
+      /* If even the last call return false, it means the configuration does not have any of
+       * these keys: HISTORY_SOURCE, SCHEDULE, REFCASE.
+       * History matching won't be supported for this configuration.
+       */
+    }
 
   if (model_config->history != NULL) {
     int num_restart = model_config_get_last_history_restart(model_config);

--- a/libenkf/src/site_config.c
+++ b/libenkf/src/site_config.c
@@ -577,9 +577,9 @@ static bool site_config_init(site_config_type * site_config, const config_conten
 
   if (config_content_has_item(config, UMASK_KEY)) {
     const char * string_mask = config_content_get_value(config, UMASK_KEY);
-    mode_t umask_value;
+    int umask_value;
     if (util_sscanf_octal_int(string_mask, &umask_value))
-      site_config_set_umask(site_config, umask_value);
+      site_config_set_umask(site_config, (mode_t)umask_value);
     else
       util_abort("%s: failed to parse:\"%s\" as a valid octal literal \n", __func__, string_mask);
   }

--- a/libjob_queue/src/environment_varlist.c
+++ b/libjob_queue/src/environment_varlist.c
@@ -52,7 +52,7 @@ static void env_varlist_fprintf_hash(const hash_type * list, char * keystring, F
   stringlist_type * stringlist = hash_alloc_stringlist(list);
   int i_max = size - 1;
   for (int i = 0; i < size; i++) {
-    char * key = stringlist_iget(stringlist, i);
+    const char * key = stringlist_iget(stringlist, i);
     fprintf(stream, "\"%s\" : \"%s\"", key, (char*)hash_get(list, key)   );
     if (i < i_max)
       fprintf(stream, ", ");

--- a/libjob_queue/src/ext_job.c
+++ b/libjob_queue/src/ext_job.c
@@ -774,35 +774,35 @@ static void __fprintf_python_arg_types(FILE * stream,
                                        const char * suffix,
                                        const char * null_value) {
   fprintf(stream, "%s", prefix);
-  if (ext_job->arg_types) {
-    fprintf(stream, "\"%s\" : [", key);
-    int i;
-    for (i = 0; i < ext_job->max_arg; i++) {
-
-      char * arg_type;
-      int type = int_vector_safe_iget(ext_job->arg_types, i);
-      switch(type) {
-        case CONFIG_INT:          arg_type = JOB_INT_TYPE; break;
-        case CONFIG_FLOAT:        arg_type = JOB_FLOAT_TYPE; break;
-        case CONFIG_STRING:       arg_type = JOB_STRING_TYPE; break;
-        case CONFIG_BOOL:         arg_type = JOB_BOOL_TYPE; break;
-        case CONFIG_RUNTIME_FILE: arg_type = JOB_RUNTIME_FILE_TYPE; break;
-        case CONFIG_RUNTIME_INT:  arg_type = JOB_RUNTIME_INT_TYPE; break;
-        
-        default: util_abort("ERROR in %s", __func__);
-      }
-
-      fprintf(stream, "\"%s\"", arg_type);      
-      if ((i + 1) < ext_job->max_arg)
-        fprintf(stream, ", ");
-    }    
-    fprintf(stream, "]");
-  }
-  else
+  if (!ext_job->arg_types) {
     fprintf(stream , "\"%s\" : %s" , key, null_value);
-  fprintf(stream, "%s", suffix);
+    goto postfix;
+  }
+
+  fprintf(stream, "\"%s\" : [", key);
+  for (int i = 0; i < ext_job->max_arg; i++) {
+
+    char * arg_type = NULL;
+    int type = int_vector_safe_iget(ext_job->arg_types, i);
+    switch(type) {
+    case CONFIG_INT:          arg_type = JOB_INT_TYPE; break;
+    case CONFIG_FLOAT:        arg_type = JOB_FLOAT_TYPE; break;
+    case CONFIG_STRING:       arg_type = JOB_STRING_TYPE; break;
+    case CONFIG_BOOL:         arg_type = JOB_BOOL_TYPE; break;
+    case CONFIG_RUNTIME_FILE: arg_type = JOB_RUNTIME_FILE_TYPE; break;
+    case CONFIG_RUNTIME_INT:  arg_type = JOB_RUNTIME_INT_TYPE; break;
+    default: util_abort("%s unknown config type %d", __func__, type);
+    }
+
+    fprintf(stream, "\"%s\"", arg_type);
+    if ((i + 1) < ext_job->max_arg)
+      fprintf(stream, ", ");
+  }
+  fprintf(stream, "]");
+
+  postfix: fprintf(stream, "%s", suffix);
 }
-                                       
+
 
 void ext_job_json_fprintf(const ext_job_type * ext_job, FILE * stream, const subst_list_type * global_args) {
   const char * null_value = "null";


### PR DESCRIPTION
Some warnings have been purged, can be built with `-Werror=all` now