### PR TITLE
Removed ExtJob.get_environment()

### DIFF
--- a/python/python/res/config/config_parser.py
+++ b/python/python/res/config/config_parser.py
@@ -30,7 +30,7 @@ class ConfigParser(BaseCClass):
     _alloc = ConfigPrototype("void* config_alloc()", bind=False)
     _add   = ConfigPrototype("schema_item_ref config_add_schema_item(config_parser, char*, bool)")
     _free  = ConfigPrototype("void config_free(config_parser)")
-    _parse = ConfigPrototype("config_content_obj config_parse(config_parser, char*, char*, char*, char*, hash, config_unrecognized_enum, bool)")
+    _parse = ConfigPrototype("config_content_obj config_parse(config_parser, char*, char*, char*, char*, void* , config_unrecognized_enum, bool)")
     _size  = ConfigPrototype("int config_get_schema_size(config_parser)");
     _get_schema_item = ConfigPrototype("schema_item_ref config_get_schema_item(config_parser, char*)")
     _has_schema_item = ConfigPrototype("bool config_has_schema_item(config_parser, char*)")
@@ -77,7 +77,6 @@ class ConfigParser(BaseCClass):
               comment_string="--",
               include_kw="INCLUDE",
               define_kw="DEFINE",
-              pre_defined_kw_map=None,
               unrecognized=UnrecognizedEnum.CONFIG_UNRECOGNIZED_WARN,
               validate=True):
         """ @rtype: ConfigContent """
@@ -90,7 +89,7 @@ class ConfigParser(BaseCClass):
                                      comment_string,
                                      include_kw,
                                      define_kw,
-                                     pre_defined_kw_map,
+                                     None,
                                      unrecognized,
                                      validate)
         config_content.setParser(self)

--- a/python/python/res/enkf/site_config.py
+++ b/python/python/res/enkf/site_config.py
@@ -36,7 +36,6 @@ class SiteConfig(BaseCClass):
     _set_rsh_command       = EnkfPrototype("void site_config_set_rsh_command(site_config, char*)")
     _get_max_running_rsh   = EnkfPrototype("int site_config_get_max_running_rsh(site_config)")
     _set_max_running_rsh   = EnkfPrototype("void site_config_set_max_running_rsh(site_config, int)")
-    _get_rsh_host_list     = EnkfPrototype("integer_hash_ref site_config_get_rsh_host_list(site_config)")
     _clear_rsh_host_list   = EnkfPrototype("void site_config_clear_rsh_host_list(site_config)")
     _add_rsh_host          = EnkfPrototype("void site_config_add_rsh_host(site_config, char*, int)")
     _get_max_running_local = EnkfPrototype("int site_config_get_max_running_local(site_config)")
@@ -167,11 +166,6 @@ class SiteConfig(BaseCClass):
     def isQueueRunning(self):
         """ @rtype: bool """
         return self._queue_is_running( )
-
-    def getRshHostList(self):
-        """ @rtype: IntegerHash """
-        host_list = self._get_rsh_host_list()
-        return host_list
 
     def addRshHost(self, host, max_running):
         self._add_rsh_host(host, max_running)

--- a/python/python/res/job_queue/ext_job.py
+++ b/python/python/res/job_queue/ext_job.py
@@ -17,7 +17,7 @@ import os.path
 
 from cwrap import BaseCClass
 from res.job_queue import QueuePrototype
-from ecl.util import StringList, Hash
+from ecl.util import StringList
 from res.config import ContentTypeEnum
 
 class ExtJob(BaseCClass):
@@ -53,7 +53,6 @@ class ExtJob(BaseCClass):
     _max_arg                    = QueuePrototype("int ext_job_get_max_arg(ext_job)")
     _arg_type                   = QueuePrototype("config_content_type_enum ext_job_iget_argtype(ext_job, int)")
 
-    _get_environment            = QueuePrototype("string_hash_ref ext_job_get_environment(ext_job)")
     _set_environment            = QueuePrototype("void ext_job_add_environment(ext_job, char*, char*)")
     _get_license_path           = QueuePrototype("char* ext_job_get_license_path(ext_job)")
     _get_arglist                = QueuePrototype("stringlist_ref ext_job_get_arglist(ext_job)") 
@@ -168,9 +167,6 @@ class ExtJob(BaseCClass):
           if not arg_type.valid_string(arg, runtime):
                 return False
           return True
-
-    def get_environment(self):
-        return self._get_environment( )
 
     def set_environment(self, key, value):
         self._set_environment( key, value)

--- a/python/python/res/job_queue/ext_joblist.py
+++ b/python/python/res/job_queue/ext_joblist.py
@@ -27,18 +27,11 @@ class ExtJoblist(BaseCClass):
     _del_job    = QueuePrototype("int ext_joblist_del_job(ext_joblist, char*)")
     _has_job    = QueuePrototype("int ext_joblist_has_job(ext_joblist, char*)")
     _add_job    = QueuePrototype("void ext_joblist_add_job(ext_joblist, char*, ext_job)")
-    _get_jobs   = QueuePrototype("hash_ref ext_joblist_get_jobs(ext_joblist)")
     _size       = QueuePrototype("int ext_joblist_get_size(ext_joblist)")
 
     def __init__(self):
         c_ptr = self._alloc()
         super(ExtJoblist, self).__init__(c_ptr)
-
-    def get_jobs(self):
-        """ @rtype: Hash """
-        jobs = self._get_jobs( )
-        jobs.setParent(self)
-        return jobs
 
     def __len__(self):
         return self._size( )


### PR DESCRIPTION
**Task**
Remove the `hash` wrapping from libecl.



**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
