### PR TITLE
Added friendly message for change in interpretation of obs files.

### DIFF
--- a/libconfig/include/ert/config/conf.h
+++ b/libconfig/include/ert/config/conf.h
@@ -333,6 +333,7 @@ time_t conf_instance_get_item_value_time_t(
 bool conf_instance_validate(
   const conf_instance_type * conf_instance);
 
+bool conf_instance_has_path_error(const conf_instance_type * conf_instance);
 
 
 /** A L L O C   F R O M   F I L E */

--- a/libenkf/CMakeLists.txt
+++ b/libenkf/CMakeLists.txt
@@ -139,6 +139,7 @@ foreach (test   enkf_active_list
                 enkf_local_obsdata_node
                 enkf_meas_data
                 enkf_model_config
+                enkf_obs_invalid_path
                 enkf_obs_tests
                 enkf_obs_vector
                 enkf_pca_plot

--- a/libenkf/include/ert/enkf/enkf_obs.h
+++ b/libenkf/include/ert/enkf/enkf_obs.h
@@ -28,6 +28,8 @@ extern "C" {
 #include <ert/util/int_vector.h>
 #include <ert/util/type_macros.h>
 
+#include <ert/config/conf.h>
+
 #include <ert/sched/history.h>
 
 #include <ert/ecl/ecl_sum.h>
@@ -94,7 +96,7 @@ extern "C" {
   void              enkf_obs_add_local_nodes_with_data(const enkf_obs_type * enkf_obs , local_obsdata_type * local_obs , enkf_fs_type *fs , const bool_vector_type * ens_mask);
   double            enkf_obs_scale_correlated_std(const enkf_obs_type * enkf_obs , enkf_fs_type * fs , const int_vector_type * ens_active_list , const local_obsdata_type * local_obsdata);
   local_obsdata_type * enkf_obs_alloc_all_active_local_obs( const enkf_obs_type * enkf_obs , const char * key);
-
+  conf_class_type * enkf_obs_get_obs_conf_class();
   UTIL_IS_INSTANCE_HEADER( enkf_obs );
 
 #ifdef __cplusplus

--- a/libenkf/src/enkf_obs.c
+++ b/libenkf/src/enkf_obs.c
@@ -172,13 +172,7 @@ In the following example we have two observations
  */
 
 
-/**
-TODO
 
-    This static function header shall be removed when the
-    configuration is unified....
-*/
-static conf_class_type * enkf_obs_get_obs_conf_class();
 
 
 
@@ -735,9 +729,22 @@ static void handle_general_observation(enkf_obs_type * enkf_obs,
 }
 
 
+static enkf_obs_reinterpret_DT_FILE(const char * config_file) {
+  fprintf(stderr,"**********************************************************************\n");
+  fprintf(stderr,"* In ert version 2.3 we have changed how filepaths are interpreted   *\n");
+  fprintf(stderr,"* in the observation file. When using the keywords OBS_FILE,         *\n");
+  fprintf(stderr,"* ERROR_COVAR and INDEX_FILE in the category GENERAL_OBSERVATION     *\n");
+  fprintf(stderr,"* the filenames will be interpreted relative to the main observation *\n");
+  fprintf(stderr,"* file.                                                              *\n");
+  fprintf(stderr,"*                                                                    *\n");
+  fprintf(stderr,"* Please update the OBS_FILE, ERROR_COVAR and INDEX_FILE keywords    *\n");
+  fprintf(stderr,"* by removing the path to the main observation file.                 *\n");
+  fprintf(stderr,"**********************************************************************\n");
+}
+
 
 /**
-   This function will load an observation configuration from the
+ This function will load an observation configuration from the
    observation file @config_file.
 
    If called several times during one invocation the function will
@@ -757,6 +764,11 @@ void enkf_obs_load(enkf_obs_type * enkf_obs ,
                                                                  "enkf_conf",
                                                                  config_file);
 
+  if (conf_instance_get_path_error(enkf_conf)) {
+    enkf_obs_reinterpret_DT_FILE(config_file);
+    exit(1);
+  }
+
   if(!conf_instance_validate(enkf_conf))
     util_abort("%s: Can not proceed with this configuration: %s\n",
                __func__, config_file);
@@ -773,7 +785,7 @@ void enkf_obs_load(enkf_obs_type * enkf_obs ,
 }
 
 
-static conf_class_type * enkf_obs_get_obs_conf_class( void ) {
+conf_class_type * enkf_obs_get_obs_conf_class( void ) {
   const char * enkf_conf_help = "An instance of the class ENKF_CONFIG shall contain neccessary infomation to run the enkf.";
   conf_class_type * enkf_conf_class = conf_class_alloc_empty("ENKF_CONFIG", true , false , enkf_conf_help);
   conf_class_set_help(enkf_conf_class, enkf_conf_help);

--- a/libenkf/tests/enkf_obs_invalid_path.c
+++ b/libenkf/tests/enkf_obs_invalid_path.c
@@ -1,0 +1,96 @@
+/*
+   Copyright (C) 2018  Statoil ASA, Norway.
+
+   The file 'enkf_obs_invalid_file.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <ert/util/test_work_area.h>
+#include <ert/util/test_util.h>
+
+#include <ert/enkf/enkf_obs.h>
+
+
+void test_invalid_path() {
+  test_work_area_type * work_area = test_work_area_alloc("conf");
+  util_make_path("obs_path");
+  {
+    FILE * stream = util_fopen("obs_path/conf.txt","w");
+    fprintf(stream,
+            "GENERAL_OBSERVATION WPR_DIFF_1 {"
+            "DATA       = SNAKE_OIL_WPR_DIFF;"
+            "INDEX_LIST = 400,800,1200,1800;"
+            "RESTART    = 199;"
+            "OBS_FILE   = obs_path/obs.txt;"
+            "};");
+    fclose(stream);
+  }
+  {
+    FILE * stream = util_fopen("obs_path/obs.txt","w");
+    fclose(stream);
+  }
+
+  conf_class_type * enkf_conf_class = enkf_obs_get_obs_conf_class();
+  conf_instance_type * enkf_conf = conf_instance_alloc_from_file(enkf_conf_class,
+                                                                 "enkf_conf",
+                                                                 "obs_path/conf.txt");
+  test_assert_true(conf_instance_get_path_error(enkf_conf));
+  test_assert_false(conf_instance_validate(enkf_conf));
+
+  conf_instance_free(enkf_conf);
+  test_work_area_set_store(work_area, true);
+
+  test_work_area_free(work_area);
+}
+
+
+void test_valid_path() {
+  test_work_area_type * work_area = test_work_area_alloc("conf");
+  util_make_path("obs_path");
+  {
+    FILE * stream = util_fopen("obs_path/conf.txt","w");
+    fprintf(stream,
+            "GENERAL_OBSERVATION WPR_DIFF_1 {\n"
+            "DATA       = SNAKE_OIL_WPR_DIFF;\n"
+            "INDEX_LIST = 400,800,1200,1800;\n"
+            "RESTART    = 199;\n"
+            "OBS_FILE   = obs.txt;\n"
+            "};");
+    fclose(stream);
+  }
+  {
+    FILE * stream = util_fopen("obs_path/obs.txt","w");
+    fclose(stream);
+  }
+
+  conf_class_type * enkf_conf_class = enkf_obs_get_obs_conf_class();
+  conf_instance_type * enkf_conf = conf_instance_alloc_from_file(enkf_conf_class,
+                                                                 "enkf_conf",
+                                                                 "obs_path/conf.txt");
+
+  test_assert_false(conf_instance_get_path_error(enkf_conf));
+  test_assert_true(conf_instance_validate(enkf_conf));
+
+  conf_instance_free(enkf_conf);
+  test_work_area_free(work_area); 
+}
+
+
+
+int main(int argc , char ** argv) {
+  test_valid_path();
+  test_invalid_path();
+}


### PR DESCRIPTION
**Task**
As part of the development cycle from 2.2 to 2.3 we have changed how paths are resolved in the observation file. They are now resolved relative to the main observation file, which is accordance with how the rest of ERT handles paths.

When the new version is deployed people must update their observation files. With this PR they should get a reasonably nice message informing them what to do.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps


