### PR TITLE
Fix batch simulator job check

### DIFF
--- a/python/python/res/simulator/batch_simulator_context.py
+++ b/python/python/res/simulator/batch_simulator_context.py
@@ -78,7 +78,7 @@ class BatchContext(SimulationContext):
         nodes = [ EnkfNode(self.res_config.ensemble_config[key]) for key in self.result_keys ]
         for sim_id in range(len(self)):
             node_id = NodeId( 0, sim_id)
-            if not self._queue_manager.didJobSucceed(sim_id):
+            if not self.didRealizationSucceed(sim_id):
                 logging.error('Simulation %d (node %s) failed.' % (sim_id, str(node_id)))
                 res.append(None)
                 continue


### PR DESCRIPTION
**Task**
_`BatchSimulator` mistakenly reported that simulations succeed/failed._


**Approach**
_The implementation was passing the `sim_id` to the queue to get the information, while the queue expects the `queue_idx` instead. Used the function from `SimulationContext` wrapping this logic._


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
