### PR TITLE
Add util env

### DIFF
--- a/applications/job_queue/block_node.c
+++ b/applications/job_queue/block_node.c
@@ -25,6 +25,7 @@
 #include <ert/util/util.h>
 #include <ert/util/hash.h>
 #include <ert/util/vector.h>
+#include <ert/res_util/res_env.h>
 
 #include <ert/job_queue/lsf_driver.h>
 

--- a/libconfig/src/conf_util.c
+++ b/libconfig/src/conf_util.c
@@ -17,6 +17,7 @@
 */
 
 #include <assert.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdlib.h>
 

--- a/libconfig/src/config_content_node.c
+++ b/libconfig/src/config_content_node.c
@@ -23,6 +23,8 @@
 #include <ert/util/util.h>
 #include <ert/util/stringlist.h>
 
+#include <ert/res_util/res_env.h>
+
 #include <ert/config/config_schema_item.h>
 #include <ert/config/config_content_node.h>
 #include <ert/config/config_path_elm.h>
@@ -199,7 +201,7 @@ const char * config_content_node_iget_as_executable( config_content_node_type * 
 
     if( !strstr( config_value, UTIL_PATH_SEP_STRING )
      && !util_file_exists( path_value ) ) {
-        char* tmp = util_alloc_PATH_executable( config_value );
+        char* tmp = res_env_alloc_PATH_executable( config_value );
         if( tmp ) {
             free( path_value );
             path_value = tmp;

--- a/libconfig/src/config_parser.c
+++ b/libconfig/src/config_parser.c
@@ -30,6 +30,7 @@
 #include <ert/util/vector.h>
 #include <ert/util/path_stack.h>
 #include <ert/res_util/subst_list.h>
+#include <ert/res_util/res_env.h>
 
 #include <ert/config/config_parser.h>
 #include <ert/config/config_error.h>
@@ -193,7 +194,7 @@ static config_content_node_type * config_content_item_set_arg__(subst_list_type 
       for (iarg = 0; iarg < argc; iarg++) {
         int    env_offset = 0;
         while (true) {
-          char * env_var = util_isscanf_alloc_envvar(  stringlist_iget(token_list , iarg + 1) , env_offset );
+          char * env_var = res_env_isscanf_alloc_envvar(  stringlist_iget(token_list , iarg + 1) , env_offset );
           if (env_var == NULL)
             break;
 

--- a/libconfig/src/config_schema_item.c
+++ b/libconfig/src/config_schema_item.c
@@ -29,6 +29,7 @@
 #include <ert/util/set.h>
 #include <ert/util/vector.h>
 #include <ert/res_util/subst_list.h>
+#include <ert/res_util/res_env.h>
 
 #include <ert/config/config_error.h>
 #include <ert/config/config_schema_item.h>
@@ -404,7 +405,7 @@ bool config_schema_item_validate_set(const config_schema_item_type * item , stri
                * util_alloc_PATH_executable aborts if some parts of the path is
                * not an existing dir, so call it only when its an absolute path
                */
-              char * path_exe  = util_alloc_PATH_executable( value );
+              char * path_exe  = res_env_alloc_PATH_executable( value );
               if (path_exe != NULL)
                 stringlist_iset_copy( token_list , iarg , path_exe);
               else

--- a/libenkf/src/site_config.c
+++ b/libenkf/src/site_config.c
@@ -40,6 +40,8 @@
 #include <ert/config/config_content_node.h>
 #include <ert/config/config_schema_item.h>
 
+#include <ert/res_util/res_env.h>
+
 #include <ert/enkf/site_config.h>
 #include <ert/enkf/queue_config.h>
 #include <ert/enkf/enkf_defaults.h>
@@ -344,9 +346,9 @@ void site_config_clear_pathvar(site_config_type * site_config) {
       const char * site_value = hash_get(site_config->path_variables_site, var);
 
       if (site_value == NULL)
-        util_unsetenv(var);
+        res_env_unsetenv(var);
       else
-        util_setenv(var, site_value);
+        res_env_setenv(var, site_value);
     }
   }
 }
@@ -361,7 +363,7 @@ void site_config_update_pathvar(site_config_type * site_config, const char * pat
                                                                               site_config. We store a NULL, so can roll back
                                                                               (i.e. call unsetenv()). */
   }
-  util_update_path_var(pathvar, value, false);
+  res_env_update_path_var(pathvar, value, false);
 }
 
 /*****************************************************************/

--- a/libjob_queue/src/environment_varlist.c
+++ b/libjob_queue/src/environment_varlist.c
@@ -18,7 +18,8 @@
 
 #include <ert/job_queue/environment_varlist.h>
 
-#include <ert/util/util_env.h>
+#include <ert/res_util/res_env.h>
+
 #include <ert/util/hash.h>
 
 #define ENV_VAR_KEY_STRING     "global_environment"
@@ -37,11 +38,11 @@ env_varlist_type * env_varlist_alloc() {
 }
 
 void env_varlist_update_path(env_varlist_type * list, const char * path_var, const char * new_path)  {
-  hash_insert_string( list->updatelist, path_var , util_update_path_var( path_var , new_path , false));
+  hash_insert_string( list->updatelist, path_var , res_env_update_path_var( path_var , new_path , false));
 }
 
 void env_varlist_setenv(env_varlist_type * list, const char * key, const char * value) {
-  const char * interp_value = util_interp_setenv(key, value);
+  const char * interp_value = res_env_interp_setenv(key, value);
   hash_insert_string(list->varlist, key, interp_value);
 }
 

--- a/libjob_queue/src/ext_job.c
+++ b/libjob_queue/src/ext_job.c
@@ -29,6 +29,7 @@
 #include <ert/util/stringlist.h>
 #include <ert/util/parser.h>
 #include <ert/res_util/subst_list.h>
+#include <ert/res_util/res_env.h>
 
 #include <ert/config/config_parser.h>
 #include <ert/config/config_content.h>
@@ -451,7 +452,7 @@ void ext_job_set_executable(ext_job_type * ext_job, const char * executable_abs,
   } else {
       if (search_path){
         /* Go through the PATH variable to try to locate the executable. */
-        char * path_executable = util_alloc_PATH_executable( executable_input );
+        char * path_executable = res_env_alloc_PATH_executable( executable_input );
 
         if (path_executable != NULL) {
           ext_job_set_executable( ext_job , path_executable, NULL, search_path );

--- a/libjob_queue/src/lsf_driver.c
+++ b/libjob_queue/src/lsf_driver.c
@@ -28,6 +28,7 @@
 #include <ert/util/stringlist.h>
 #include <ert/res_util/log.h>
 #include <ert/res_util/res_log.h>
+#include <ert/res_util/res_env.h>
 
 #include <ert/job_queue/queue_driver.h>
 #include <ert/job_queue/lsf_driver.h>
@@ -1116,7 +1117,7 @@ static void lsf_driver_set_remote_server( lsf_driver_type * driver , const char 
 #endif
   } else {
     driver->remote_lsf_server = util_realloc_string_copy( driver->remote_lsf_server , remote_server );
-    util_unsetenv( "BSUB_QUIET" );
+    res_env_unsetenv( "BSUB_QUIET" );
     {
       char * tmp_server = util_alloc_strupr_copy( remote_server );
 

--- a/libjob_queue/src/queue_driver.c
+++ b/libjob_queue/src/queue_driver.c
@@ -17,6 +17,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include <stdbool.h>
 #include <string.h>
 

--- a/libres_util/CMakeLists.txt
+++ b/libres_util/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library( res_util src/res_log.c
                       src/template.c
                       src/template_loop.c
                       src/path_fmt.c
+                      src/res_env.c
                       src/block_fs.c
                       src/res_version.c
                       src/regression.c
@@ -72,6 +73,10 @@ add_test(NAME ert_util_subst_list COMMAND ert_util_subst_list)
 add_executable(ert_util_block_fs tests/ert_util_block_fs.c)
 target_link_libraries(ert_util_block_fs res_util)
 add_test(NAME ert_util_block_fs COMMAND ert_util_block_fs)
+
+add_executable(res_util_PATH tests/res_util_PATH.c)
+target_link_libraries(res_util_PATH res_util)
+add_test(NAME res_util_PATH COMMAND res_util_PATH)
 
 find_library( VALGRIND NAMES valgr )
 if (VALGRIND)

--- a/libres_util/include/ert/res_util/res_env.h
+++ b/libres_util/include/ert/res_util/res_env.h
@@ -1,0 +1,40 @@
+/*
+   Copyright (C) 2018  Statoil ASA, Norway.
+
+   The file 'res_env.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#ifndef RESENV_H
+#define RESENV_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+
+  char       ** res_env_alloc_PATH_list();
+  char       *  res_env_alloc_PATH_executable(const char * executable );
+  void          res_env_setenv( const char * variable , const char * value);
+  const char *  res_env_interp_setenv( const char * variable , const char * value);
+  void          res_env_unsetenv( const char * variable);
+  char       *  res_env_alloc_envvar( const char * value );
+  char       *  res_env_isscanf_alloc_envvar( const char * string , int env_index );
+  const char *  res_env_update_path_var(const char * variable, const char * value, bool append);
+
+#ifdef __cplusplus
+}
+#endif
+#endif // RESLOG_H

--- a/libres_util/include/ert/res_util/subst_list.h
+++ b/libres_util/include/ert/res_util/subst_list.h
@@ -27,6 +27,7 @@ extern "C" {
 
 #include <ert/util/type_macros.h>
 #include <ert/util/buffer.h>
+
 #include <ert/res_util/subst_func.h>
 
   typedef struct          subst_list_struct subst_list_type;

--- a/libres_util/src/res_env.c
+++ b/libres_util/src/res_env.c
@@ -1,0 +1,347 @@
+/*
+   Copyright (C) 2018  Statoil ASA, Norway.
+
+   The file 'log.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+#include "ert/util/build_config.h"
+
+#include <ert/util/util.h>
+#include <ert/res_util/res_env.h>
+#include <ert/util/buffer.h>
+
+#ifdef HAVE_POSIX_SETENV
+#define PATHVAR_SPLIT ":"
+
+void res_env_unsetenv( const char * variable ) {
+  unsetenv( variable );
+}
+
+void res_env_setenv( const char * variable , const char * value) {
+  int overwrite = 1;
+  setenv( variable , value , overwrite );
+}
+
+#else
+
+#include <Windows.h>
+
+#define PATHVAR_SPLIT ";"
+void res_env_setenv( const char * variable , const char * value) {
+  SetEnvironmentVariable( variable , NULL );
+}
+
+void res_env_unsetenv( const char * variable ) {
+  res_env_setenv( variable , NULL );
+}
+#endif
+
+/**
+   Will return a NULL terminated list char ** of the paths in the PATH
+   variable.
+*/
+
+char ** res_env_alloc_PATH_list() {
+  char ** path_list = NULL;
+  char *  path_env  = getenv("PATH");
+  if (path_env != NULL) {
+    int     path_size;
+
+    util_split_string(path_env , PATHVAR_SPLIT , &path_size , &path_list);
+    path_list = (char**)util_realloc( path_list , (path_size + 1) * sizeof * path_list);
+    path_list[path_size] = NULL;
+  } else {
+    path_list = (char**)util_malloc( sizeof * path_list);
+    path_list[0] = NULL;
+  }
+  return path_list;
+}
+
+/**
+   This function searches through the content of the (currently set)
+   PATH variable, and allocates a string containing the full path
+   (first match) to the executable given as input.
+
+   * If the entered executable already is an absolute path, a copy of
+     the input is returned *WITHOUT* consulting the PATH variable (or
+     checking that it exists).
+
+   * If the executable starts with "./" getenv("PWD") is prepended.
+
+   * If the executable is not found in the PATH list NULL is returned.
+*/
+
+
+char * res_env_alloc_PATH_executable(const char * executable) {
+  if (util_is_abs_path(executable)) {
+    if (util_is_executable(executable))
+      return util_alloc_string_copy(executable);
+    else
+      return NULL;
+  } else if (strncmp(executable , "./" , 2) == 0) {
+    char * cwd = util_alloc_cwd();
+    char * path = util_alloc_filename(cwd , &executable[2] , NULL);
+
+    /* The program has been invoked as ./xxxx */
+    if (!(util_is_file(path) && util_is_executable( path ))) {
+      free( path );
+      path = NULL;
+    }
+    free( cwd );
+
+    return path;
+  } else {
+    char * full_path  = NULL;
+    char ** path_list = res_env_alloc_PATH_list();
+    int ipath = 0;
+
+    while (true) {
+      if (path_list[ipath] != NULL)  {
+        char * current_attempt = util_alloc_filename(path_list[ipath] , executable , NULL);
+
+        if ( util_is_file( current_attempt ) && util_is_executable( current_attempt )) {
+          full_path = current_attempt;
+          break;
+        } else {
+          free(current_attempt);
+          ipath++;
+        }
+      } else
+        break;
+    }
+
+    util_free_NULL_terminated_stringlist(path_list);
+    return full_path;
+  }
+}
+
+
+
+
+
+/**
+   This function updates an environment variable representing a path,
+   before actually updating the environment variable the current value
+   is checked, and the following rules apply:
+
+   1. If @append == true, and @value is already included in the
+      environment variable; nothing is done.
+
+   2. If @append == false, and the variable already starts with
+      @value, nothing is done.
+
+   A pointer to the updated(?) environment variable is returned.
+*/
+
+const char * res_env_update_path_var(const char * variable, const char * value, bool append) {
+  const char * current_value = getenv( variable );
+  if (current_value == NULL)
+    /* The (path) variable is not currently set. */
+    res_env_setenv( variable , value );
+  else {
+    bool    update = true;
+
+    {
+      char ** path_list;
+      int     num_path;
+      util_split_string( current_value , ":" , &num_path , &path_list);
+      if (append) {
+        int i;
+        for (i = 0; i < num_path; i++) {
+          if (util_string_equal( path_list[i] , value))
+            update = false;                            /* The environment variable already contains @value - no point in appending it at the end. */
+        }
+      } else {
+        if (util_string_equal( path_list[0] , value))
+          update = false;                              /* The environment variable already starts with @value. */
+      }
+      util_free_stringlist( path_list , num_path );
+    }
+
+    if (update) {
+      char  * new_value;
+      if (append)
+        new_value = util_alloc_sprintf("%s:%s" , current_value , value);
+      else
+        new_value = util_alloc_sprintf("%s:%s" , value , current_value);
+      res_env_setenv( variable , new_value );
+      free( new_value );
+    }
+
+  }
+  return getenv( variable );
+}
+
+
+
+/**
+   This is a thin wrapper around the setenv() call, with the twist
+   that all $VAR expressions in the @value parameter are replaced with
+   getenv() calls, so that the function call:
+
+      res_env_setenv("PATH" , "$HOME/bin:$PATH")
+
+   Should work as in the shell. If the variables referred to with ${}
+   in @value do not exist the literal string, i.e. '$HOME' is
+   retained.
+
+   If @value == NULL a call to unsetenv( @variable ) will be issued.
+*/
+
+const char * res_env_interp_setenv( const char * variable , const char * value) {
+  char * interp_value = res_env_alloc_envvar( value );
+  if (interp_value != NULL) {
+    res_env_setenv( variable , interp_value);
+    free( interp_value );
+  } else
+    res_env_unsetenv( variable );
+
+  return getenv( variable );
+}
+
+
+
+/**
+   This function will take a string as input, and then replace all if
+   $VAR expressions with the corresponding environment variable. If
+   the environament variable VAR is not set, the string literal $VAR
+   is retained. The return value is a newly allocated string.
+
+   If the input value is NULL - the function will just return NULL;
+*/
+
+
+char * res_env_alloc_envvar( const char * value ) {
+  if (value == NULL)
+    return NULL;
+  else {
+    buffer_type * buffer = buffer_alloc( 1024 );               /* Start by filling up a buffer instance with
+                                                                  the current content of @value. */
+    buffer_fwrite_char_ptr( buffer , value );
+    buffer_rewind( buffer );
+
+
+    while (true) {
+      if (buffer_strchr( buffer , '$')) {
+        const char * data = (const char*)buffer_get_data( buffer );
+        int offset        = buffer_get_offset( buffer ) + 1;    /* Points at the first character following the '$' */
+        int var_length = 0;
+
+        /* Find the length of the variable name */
+        while (true) {
+          char c;
+          c = data[offset + var_length];
+          if (!(isalnum( c ) || c == '_'))      /* Any character which is NOT in the set [a-Z,0-9_] marks the end of the variable. */
+            break;
+
+          if (c == '\0')                        /* The end of the string. */
+            break;
+
+          var_length += 1;
+        }
+
+        {
+          char * var_name        = util_alloc_substring_copy( data , offset - 1 , var_length + 1);  /* Include the leading $ */
+          const char * var_value = getenv( &var_name[1] );
+
+          if (var_value != NULL)
+            buffer_search_replace( buffer , var_name , var_value);                                      /* The actual string replacement. */
+          else
+            buffer_fseek( buffer , var_length , SEEK_CUR );                                      /* The variable is not defined, and we leave the $name. */
+
+          free( var_name );
+        }
+      } else break;  /* No more $ to replace */
+    }
+
+
+    buffer_shrink_to_fit( buffer );
+    {
+      char * expanded_value = (char*)buffer_get_data( buffer );
+      buffer_free_container( buffer );
+      return expanded_value;
+    }
+  }
+}
+
+/**
+   This function will allocate a string copy of the env_index'th
+   occurence of an embedded environment variable from the input
+   string.
+
+   An environment variable is defined as follows:
+
+     1. It starts with '$'.
+     2. It ends with a characeter NOT in the set [a-Z,0-9,_].
+
+   The function will return environment variable number 'env_index'. If
+   no such environment variable can be found in the string the
+   function will return NULL.
+
+   Observe that the returned string will start with '$'. This is to
+   simplify subsequent calls to util_string_replace_XXX() functions,
+   however &ret_value[1] must be used in the subsequent getenv() call:
+
+   {
+      char * env_var = res_env_isscanf_alloc_envvar( s , 0 );
+      if (env_var != NULL) {
+         const char * env_value = getenv( &env_var[1] );   // Skip the leading '$'.
+         if (env_value != NULL)
+            util_string_replace_inplace( s , env_value );
+         else
+            fprintf(stderr,"** Warning: environment variable: \'%s\' is not defined \n", env_var);
+         free( env_var );
+      }
+   }
+
+
+*/
+
+char * res_env_isscanf_alloc_envvar( const char * string , int env_index ) {
+  int env_count = 0;
+  const char * offset = string;
+  const char * env_ptr;
+  do {
+    env_ptr = strchr( offset , '$' );
+    offset = &env_ptr[1];
+    env_count++;
+  } while ((env_count <= env_index) && (env_ptr != NULL));
+
+  if (env_ptr != NULL) {
+    /*
+       We found an environment variable we are interested in. Find the
+       end of this variable and return a copy.
+    */
+    int length = 1;
+    bool cont  = true;
+    do {
+
+      if ( !( isalnum(env_ptr[length]) || env_ptr[length] == '_' ))
+        cont = false;
+      else
+        length++;
+      if (length == strlen( env_ptr ))
+        cont = false;
+    } while (cont);
+
+    return util_alloc_substring_copy( env_ptr , 0 , length );
+  } else
+    return NULL; /* Could not find any env variable occurences. */
+}
+

--- a/libres_util/src/template.c
+++ b/libres_util/src/template.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'template.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'template.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #include <stdlib.h>
@@ -45,14 +45,14 @@ static char * template_load( const template_type * template , const subst_list_t
   int buffer_size;
   char * template_file = util_alloc_string_copy( template->template_file );
   char * template_buffer;
-  
+
   subst_list_update_string( template->arg_list , &template_file);
   if (ext_arg_list != NULL)
     subst_list_update_string( ext_arg_list , &template_file);
-  
+
   template_buffer = util_fread_alloc_file_content( template_file , &buffer_size );
   free( template_file );
-  
+
   return template_buffer;
 }
 
@@ -62,13 +62,13 @@ void template_set_template_file( template_type * template , const char * templat
   template->template_file = util_realloc_string_copy( template->template_file , template_file );
   if (template->internalize_template) {
     util_safe_free( template->template_buffer );
-    template->template_buffer = template_load( template , NULL );  
+    template->template_buffer = template_load( template , NULL );
   }
 }
 
 /** This will not instantiate */
 const char * template_get_template_file( const template_type * template ) {
-  return template->template_file; 
+  return template->template_file;
 }
 
 
@@ -114,7 +114,7 @@ void template_free( template_type * template ) {
   regfree( &template->start_regexp );
   regfree( &template->end_regexp );
 #endif
-  
+
   free( template );
 }
 
@@ -128,14 +128,14 @@ void template_free( template_type * template ) {
    which case this is more like copy operation.
 
    Observe that:
-   
+
     1. Substitutions will be performed on @__target_file
 
     2. @__target_file can contain path components.
 
     3. If internalize_template == false subsititions will be performed
        on the filename of the file with template content.
-  
+
     4. If the parameter @override_symlink is true the function will
        have the following behaviour:
 
@@ -144,7 +144,7 @@ void template_free( template_type * template ) {
          ensuring that a remote file is not updated.
 
 */
-   
+
 
 
 void template_instantiate( const template_type * template , const char * __target_file , const subst_list_type * arg_list , bool override_symlink) {
@@ -161,12 +161,12 @@ void template_instantiate( const template_type * template , const char * __targe
       char_buffer = util_alloc_string_copy( template->template_buffer);
     else
       char_buffer = template_load( template , arg_list );
-    
+
     /* Substitutions on the content. */
     subst_list_update_string( template->arg_list , &char_buffer );
     if (arg_list != NULL) subst_list_update_string( arg_list , &char_buffer );
 
-    
+
 #ifdef ERT_HAVE_REGEXP
     {
       buffer_type * buffer = buffer_alloc_private_wrapper( char_buffer , strlen( char_buffer ) + 1);
@@ -176,15 +176,15 @@ void template_instantiate( const template_type * template , const char * __targe
     }
 #endif
 
-    /* 
-       Check if target file already exists as a symlink, 
-       and remove it if override_symlink is true. 
+    /*
+       Check if target file already exists as a symlink,
+       and remove it if override_symlink is true.
     */
     if (override_symlink) {
       if (util_is_link( target_file ))
         remove( target_file );
     }
-    
+
     /* Write the content out. */
     {
       FILE * stream = util_mkdir_fopen( target_file , "w");
@@ -193,7 +193,7 @@ void template_instantiate( const template_type * template , const char * __targe
     }
     free( char_buffer );
   }
-  
+
   free( target_file );
 }
 

--- a/libres_util/tests/res_util_PATH.c
+++ b/libres_util/tests/res_util_PATH.c
@@ -1,0 +1,60 @@
+/*
+   Copyright (C) 2012  Statoil ASA, Norway.
+
+   The file 'ert_util_PATH_test.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <ert/util/vector.h>
+#include <ert/util/util.h>
+#include <ert/util/test_util.h>
+
+#include <ert/res_util/res_env.h>
+
+
+int main(int argc , char ** argv) {
+  unsetenv("PATH");
+  {
+    char ** path_list = res_env_alloc_PATH_list();
+    if (path_list[0] != NULL)
+      test_error_exit("Failed on empty PATH\n");
+
+    util_free_NULL_terminated_stringlist( path_list );
+  }
+
+
+  setenv("PATH" , "/usr/bin:/bin:/usr/local/bin" , 1);
+  {
+    char ** path_list = res_env_alloc_PATH_list();
+    if (strcmp(path_list[0] , "/usr/bin") != 0)
+      test_error_exit("Failed on first path element\n");
+
+    if (strcmp(path_list[1] , "/bin") != 0)
+      test_error_exit("Failed on second path element\n");
+
+    if (strcmp(path_list[2] , "/usr/local/bin") != 0)
+      test_error_exit("Failed on third  path element\n");
+
+    if (path_list[3] != NULL)
+      test_error_exit("Failed termination \n");
+    
+    util_free_NULL_terminated_stringlist( path_list );
+  }
+  
+
+  exit(0);
+}


### PR DESCRIPTION
Functions - working with `getenv()`and `setenv()` are moved from libecl.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#357
