### PR TITLE
Inline stringlist buffer functions

### DIFF
--- a/libconfig/include/ert/config/conf.h
+++ b/libconfig/include/ert/config/conf.h
@@ -326,6 +326,9 @@ time_t conf_instance_get_item_value_time_t(
   const conf_instance_type * conf_instance,
   const char               * item_name);
 
+bool conf_instance_get_path_error(
+  const conf_instance_type * conf_instance);
+
 /** V A L I D A T O R S */
 
 

--- a/libconfig/src/conf_util.c
+++ b/libconfig/src/conf_util.c
@@ -18,6 +18,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <ert/util/util.h>
 #include <ert/util/parser.h>

--- a/libconfig/src/conf_util.c
+++ b/libconfig/src/conf_util.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'conf_util.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'conf_util.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <assert.h>
@@ -85,7 +85,7 @@ char * conf_util_fscanf_alloc_token_buffer(
   of the next token in the string. Furthermore, the position in the string is
   moved to the position after the token. Strings inside quotations " and ' are
   treated as one token, and the quotations removed.
-  
+
   Note: Quoted strings with no content, e.g. "   "  are NOT considered as tokens!
 
 */
@@ -153,7 +153,7 @@ char * conf_util_alloc_next_token(
   memmove(token, *buff_pos, len_token);
   token[len_token] = '\0';
   *buff_pos += len_token;
-  
+
   if(quoted)
     *buff_pos += 1;
 

--- a/libconfig/src/config_content_node.c
+++ b/libconfig/src/config_content_node.c
@@ -17,6 +17,7 @@
 */
 
 #include <stdbool.h>
+#include <string.h>
 
 #include <ert/util/type_macros.h>
 #include <ert/util/util.h>

--- a/libconfig/src/config_error.c
+++ b/libconfig/src/config_error.c
@@ -16,6 +16,7 @@
    for more details.
 */
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <ert/util/util.h>
 #include <ert/util/stringlist.h>

--- a/libenkf/src/custom_kw.c
+++ b/libenkf/src/custom_kw.c
@@ -104,12 +104,18 @@ bool custom_kw_forward_load(custom_kw_type * custom_kw, const char * ecl_file, c
 }
 
 bool custom_kw_write_to_buffer(const custom_kw_type * custom_kw, buffer_type * buffer, int report_step) {
-  stringlist_buffer_fwrite(custom_kw->data, buffer);
+  int size = stringlist_get_size(custom_kw->data);
+  buffer_fwrite_int(buffer, size);
+  for (int i=0; i < size; i++)
+    buffer_fwrite_string(buffer, stringlist_iget(custom_kw->data, i));
   return true;
 }
 
 void custom_kw_read_from_buffer(const custom_kw_type * custom_kw, buffer_type * buffer, enkf_fs_type * fs, int report_step) {
-    stringlist_buffer_fread(custom_kw->data, buffer);
+  int size = buffer_fread_int(buffer);
+  stringlist_clear(custom_kw->data);
+  for (int i=0; i < size; i++)
+    stringlist_append_owned_ref(custom_kw->data, buffer_fread_alloc_string(buffer));
 }
 
 

--- a/libenkf/src/enkf_obs.c
+++ b/libenkf/src/enkf_obs.c
@@ -729,7 +729,7 @@ static void handle_general_observation(enkf_obs_type * enkf_obs,
 }
 
 
-static enkf_obs_reinterpret_DT_FILE(const char * config_file) {
+static void enkf_obs_reinterpret_DT_FILE(const char * config_file) {
   fprintf(stderr,"**********************************************************************\n");
   fprintf(stderr,"* In ert version 2.3 we have changed how filepaths are interpreted   *\n");
   fprintf(stderr,"* in the observation file. When using the keywords OBS_FILE,         *\n");

--- a/libenkf/src/misfit_ts.c
+++ b/libenkf/src/misfit_ts.c
@@ -16,6 +16,7 @@
    for more details.
 */
 
+#include <stdlib.h>
 
 #include <ert/util/util.h>
 #include <ert/util/type_macros.h>

--- a/libenkf/src/misfit_ts.c
+++ b/libenkf/src/misfit_ts.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2012  Statoil ASA, Norway. 
-    
-   The file 'misfit_ts.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2012  Statoil ASA, Norway.
+
+   The file 'misfit_ts.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 
@@ -35,9 +35,9 @@ struct misfit_ts_struct {
 static UTIL_SAFE_CAST_FUNCTION(misfit_ts , MISFIT_TS_TYPE_ID);
 
 /******************************************************************/
-/* 
+/*
    Implementation of the misfit_ts type. Contains the full
-   timeseries of misfit for one member/one observation key. 
+   timeseries of misfit for one member/one observation key.
 */
 
 misfit_ts_type * misfit_ts_alloc(int history_length) {
@@ -94,7 +94,7 @@ double misfit_ts_eval( const misfit_ts_type * vector , const int_vector_type * s
     step = int_vector_iget(steps, i);
     misfit_sum += double_vector_iget(vector->data , step );
   }
-  
+
   return misfit_sum;
 }
 

--- a/libenkf/src/rng_manager.c
+++ b/libenkf/src/rng_manager.c
@@ -17,6 +17,7 @@
 */
 
 #include <stdlib.h>
+#include <string.h>
 
 #include <ert/util/rng.h>
 #include <ert/util/vector.h>

--- a/libenkf/src/runpath_list.c
+++ b/libenkf/src/runpath_list.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <string.h>
 #include <pthread.h>
 
 #include <ert/util/vector.h>

--- a/libjob_queue/src/queue_driver.c
+++ b/libjob_queue/src/queue_driver.c
@@ -18,6 +18,7 @@
 
 #include <stdlib.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include <ert/util/util.h>
 

--- a/libjob_queue/tests/job_lsf_exclude_hosts_test.c
+++ b/libjob_queue/tests/job_lsf_exclude_hosts_test.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <unistd.h>
+#include <string.h>
 
 #include <assert.h>
 #include <ert/util/util.h>

--- a/libres_util/include/ert/res_util/subst_list.h
+++ b/libres_util/include/ert/res_util/subst_list.h
@@ -26,7 +26,7 @@ extern "C" {
 #include <stdbool.h>
 
 #include <ert/util/type_macros.h>
-
+#include <ert/util/buffer.h>
 #include <ert/res_util/subst_func.h>
 
   typedef struct          subst_list_struct subst_list_type;

--- a/libres_util/src/ui_return.c
+++ b/libres_util/src/ui_return.c
@@ -22,11 +22,13 @@
    for more details.
 */
 #include <stdlib.h>
+#include <string.h>
 
+#include <ert/util/stringlist.h>
 #include <ert/util/type_macros.h>
 #include <ert/util/util.h>
+
 #include <ert/res_util/ui_return.h>
-#include <ert/util/stringlist.h>
 
 
 #define UI_RETURN_TYPE_ID 6122209


### PR DESCRIPTION
Functions to read and write stringlist from buffer have been removed from libecl. Implementing inline here.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#352
