### PR TITLE
Callback argument moved from start method to __init__

### DIFF
--- a/python/tests/res/simulator/test_batch_sim.py
+++ b/python/tests/res/simulator/test_batch_sim.py
@@ -145,13 +145,14 @@ class BatchSimulatorTest(ResTest):
             test_area.copy_parent_content(config_file)
 
             res_config = ResConfig(user_config_file=os.path.basename(config_file))
-
+            monitor = TestMonitor()
             rsim = BatchSimulator(res_config,
                                   {
                                       "WELL_ORDER" : ["W1", "W2", "W3"],
                                       "WELL_ON_OFF" : ["W1", "W2", "W3"]
                                   },
-                                  ["ORDER", "ON_OFF"])
+                                  ["ORDER", "ON_OFF"],
+                                  callback=partial(TestMonitor.start_callback, monitor)) 
 
             # Starting a simulation which should actually run through.
             case_data = [
@@ -167,8 +168,7 @@ class BatchSimulatorTest(ResTest):
                  }),
             ]
 
-            monitor = TestMonitor()
-            ctx = rsim.start("case", case_data, callback=partial(TestMonitor.start_callback, monitor))
+            ctx = rsim.start("case", case_data)
 
             # Asking for results before it is complete.
             with self.assertRaises(RuntimeError):


### PR DESCRIPTION
**Task**
Moved the callback argument from  `BatchSimulator.start()` to `BatchSimulator.__init__()`. Actually having it on the `start()` method feels better, but due to the usage in the everest <-> seba <-> libres triangle moving it to the `__init__()` seems simpler. 

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

