### PR TITLE
Added start_callback callable to the BatchSimulator

### DIFF
--- a/python/python/res/simulator/batch_simulator.py
+++ b/python/python/res/simulator/batch_simulator.py
@@ -87,7 +87,7 @@ class BatchSimulator(object):
                 node.save(file_system, node_id)
 
 
-    def start(self, case_name, case_data):
+    def start(self, case_name, case_data, callback=None):
         """Will start batch simulation, returning a handle to query status and results.
 
         The start method will submit simulations to the queue system and then
@@ -136,6 +136,18 @@ class BatchSimulator(object):
         Observe that only one BatchSimulator should actually be running at a
         time, so when you have called the 'start' method you need to let that
         batch complete before you start a new batch.
+
+        The optional argument callback can be used to provide a callable
+        which will be called as:
+
+              callback(run_context)
+
+        When the simulator has started. For the callable passed as callback you
+        are encouraged to use the future proof signature:
+
+             def callback(*args, **kwargs):
+                 ....
+
         """
 
         self.ert.addDataKW("<CASE_NAME>", _slug(case_name))
@@ -153,4 +165,6 @@ class BatchSimulator(object):
         for sim_id, (geo_id, _) in enumerate(case_data):
             sim_context.addSimulation(sim_id, geo_id)
 
+        if callback:
+            callback(sim_context)
         return sim_context


### PR DESCRIPTION
**Task**
Add (optional) callable argument to the batch simulator which can be used to pass simulation context elsewhere.




**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
