### PR TITLE
ecl.geo changed to ecl.util.geometry: changed import statements in li…

### DIFF
--- a/python/python/res/enkf/__init__.py
+++ b/python/python/res/enkf/__init__.py
@@ -18,7 +18,7 @@
 from cwrap import Prototype
 import res
 import ecl.util
-import ecl.geo
+import ecl.util.geometry
 import ecl
 import ecl.eclfile
 import ecl.grid

--- a/python/python/res/enkf/local_dataset.py
+++ b/python/python/res/enkf/local_dataset.py
@@ -1,7 +1,7 @@
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
 from ecl.grid import EclRegion
-from ecl.geo import GeoRegion
+from ecl.util.geometry import GeoRegion
 
 class LocalDataset(BaseCClass):
     TYPE_NAME = "local_dataset"

--- a/python/python/res/rms/__init__.py
+++ b/python/python/res/rms/__init__.py
@@ -1,6 +1,6 @@
 import res
 import ecl.util
-import ecl.geo
+import ecl.util.geometry
 import ecl
 
 RMS_LIB = res.load("librms")

--- a/python/python/res/sched/__init__.py
+++ b/python/python/res/sched/__init__.py
@@ -16,7 +16,7 @@
 import res
 import ecl
 import ecl.util
-import ecl.geo
+import ecl.util.geometry
 
 from cwrap import Prototype
 


### PR DESCRIPTION
**Task**
As part if dealing with libecl issue no. 27, ecl.geo is changed to ecl.util.geometry.


**Approach**
Import statements changed. 


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#310
