### PR TITLE
New subpackage ecl.util.util: import statements in libres changed to …

### DIFF
--- a/python/python/res/__init__.py
+++ b/python/python/res/__init__.py
@@ -119,7 +119,7 @@ def load(name):
 
 
 from res.util import ResVersion
-from ecl.util import updateAbortSignals
+from ecl.util.util import updateAbortSignals
 
 updateAbortSignals( )
 

--- a/python/python/res/analysis/analysis_module.py
+++ b/python/python/res/analysis/analysis_module.py
@@ -15,10 +15,10 @@
 #  for more details.
 
 from cwrap import BaseCClass
-from ecl.util.rng import RandomNumberGenerator
+from ecl.util.util.rng import RandomNumberGenerator
 from res.analysis import AnalysisPrototype
 
-from ecl.util import Matrix
+from ecl.util.util import Matrix
 
 class AnalysisModule(BaseCClass):
     TYPE_NAME = "analysis_module"

--- a/python/python/res/config/config_parser.py
+++ b/python/python/res/config/config_parser.py
@@ -19,7 +19,7 @@ import os.path
 import warnings
 
 from cwrap import BaseCClass
-from ecl.util import StringList
+from ecl.util.util import StringList
 from res.config import (ContentTypeEnum, ConfigContent, ConfigPrototype,
                         UnrecognizedEnum, ConfigPathElm)
 

--- a/python/python/res/enkf/analysis_config.py
+++ b/python/python/res/enkf/analysis_config.py
@@ -18,7 +18,7 @@ from os.path import isfile
 
 from cwrap import BaseCClass
 
-from ecl.util import StringList
+from ecl.util.util import StringList
 
 from res.enkf import EnkfPrototype
 from res.enkf import AnalysisIterConfig

--- a/python/python/res/enkf/config/custom_kw_config.py
+++ b/python/python/res/enkf/config/custom_kw_config.py
@@ -17,7 +17,7 @@ import sys
 
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
-from ecl.util import StringList, IntegerHash
+from ecl.util.util import StringList, IntegerHash
 
 
 class CustomKWConfig(BaseCClass):

--- a/python/python/res/enkf/config/enkf_config_node.py
+++ b/python/python/res/enkf/config/enkf_config_node.py
@@ -16,7 +16,7 @@
 from cwrap import BaseCClass
 
 from ecl.grid import EclGrid
-from ecl.util import StringList, IntVector
+from ecl.util.util import StringList, IntVector
 
 from res.util import PathFormat
 from res.enkf import EnkfPrototype

--- a/python/python/res/enkf/config/ext_param_config.py
+++ b/python/python/res/enkf/config/ext_param_config.py
@@ -15,7 +15,7 @@
 #  for more details.
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
-from ecl.util import StringList
+from ecl.util.util import StringList
 
 
 class ExtParamConfig(BaseCClass):

--- a/python/python/res/enkf/config/gen_kw_config.py
+++ b/python/python/res/enkf/config/gen_kw_config.py
@@ -16,7 +16,7 @@
 from cwrap import BaseCClass
 import os
 from res.enkf import EnkfPrototype
-from ecl.util import StringList
+from ecl.util.util import StringList
 
 
 class GenKwConfig(BaseCClass):

--- a/python/python/res/enkf/data/gen_data.py
+++ b/python/python/res/enkf/data/gen_data.py
@@ -1,5 +1,5 @@
 from cwrap import BaseCClass
-from ecl.util import DoubleVector
+from ecl.util.util import DoubleVector
 from res.enkf import EnkfPrototype
 
 

--- a/python/python/res/enkf/data/gen_kw.py
+++ b/python/python/res/enkf/data/gen_kw.py
@@ -17,7 +17,7 @@ import os.path
 
 from cwrap import BaseCClass, CFILE
 
-from ecl.util import DoubleVector
+from ecl.util.util import DoubleVector
 from res.enkf import EnkfPrototype
 from res.enkf.config import GenKwConfig
 

--- a/python/python/res/enkf/ecl_config.py
+++ b/python/python/res/enkf/ecl_config.py
@@ -19,7 +19,7 @@ from res.enkf import EnkfPrototype
 from res.config import ConfigContent
 from ecl.grid import EclGrid
 from ecl.summary import EclSum
-from ecl.util import StringList
+from ecl.util.util import StringList
 from res.sched import SchedFile
 from res.util import UIReturn
 

--- a/python/python/res/enkf/enkf_fs_manager.py
+++ b/python/python/res/enkf/enkf_fs_manager.py
@@ -1,7 +1,7 @@
 import os.path
 from cwrap import BaseCClass
 from res.enkf import EnkfFs, StateMap, TimeMap, RealizationStateEnum, EnkfInitModeEnum, EnkfPrototype
-from ecl.util import StringList, BoolVector
+from ecl.util.util import StringList, BoolVector
 
 import re
 

--- a/python/python/res/enkf/enkf_linalg.py
+++ b/python/python/res/enkf/enkf_linalg.py
@@ -1,6 +1,6 @@
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
-from ecl.util import Matrix , DoubleVector
+from ecl.util.util import Matrix , DoubleVector
 
 class EnkfLinalg(BaseCClass):
     TYPE_NAME = "EnkfLinalg"

--- a/python/python/res/enkf/enkf_obs.py
+++ b/python/python/res/enkf/enkf_obs.py
@@ -16,7 +16,7 @@
 import os.path
 
 from cwrap import BaseCClass
-from ecl.util import StringList, IntVector
+from ecl.util.util import StringList, IntVector
 from res.sched import History
 from ecl.grid import EclGrid
 from ecl.summary import EclSum

--- a/python/python/res/enkf/enkf_simulation_runner.py
+++ b/python/python/res/enkf/enkf_simulation_runner.py
@@ -2,7 +2,7 @@ from cwrap import BaseCClass
 from res.enkf import EnkfFs
 from res.enkf import EnkfPrototype, ErtRunContext
 from res.enkf.enums import EnkfInitModeEnum
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 
 class EnkfSimulationRunner(BaseCClass):

--- a/python/python/res/enkf/ensemble_config.py
+++ b/python/python/res/enkf/ensemble_config.py
@@ -14,7 +14,7 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 from cwrap import BaseCClass
-from ecl.util import StringList
+from ecl.util.util import StringList
 from ecl.grid import EclGrid
 from ecl.summary import EclSum
 from res.enkf import EnkfPrototype, SummaryKeyMatcher

--- a/python/python/res/enkf/ert_run_context.py
+++ b/python/python/res/enkf/ert_run_context.py
@@ -15,7 +15,7 @@
 #  for more details.
 from cwrap import BaseCClass
 
-from ecl.util import StringList
+from ecl.util.util import StringList
 
 from res.util import PathFormat
 from res.enkf import EnkfPrototype

--- a/python/python/res/enkf/ert_templates.py
+++ b/python/python/res/enkf/ert_templates.py
@@ -15,7 +15,7 @@
 #  for more details.
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype, ErtTemplate
-from ecl.util import StringList
+from ecl.util.util import StringList
 
 
 class ErtTemplates(BaseCClass):

--- a/python/python/res/enkf/ert_workflow_list.py
+++ b/python/python/res/enkf/ert_workflow_list.py
@@ -1,6 +1,6 @@
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
-from ecl.util import StringList
+from ecl.util.util import StringList
 from res.util.substitution_list import SubstitutionList
 from res.job_queue import Workflow, WorkflowJob
 

--- a/python/python/res/enkf/export/arg_loader.py
+++ b/python/python/res/enkf/export/arg_loader.py
@@ -4,7 +4,7 @@ from pandas import DataFrame, MultiIndex
 import numpy
 from res.enkf import ErtImplType, EnKFMain, EnkfFs, RealizationStateEnum, GenKwConfig
 from res.enkf.plot_data import EnsemblePlotGenData
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 
 class ArgLoader(object):

--- a/python/python/res/enkf/export/gen_data_collector.py
+++ b/python/python/res/enkf/export/gen_data_collector.py
@@ -3,7 +3,7 @@ from pandas import DataFrame, MultiIndex
 import numpy
 from res.enkf import ErtImplType, EnKFMain, EnkfFs, RealizationStateEnum, GenKwConfig
 from res.enkf.plot_data import EnsemblePlotGenData
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 
 class GenDataCollector(object):

--- a/python/python/res/enkf/export/gen_kw_collector.py
+++ b/python/python/res/enkf/export/gen_kw_collector.py
@@ -4,7 +4,7 @@ import numpy
 from res.enkf import ErtImplType, EnKFMain, EnkfFs, RealizationStateEnum, GenKwConfig
 from res.enkf.key_manager import KeyManager
 from res.enkf.plot_data import EnsemblePlotGenKW
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 
 class GenKwCollector(object):

--- a/python/python/res/enkf/export/misfit_collector.py
+++ b/python/python/res/enkf/export/misfit_collector.py
@@ -2,7 +2,7 @@ from pandas import DataFrame
 import numpy
 from res.enkf import EnKFMain, EnkfFs, RealizationStateEnum
 from res.enkf.key_manager import KeyManager
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 
 class MisfitCollector(object):

--- a/python/python/res/enkf/export/summary_collector.py
+++ b/python/python/res/enkf/export/summary_collector.py
@@ -3,7 +3,7 @@ import numpy
 from res.enkf import ErtImplType, EnKFMain, EnkfFs, RealizationStateEnum
 from res.enkf.key_manager import KeyManager
 from res.enkf.plot_data import EnsemblePlotData
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 
 class SummaryCollector(object):

--- a/python/python/res/enkf/export/summary_observation_collector.py
+++ b/python/python/res/enkf/export/summary_observation_collector.py
@@ -3,7 +3,7 @@ import numpy
 from res.enkf import ErtImplType, EnKFMain, EnkfFs, RealizationStateEnum, EnkfObservationImplementationType
 from res.enkf.key_manager import KeyManager
 from res.enkf.plot_data import EnsemblePlotData
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 
 class SummaryObservationCollector(object):

--- a/python/python/res/enkf/meas_block.py
+++ b/python/python/res/enkf/meas_block.py
@@ -1,7 +1,7 @@
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
 from res.enkf.obs_data import ObsData
-from ecl.util import Matrix, IntVector , BoolVector
+from ecl.util.util import Matrix, IntVector , BoolVector
 
 
 class MeasBlock(BaseCClass):

--- a/python/python/res/enkf/meas_data.py
+++ b/python/python/res/enkf/meas_data.py
@@ -1,7 +1,7 @@
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
 from res.enkf.obs_data import ObsData
-from ecl.util import Matrix, IntVector
+from ecl.util.util import Matrix, IntVector
 
 
 class MeasData(BaseCClass):

--- a/python/python/res/enkf/obs_block.py
+++ b/python/python/res/enkf/obs_block.py
@@ -1,6 +1,6 @@
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
-from ecl.util import Matrix
+from ecl.util.util import Matrix
 
 
 class ObsBlock(BaseCClass):

--- a/python/python/res/enkf/obs_data.py
+++ b/python/python/res/enkf/obs_data.py
@@ -19,7 +19,7 @@ from __future__ import (absolute_import, division,
 
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
-from ecl.util import Matrix
+from ecl.util.util import Matrix
 
 
 class ObsData(BaseCClass):

--- a/python/python/res/enkf/observations/gen_observation.py
+++ b/python/python/res/enkf/observations/gen_observation.py
@@ -16,7 +16,7 @@
 import os.path
 
 from cwrap import BaseCClass
-from ecl.util import IntVector
+from ecl.util.util import IntVector
 from res.enkf import EnkfPrototype
 from res.enkf import GenDataConfig
 

--- a/python/python/res/enkf/plot/pca_fetcher.py
+++ b/python/python/res/enkf/plot/pca_fetcher.py
@@ -2,7 +2,7 @@ from res.enkf.plot import DataFetcher, ObservationGenDataFetcher, BlockObservati
 from res.enkf.plot_data import PcaPlotData
 from res.enkf.enums import RealizationStateEnum, EnkfObservationImplementationType
 from res.enkf import LocalObsdata, LocalObsdataNode, EnkfLinalg, MeasData, ObsData
-from ecl.util import Matrix, BoolVector, DoubleVector
+from ecl.util.util import Matrix, BoolVector, DoubleVector
 
 
 class PcaDataFetcher(DataFetcher):

--- a/python/python/res/enkf/plot_data/ensemble_plot_data.py
+++ b/python/python/res/enkf/plot_data/ensemble_plot_data.py
@@ -2,7 +2,7 @@ from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
 from res.enkf.config import EnkfConfigNode
 from res.enkf.enkf_fs import EnkfFs
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 
 class EnsemblePlotData(BaseCClass):

--- a/python/python/res/enkf/plot_data/ensemble_plot_data_vector.py
+++ b/python/python/res/enkf/plot_data/ensemble_plot_data_vector.py
@@ -1,6 +1,6 @@
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
-from ecl.util import CTime
+from ecl.util.util import CTime
 
 
 

--- a/python/python/res/enkf/plot_data/ensemble_plot_gen_data.py
+++ b/python/python/res/enkf/plot_data/ensemble_plot_gen_data.py
@@ -19,7 +19,7 @@ from res.enkf import EnkfPrototype
 from res.enkf.config import EnkfConfigNode
 from res.enkf.enkf_fs import EnkfFs
 from res.enkf.enums.ert_impl_type_enum import ErtImplType
-from ecl.util import BoolVector, DoubleVector
+from ecl.util.util import BoolVector, DoubleVector
 
 
 class EnsemblePlotGenData(BaseCClass):

--- a/python/python/res/enkf/plot_data/ensemble_plot_gen_kw.py
+++ b/python/python/res/enkf/plot_data/ensemble_plot_gen_kw.py
@@ -19,7 +19,7 @@ from res.enkf import EnkfPrototype
 from res.enkf.config import EnkfConfigNode
 from res.enkf.enkf_fs import EnkfFs
 from res.enkf.enums.ert_impl_type_enum import ErtImplType
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from res.enkf.plot_data import EnsemblePlotGenKWVector
 
 

--- a/python/python/res/enkf/plot_data/pca_plot_data.py
+++ b/python/python/res/enkf/plot_data/pca_plot_data.py
@@ -1,7 +1,7 @@
 from cwrap import BaseCClass
 
 from res.enkf import EnkfPrototype
-from ecl.util import Matrix
+from ecl.util.util import Matrix
 from res.enkf.plot_data import PcaPlotVector
 
 

--- a/python/python/res/enkf/plot_data/pca_plot_vector.py
+++ b/python/python/res/enkf/plot_data/pca_plot_vector.py
@@ -1,7 +1,7 @@
 from cwrap import BaseCClass
 
 from res.enkf import EnkfPrototype
-from ecl.util import Matrix
+from ecl.util.util import Matrix
 
 
 class PcaPlotVector(BaseCClass):

--- a/python/python/res/enkf/plot_data/plot_block_data.py
+++ b/python/python/res/enkf/plot_data/plot_block_data.py
@@ -1,5 +1,5 @@
 from res.enkf.plot_data import PlotBlockVector
-from ecl.util import DoubleVector
+from ecl.util.util import DoubleVector
 
 
 class PlotBlockData(object):

--- a/python/python/res/enkf/plot_data/plot_block_data_loader.py
+++ b/python/python/res/enkf/plot_data/plot_block_data_loader.py
@@ -1,6 +1,6 @@
 from res.enkf import RealizationStateEnum, EnkfNode, ErtImplType, NodeId
 from res.enkf.plot_data import PlotBlockData, PlotBlockVector
-from ecl.util import DoubleVector, BoolVector, ThreadPool
+from ecl.util.util import DoubleVector, BoolVector, ThreadPool
 
 
 class PlotBlockDataLoader(object):

--- a/python/python/res/enkf/plot_data/plot_block_vector.py
+++ b/python/python/res/enkf/plot_data/plot_block_vector.py
@@ -1,4 +1,4 @@
-from ecl.util import DoubleVector
+from ecl.util.util import DoubleVector
 
 
 class PlotBlockVector(object):

--- a/python/python/res/enkf/queue_config.py
+++ b/python/python/res/enkf/queue_config.py
@@ -16,7 +16,7 @@
 
 from cwrap import BaseCClass
 
-from ecl.util import StringList, Hash
+from ecl.util.util import StringList, Hash
 
 from res.enkf import EnkfPrototype
 from res.job_queue import JobQueue, ExtJoblist, Driver

--- a/python/python/res/enkf/res_config.py
+++ b/python/python/res/enkf/res_config.py
@@ -19,7 +19,7 @@ from os.path import isfile
 
 from cwrap import BaseCClass
 
-from ecl.util import StringList
+from ecl.util.util import StringList
 
 from res.config import (ConfigParser, ConfigContent, ConfigSettings,
                         UnrecognizedEnum)

--- a/python/python/res/enkf/site_config.py
+++ b/python/python/res/enkf/site_config.py
@@ -18,7 +18,7 @@ from os.path import isfile
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
 from res.job_queue import JobQueue, ExtJoblist
-from ecl.util import StringList, Hash
+from ecl.util.util import StringList, Hash
 
 
 class SiteConfig(BaseCClass):

--- a/python/python/res/enkf/state_map.py
+++ b/python/python/res/enkf/state_map.py
@@ -16,7 +16,7 @@
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
 from res.enkf.enums import RealizationStateEnum
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 
 class StateMap(BaseCClass):

--- a/python/python/res/enkf/summary_key_matcher.py
+++ b/python/python/res/enkf/summary_key_matcher.py
@@ -1,6 +1,6 @@
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
-from ecl.util import StringList
+from ecl.util.util import StringList
 
 
 class SummaryKeyMatcher(BaseCClass):

--- a/python/python/res/enkf/summary_key_set.py
+++ b/python/python/res/enkf/summary_key_set.py
@@ -1,6 +1,6 @@
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
-from ecl.util import StringList
+from ecl.util.util import StringList
 
 
 class SummaryKeySet(BaseCClass):

--- a/python/python/res/enkf/util/time_map.py
+++ b/python/python/res/enkf/util/time_map.py
@@ -18,7 +18,7 @@ import errno
 
 from cwrap import BaseCClass
 from res.enkf import EnkfPrototype
-from ecl.util import CTime
+from ecl.util.util import CTime
 
 
 class TimeMap(BaseCClass):

--- a/python/python/res/job_queue/ext_job.py
+++ b/python/python/res/job_queue/ext_job.py
@@ -17,7 +17,7 @@ import os.path
 
 from cwrap import BaseCClass
 from res.job_queue import QueuePrototype
-from ecl.util import StringList, Hash
+from ecl.util.util import StringList, Hash
 from res.config import ContentTypeEnum
 
 class ExtJob(BaseCClass):

--- a/python/python/res/job_queue/ext_joblist.py
+++ b/python/python/res/job_queue/ext_joblist.py
@@ -15,7 +15,7 @@
 #  for more details.
 from cwrap import BaseCClass
 from res.job_queue import QueuePrototype, ExtJob
-from ecl.util import StringList
+from ecl.util.util import StringList
 
 
 class ExtJoblist(BaseCClass):

--- a/python/python/res/job_queue/forward_model.py
+++ b/python/python/res/job_queue/forward_model.py
@@ -16,7 +16,7 @@
 from cwrap import BaseCClass
 from res.job_queue import ExtJob, QueuePrototype, ExtJoblist
 from res.job_queue import EnvironmentVarlist
-from ecl.util import StringList
+from ecl.util.util import StringList
 from res.util.substitution_list import SubstitutionList
 
 

--- a/python/python/res/job_queue/function_ert_script.py
+++ b/python/python/res/job_queue/function_ert_script.py
@@ -2,7 +2,7 @@ import ecl
 import cwrap
 
 from res.job_queue import ErtScript
-from ecl.util.stringlist import StringList
+from ecl.util.util.stringlist import StringList
 
 
 class _NonePrototype(cwrap.Prototype):

--- a/python/python/res/sched/sched_file.py
+++ b/python/python/res/sched/sched_file.py
@@ -17,7 +17,7 @@ import os.path
 
 from cwrap import BaseCClass
 from res.sched import SchedulePrototype
-from ecl.util import CTime
+from ecl.util.util import CTime
 
 
 class SchedFile(BaseCClass):

--- a/python/python/res/server/ertrpcserver.py
+++ b/python/python/res/server/ertrpcserver.py
@@ -12,7 +12,7 @@ except ImportError:
 import warnings
 from res.util import ResVersion
 from res.enkf import EnKFMain, NodeId, ResConfig
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from res.enkf.config import CustomKWConfig
 from res.enkf.data import EnkfNode, CustomKW
 from res.enkf.enums import RealizationStateEnum, EnkfVarType, ErtImplType

--- a/python/python/res/server/simulation_context.py
+++ b/python/python/res/server/simulation_context.py
@@ -1,4 +1,4 @@
-from ecl.util import ArgPack, CThreadPool,BoolVector
+from ecl.util.util import ArgPack, CThreadPool,BoolVector
 
 from res.job_queue import JobQueueManager
 

--- a/python/python/res/simulator/batch_simulator.py
+++ b/python/python/res/simulator/batch_simulator.py
@@ -1,4 +1,4 @@
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 from res.enkf import ResConfig, EnKFMain, EnkfConfigNode, EnkfNode, NodeId
 from .batch_simulator_context import BatchContext

--- a/python/python/res/util/res_version.py
+++ b/python/python/res/util/res_version.py
@@ -1,4 +1,4 @@
-from ecl.util import Version
+from ecl.util.util import Version
 from res.util import ResUtilPrototype
 
 class ResVersion(Version):

--- a/python/tests/res/analysis/test_analysis_module.py
+++ b/python/tests/res/analysis/test_analysis_module.py
@@ -19,9 +19,9 @@ from tests import ResTest
 from res.analysis import AnalysisModule, AnalysisModuleLoadStatusEnum, AnalysisModuleOptionsEnum
 
 from ecl.util.enums import RngAlgTypeEnum, RngInitModeEnum
-from ecl.util.rng import RandomNumberGenerator
+from ecl.util.util.rng import RandomNumberGenerator
 
-from ecl.util import Matrix
+from ecl.util.util import Matrix
 
 class AnalysisModuleTest(ResTest):
     def setUp(self):

--- a/python/tests/res/analysis/test_linalg.py
+++ b/python/tests/res/analysis/test_linalg.py
@@ -17,7 +17,7 @@
 
 
 from res.enkf import ObsVector
-from ecl.util import Matrix
+from ecl.util.util import Matrix
 from res.analysis import Linalg
 from tests import ResTest
 

--- a/python/tests/res/analysis/test_rml.py
+++ b/python/tests/res/analysis/test_rml.py
@@ -18,7 +18,7 @@ import random
 
 from tests import ResTest
 from ecl.util.enums import RngAlgTypeEnum, RngInitModeEnum
-from ecl.util import Matrix, BoolVector , RandomNumberGenerator
+from ecl.util.util import Matrix, BoolVector , RandomNumberGenerator
 from res.analysis import AnalysisModule, AnalysisModuleLoadStatusEnum, AnalysisModuleOptionsEnum
 from res.enkf import MeasData , ObsData
 

--- a/python/tests/res/analysis/test_std_enkf.py
+++ b/python/tests/res/analysis/test_std_enkf.py
@@ -18,7 +18,7 @@ from tests import ResTest
 from res.analysis import AnalysisModule, AnalysisModuleLoadStatusEnum, AnalysisModuleOptionsEnum
 
 from ecl.util.enums import RngAlgTypeEnum, RngInitModeEnum
-from ecl.util.rng import RandomNumberGenerator
+from ecl.util.util.rng import RandomNumberGenerator
 
 
 class StdEnKFTest(ResTest):

--- a/python/tests/res/analysis/test_std_enkf_debug.py
+++ b/python/tests/res/analysis/test_std_enkf_debug.py
@@ -19,7 +19,7 @@ from tests import ResTest
 from res.analysis import AnalysisModule, AnalysisModuleLoadStatusEnum, AnalysisModuleOptionsEnum
 from res.analysis import AnalysisPrototype
 from ecl.util.enums import RngAlgTypeEnum, RngInitModeEnum
-from ecl.util.rng import RandomNumberGenerator
+from ecl.util.util.rng import RandomNumberGenerator
 
 
 class StdEnKFDebugTest(ResTest):

--- a/python/tests/res/enkf/data/test_custom_kw.py
+++ b/python/tests/res/enkf/data/test_custom_kw.py
@@ -9,8 +9,8 @@ from res.enkf.export.custom_kw_collector import CustomKWCollector
 from res.test.ert_test_context import ErtTestContext
 from tests import ResTest
 from ecl.util.test.test_area import TestAreaContext
-from ecl.util import StringList
-from ecl.util import BoolVector
+from ecl.util.util import StringList
+from ecl.util.util import BoolVector
 
 class CustomKWTest(ResTest):
 

--- a/python/tests/res/enkf/data/test_gen_data.py
+++ b/python/tests/res/enkf/data/test_gen_data.py
@@ -1,5 +1,5 @@
 from tests import ResTest
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from res.test import ErtTestContext
 
 from res.enkf.data.enkf_node import EnkfNode

--- a/python/tests/res/enkf/data/test_gen_data_config.py
+++ b/python/tests/res/enkf/data/test_gen_data_config.py
@@ -1,5 +1,5 @@
 from tests import ResTest
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from res.test import ErtTestContext
 
 from res.enkf.data import EnkfNode

--- a/python/tests/res/enkf/plot/test_plot_data.py
+++ b/python/tests/res/enkf/plot/test_plot_data.py
@@ -2,7 +2,7 @@ from tests import ResTest
 from res.test import ErtTestContext
 
 from res.enkf.plot_data import PlotBlockData, PlotBlockDataLoader, PlotBlockVector
-from ecl.util import DoubleVector
+from ecl.util.util import DoubleVector
 
 
 class PlotDataTest(ResTest):

--- a/python/tests/res/enkf/test_custom_kw_config_set.py
+++ b/python/tests/res/enkf/test_custom_kw_config_set.py
@@ -7,7 +7,7 @@ from res.enkf import CustomKWConfigSet
 from res.enkf.config import CustomKWConfig
 from res.enkf.enkf_fs import EnkfFs
 from res.enkf.enkf_main import EnKFMain
-from ecl.util.stringlist import StringList
+from ecl.util.util.stringlist import StringList
 
 
 class CustomKWConfigSetTest(ResTest):

--- a/python/tests/res/enkf/test_enkf.py
+++ b/python/tests/res/enkf/test_enkf.py
@@ -18,7 +18,7 @@ import os.path
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 from res.enkf import (EnsembleConfig, AnalysisConfig, ModelConfig, SiteConfig,
                       EclConfig, PlotSettings, EnkfObs, ErtTemplates, EnkfFs,

--- a/python/tests/res/enkf/test_enkf_load_results_manually.py
+++ b/python/tests/res/enkf/test_enkf_load_results_manually.py
@@ -2,7 +2,7 @@ from tests import ResTest
 from res.test import ErtTestContext
 
 from res.enkf.enums.realization_state_enum import RealizationStateEnum
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 
 class LoadResultsManuallyTest(ResTest):

--- a/python/tests/res/enkf/test_enkf_obs.py
+++ b/python/tests/res/enkf/test_enkf_obs.py
@@ -5,7 +5,7 @@ from ecl.grid import EclGrid
 from ecl.summary import EclSum
 from res.sched import History
 
-from ecl.util import BoolVector,IntVector
+from ecl.util.util import BoolVector,IntVector
 from res.enkf import ActiveMode, EnsembleConfig
 from res.enkf import (ObsVector, LocalObsdata, EnkfObs, TimeMap,
                       LocalObsdataNode, ObsData, MeasData, ActiveList)

--- a/python/tests/res/enkf/test_enkf_runpath.py
+++ b/python/tests/res/enkf/test_enkf_runpath.py
@@ -17,7 +17,7 @@
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 from res.enkf import (EnsembleConfig, AnalysisConfig, ModelConfig, SiteConfig,
                       EclConfig, PlotSettings, EnkfObs, ErtTemplates, EnkfFs,

--- a/python/tests/res/enkf/test_enkf_sim_model.py
+++ b/python/tests/res/enkf/test_enkf_sim_model.py
@@ -21,7 +21,7 @@ import subprocess
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 from res.job_queue import ExtJob
 

--- a/python/tests/res/enkf/test_enkf_transfer_env.py
+++ b/python/tests/res/enkf/test_enkf_transfer_env.py
@@ -21,7 +21,7 @@ import subprocess
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 from res.enkf import (EnsembleConfig, AnalysisConfig, ModelConfig, SiteConfig,
                       EclConfig, PlotSettings, EnkfObs, ErtTemplates, EnkfFs,

--- a/python/tests/res/enkf/test_ensemble_config.py
+++ b/python/tests/res/enkf/test_ensemble_config.py
@@ -1,7 +1,7 @@
 from tests import ResTest
 from res.test import ErtTestContext
 
-from ecl.util import BoolVector,IntVector
+from ecl.util.util import BoolVector,IntVector
 from res.enkf import ActiveMode, EnsembleConfig
 from res.enkf import ObsVector , LocalObsdata
 

--- a/python/tests/res/enkf/test_field_export.py
+++ b/python/tests/res/enkf/test_field_export.py
@@ -2,7 +2,7 @@ import os
 from tests import ResTest
 from res.test import ErtTestContext
 
-from ecl.util import IntVector
+from ecl.util.util import IntVector
 from ecl.grid import EclGrid
 
 from res.enkf.config import FieldTypeEnum, FieldConfig

--- a/python/tests/res/enkf/test_meas_block.py
+++ b/python/tests/res/enkf/test_meas_block.py
@@ -2,7 +2,7 @@ import datetime
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from res.enkf import MeasBlock
 
 

--- a/python/tests/res/enkf/test_meas_data.py
+++ b/python/tests/res/enkf/test_meas_data.py
@@ -1,6 +1,6 @@
 import datetime
 
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from ecl.util.test import TestAreaContext
 from tests import ResTest
 from res.enkf import MeasBlock, MeasData

--- a/python/tests/res/enkf/test_obs_block.py
+++ b/python/tests/res/enkf/test_obs_block.py
@@ -1,6 +1,6 @@
 import datetime
 
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from ecl.util.test import TestAreaContext
 from tests import ResTest
 from res.enkf import ObsBlock

--- a/python/tests/res/enkf/test_obs_data.py
+++ b/python/tests/res/enkf/test_obs_data.py
@@ -1,6 +1,6 @@
 import datetime
 
-from ecl.util import BoolVector, Matrix
+from ecl.util.util import BoolVector, Matrix
 from ecl.util.test import TestAreaContext
 from tests import ResTest
 from res.enkf import ObsData, ObsBlock

--- a/python/tests/res/enkf/test_res_config.py
+++ b/python/tests/res/enkf/test_res_config.py
@@ -19,7 +19,7 @@ from datetime import date
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
-from ecl.util import CTime
+from ecl.util.util import CTime
 from ecl.util.enums import RngAlgTypeEnum
 from res.util.enums import MessageLevelEnum
 

--- a/python/tests/res/enkf/test_run_context.py
+++ b/python/tests/res/enkf/test_run_context.py
@@ -1,4 +1,4 @@
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from res.util.substitution_list import SubstitutionList
 from ecl.util.test import TestAreaContext
 from tests import ResTest

--- a/python/tests/res/enkf/test_runpath_list.py
+++ b/python/tests/res/enkf/test_runpath_list.py
@@ -7,7 +7,7 @@ from res.test import ErtTestContext
 
 from res.enkf import RunpathList, RunpathNode, ErtRunContext
 from res.enkf.enums import EnkfInitModeEnum,EnkfRunType
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from res.util.substitution_list import SubstitutionList
 
 

--- a/python/tests/res/enkf/test_runpath_list_dump.py
+++ b/python/tests/res/enkf/test_runpath_list_dump.py
@@ -4,7 +4,7 @@ from ecl.util.test import TestAreaContext
 from tests import ResTest
 from res.test import ErtTestContext
 
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 from res.enkf import ResConfig, EnKFMain, EnkfFs, ErtRunContext
 from res.enkf.enums import EnKFFSType, EnkfRunType

--- a/python/tests/res/enkf/test_simulation_batch.py
+++ b/python/tests/res/enkf/test_simulation_batch.py
@@ -2,7 +2,7 @@ import os
 import sys
 from ecl.util.test import TestAreaContext
 from tests import ResTest
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 from res.test import ErtTestContext
 from res.enkf import EnkfFs, EnkfConfigNode, NodeId, EnkfNode

--- a/python/tests/res/job_queue/test_forward_model_formatted_print.py
+++ b/python/tests/res/job_queue/test_forward_model_formatted_print.py
@@ -2,7 +2,7 @@ import os.path
 import json
 
 from ecl.util.test import TestAreaContext
-from ecl.util import EclVersion, Version
+from ecl.util.util import EclVersion, Version
 from tests import ResTest
 from res.util.substitution_list import SubstitutionList
 from res.job_queue.environment_varlist import EnvironmentVarlist

--- a/python/tests/res/server/test_rpc_storage.py
+++ b/python/tests/res/server/test_rpc_storage.py
@@ -5,7 +5,7 @@ import sys
 import time
 
 from tests import ResTest
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 from res.enkf.enums import ErtImplType, EnkfRunType
 from res.enkf.export.custom_kw_collector import CustomKWCollector
 from res.server import ErtRPCClient

--- a/python/tests/res/server/test_simulation_context.py
+++ b/python/tests/res/server/test_simulation_context.py
@@ -2,7 +2,7 @@ import time
 import os.path
 import sys
 from tests import ResTest
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 from res.test import ErtTestContext
 from res.enkf import EnkfVarType

--- a/share/workflows/jobs/internal-gui/scripts/export_misfit_data.py
+++ b/share/workflows/jobs/internal-gui/scripts/export_misfit_data.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import os
 from res.enkf import ErtScript, RealizationStateEnum
-from ecl.util import BoolVector
+from ecl.util.util import BoolVector
 
 """
 This job exports misfit data into a chosen file or to the default gen_kw export file (parameters.txt)


### PR DESCRIPTION
**Task**
As part of the trask concerning libecl issue no. 27, a new subpackage ecl.util.util has been created into which the functional files from ecl.util has been moved.


**Approach**
Import statements changed to comply.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#324
* Statoil/ert#94
