### PR TITLE
Use bind=False when wrapping ResVersion class.

### DIFF
--- a/python/python/res/util/res_version.py
+++ b/python/python/res/util/res_version.py
@@ -2,12 +2,12 @@ from ecl.util import Version
 from res.util import ResUtilPrototype
 
 class ResVersion(Version):
-    _build_time = ResUtilPrototype("char* res_version_get_build_time()")
-    _git_commit = ResUtilPrototype("char* res_version_get_git_commit()")
-    _major_version = ResUtilPrototype("int res_version_get_major_version()")
-    _minor_version = ResUtilPrototype("int res_version_get_minor_version()")
-    _micro_version = ResUtilPrototype("char* res_version_get_micro_version()")
-    _is_devel = ResUtilPrototype("bool res_version_is_devel_version()")
+    _build_time = ResUtilPrototype("char* res_version_get_build_time()", bind = False)
+    _git_commit = ResUtilPrototype("char* res_version_get_git_commit()", bind = False)
+    _major_version = ResUtilPrototype("int res_version_get_major_version()", bind = False)
+    _minor_version = ResUtilPrototype("int res_version_get_minor_version()", bind = False)
+    _micro_version = ResUtilPrototype("char* res_version_get_micro_version()", bind = False)
+    _is_devel = ResUtilPrototype("bool res_version_is_devel_version()", bind = False)
 
     def __init__(self):
         major = self._major_version( )


### PR DESCRIPTION
After major overhaul to make cwrap Python3 compatible some old prototypes now require an explicit bind = False; don't really understand how it worked before?


**Depends on**
* Statoil/libecl#326
