### PR TITLE
Remove circular dependencies from EnKFMain

### DIFF
--- a/python/python/res/enkf/enkf_main.py
+++ b/python/python/res/enkf/enkf_main.py
@@ -74,11 +74,6 @@ class EnKFMain(BaseCClass):
             parent=real_enkf_main,
             is_reference=True)
 
-#         if config is None:
-#             self.__simulation_runner = None
-#             self.__fs_manager = None
-#             self.__es_update = None
-#         else:
         self.__simulation_runner = EnkfSimulationRunner(self)
         self.__fs_manager = EnkfFsManager(self)
         self.__es_update = ESUpdate(self)

--- a/python/python/res/enkf/enkf_main.py
+++ b/python/python/res/enkf/enkf_main.py
@@ -135,12 +135,30 @@ class _RealEnKFMain(BaseCClass):
     - EnKFMain: main entry point, defined further down
     - EnkfSimulationRunner, EnkfFsManager and ESUpdate: access specific
       functionalities
-
     EnKFMain owns an instance of each of the last 3 classes. Also, all
     of these classes need to access the same underlying C object.
     So, in order to avoid circular dependencies, we make _RealEnKF main
     the only "owner" of the C object, and all the classes that need to
     access it set _RealEnKFMain as parent.
+    
+    The situation can be summarized as follows (show only EnkfFSManager,
+    classes EnkfSimulationRunner and ESUpdate are treated analogously)
+     ------------------------------------
+    |   real EnKFMain object in memory   |
+     ------------------------------------
+          ^                 ^          ^
+          |                 |          |
+       (c_ptr)           (c_ptr)       |
+          |                 |          |
+    _RealEnKFMain           |          |
+       ^   ^                |          |
+       |   ^--(parent)-- EnKFMain      |
+       |                    |          |
+       |                  (owns)       |
+    (parent)                |       (c_ptr)
+       |                    v          |
+        ------------ EnkfFSManager ----
+    
     """
 
     _alloc = EnkfPrototype("void* enkf_main_alloc(res_config, bool, bool)", bind = False)

--- a/python/python/res/enkf/enkf_simulation_runner.py
+++ b/python/python/res/enkf/enkf_simulation_runner.py
@@ -1,8 +1,8 @@
 from cwrap import BaseCClass
+from ecl.util.util import BoolVector
 from res.enkf import EnkfFs
 from res.enkf import EnkfPrototype, ErtRunContext
 from res.enkf.enums import EnkfInitModeEnum
-from ecl.util.util import BoolVector
 
 
 class EnkfSimulationRunner(BaseCClass):
@@ -13,9 +13,15 @@ class EnkfSimulationRunner(BaseCClass):
 
     def __init__(self, enkf_main):
         assert isinstance(enkf_main, BaseCClass)
-        super(EnkfSimulationRunner, self).__init__(enkf_main.from_param(enkf_main).value, parent=enkf_main, is_reference=True)
-        self.ert = enkf_main
-        """:type: res.enkf.EnKFMain """
+        # enkf_main should be an EnKFMain, get the _RealEnKFMain object
+        real_enkf_main = enkf_main.parent()
+        super(EnkfSimulationRunner, self).__init__(
+            real_enkf_main.from_param(real_enkf_main).value ,
+            parent=real_enkf_main ,
+            is_reference=True)
+
+    def _enkf_main(self):
+        return self.parent()
 
     def runSimpleStep(self, job_queue, run_context):
         """ @rtype: int """
@@ -32,5 +38,5 @@ class EnkfSimulationRunner(BaseCClass):
 
     def runWorkflows(self , runtime):
         """:type res.enkf.enum.HookRuntimeEnum"""
-        hook_manager = self.ert.getHookManager()
-        hook_manager.runWorkflows( runtime  , self.ert )
+        hook_manager = self._enkf_main().getHookManager()
+        hook_manager.runWorkflows(runtime  , self._enkf_main())

--- a/python/python/res/enkf/es_update.py
+++ b/python/python/res/enkf/es_update.py
@@ -5,31 +5,35 @@ class ESUpdate(BaseCClass):
     TYPE_NAME="es_update"
     _smoother_update = EnkfPrototype("bool enkf_main_smoother_update(es_update, enkf_fs, enkf_fs)")
 
-    def __init__(self , ert):
-        assert isinstance(ert , BaseCClass)
-        super(ESUpdate, self).__init__(ert.from_param(ert).value , parent=ert , is_reference=True)
-        self.ert = ert
-        self.analysis_config = self.ert.analysisConfig( )
+    def __init__(self , enkf_main):
+        assert isinstance(enkf_main , BaseCClass)
 
+        # enkf_main should be an EnKFMain, get the _RealEnKFMain object
+        real_enkf_main = enkf_main.parent()
+
+        super(ESUpdate, self).__init__(
+            real_enkf_main.from_param(real_enkf_main).value ,
+            parent=real_enkf_main ,
+            is_reference=True)
+
+    def _analysis_config(self):
+        return self.parent().analysisConfig()
 
     def hasModule(self, name):
         """
         Will check if we have analysis module @name.
         """
-        return self.analysis_config.hasModule( name )
-
+        return self._analysis_config().hasModule(name)
 
     def getModule(self,name):
         if self.hasModule( name ):
-            self.analysis_config.getModule( name )
+            self._analysis_config().getModule(name)
         else:
             raise KeyError("No such module:%s " % name)
 
 
     def setGlobalStdScaling(self , weight):
-        self.analysis_config.setGlobalStdScaling( weight )
-
-
+        self._analysis_config().setGlobalStdScaling(weight)
 
     def smootherUpdate( self , run_context):
         data_fs   = run_context.get_sim_fs( )

--- a/python/tests/res/enkf/test_enkf.py
+++ b/python/tests/res/enkf/test_enkf.py
@@ -15,11 +15,9 @@
 #  for more details.
 
 import os.path
-
-from ecl.util.test import TestAreaContext
 from tests import ResTest
-from ecl.util.util import BoolVector
 
+from ecl.util.util import BoolVector
 from res.enkf import (EnsembleConfig, AnalysisConfig, ModelConfig, SiteConfig,
                       EclConfig, PlotSettings, EnkfObs, ErtTemplates, EnkfFs,
                       EnKFState, EnkfVarType, ObsVector, RunArg, ResConfig)
@@ -30,6 +28,7 @@ from res.enkf.enums import (EnkfObservationImplementationType, LoadFailTypeEnum,
                             EnkfRunType, EnkfFieldFileFormatEnum,
                             EnkfTruncationType, ActiveMode)
 
+from ecl.util.test import TestAreaContext
 from res.enkf.observations.summary_observation import SummaryObservation
 
 
@@ -46,7 +45,6 @@ class EnKFTest(ResTest):
             main = EnKFMain(res_config)
             pfx = 'EnKFMain(ensemble_size'
             self.assertEqual(pfx, repr(main)[:len(pfx)])
-            main.free()
 
     def test_bootstrap( self ):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
@@ -54,7 +52,6 @@ class EnKFTest(ResTest):
             res_config = ResConfig("simple_config/minimum_config")
             main = EnKFMain(res_config)
             self.assertTrue(main, "Load failed")
-            main.free()
 
     def test_site_condif(self):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
@@ -158,10 +155,6 @@ class EnKFTest(ResTest):
                 self.assertEqual(summary_key, summary_observation_node.getSummaryKey())
 
 
-            main.free()
-
-
-
     def test_config( self ):
         with TestAreaContext("enkf_test") as work_area:
             work_area.copy_directory(self.case_directory)
@@ -185,8 +178,6 @@ class EnKFTest(ResTest):
             self.assertIsInstance(main.getMemberRunningState(0), EnKFState)
 
             self.assertEqual( "simple_config/Ensemble" , main.getMountPoint())
-
-            main.free()
 
     def test_enkf_create_config_file(self):
         config_file      = "test_new_config"

--- a/python/tests/res/enkf/test_enkf_library.py
+++ b/python/tests/res/enkf/test_enkf_library.py
@@ -1,13 +1,13 @@
 import os
-from ecl.util.test import TestAreaContext
+
 from tests import ResTest
 
 from ecl.summary import EclSum
+from ecl.util.test import TestAreaContext
 from res.enkf import AnalysisConfig, EclConfig, GenKwConfig, EnkfConfigNode, SiteConfig, ObsVector
-from res.enkf import GenDataConfig, FieldConfig, EnkfFs, EnkfObs, EnKFState, EnsembleConfig
-from res.enkf import ErtTemplate, ErtTemplates, LocalConfig, ModelConfig
 from res.enkf import EnKFMain, ResConfig
-
+from res.enkf import ErtTemplate, ErtTemplates, LocalConfig, ModelConfig
+from res.enkf import GenDataConfig, FieldConfig, EnkfFs, EnkfObs, EnKFState, EnsembleConfig
 from res.enkf.util import TimeMap
 
 
@@ -41,7 +41,4 @@ class EnKFLibraryTest(ResTest):
             self.assertEqual(file_system.getCaseName(), "default")
             time_map = file_system.getTimeMap()
             self.assertIsInstance(time_map, TimeMap)
-
-            main.free()
-
 


### PR DESCRIPTION
`EnKFMain` owned instances of `EnkfFSManager`, `ESUpdate` and `EnkfSimulationRunnner`. And each of these instances referred back to `EnKFMain` as `BaseCClass.__parent`, ie:
```
    -----------------------------------
   |   real EnKFMain object in memory  |
    -----------------------------------
       ^                        ^
       |                        |
    (c_ptr)                  (c_ptr)
       |                        |
       |                        |
    EnKFMain ----(owns)------v  |
          ^                  v  |
          ^----(parent)-----EnkfFSManager
```

Now EnKFMain has been split in two classes, and the dependency structure is as follows:
```
    ------------------------------------
   |   real EnKFMain object in memory   |
    ------------------------------------
       ^                ^           ^
       |                |           |
    (c_ptr)          (c_ptr)        |
       |                |           |
  _RealEnKFMain         |           |
    ^  ^                |           |
    |  ^--(parent)-- EnkfFSManager  |
    |                   ^           |
  (parent)              |           |
    |                   |           |
  EnKFMain ----(owns)---            |
         ------------------(c_ptr)--
 ```
The code has been also modified so that the wrapped types `enkf_main`, `enkf_main_ref`, `enkf_main_obj` are mapped to the python class `EnKFMain` instead of `_RealEnKFMain`


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps


Statoil/ert#99
