### PR TITLE
Add safe check of queue index

### DIFF
--- a/libenkf/include/ert/enkf/run_arg.h
+++ b/libenkf/include/ert/enkf/run_arg.h
@@ -76,6 +76,7 @@ UTIL_IS_INSTANCE_HEADER( run_arg );
   const char * run_arg_get_run_id( const run_arg_type * run_arg);
   run_status_type run_arg_get_run_status( const run_arg_type * run_arg );
 
+  int  run_arg_get_queue_index_safe( const run_arg_type * run_arg );
   int  run_arg_get_queue_index( const run_arg_type * run_arg );
   bool run_arg_is_submitted( const run_arg_type * run_arg );
 

--- a/libenkf/src/run_arg.c
+++ b/libenkf/src/run_arg.c
@@ -256,6 +256,13 @@ run_mode_type run_arg_get_run_mode( const run_arg_type * run_arg ) {
 }
 
 
+int run_arg_get_queue_index_safe( const run_arg_type * run_arg ) {
+  if (run_arg->queue_index == INVALID_QUEUE_INDEX)
+    return -1;
+
+  return run_arg->queue_index;
+}
+
 int run_arg_get_queue_index( const run_arg_type * run_arg ) {
   if (run_arg->queue_index == INVALID_QUEUE_INDEX)
     util_abort("%s: sorry internal error - asking for the queue_index in a not-initialized run_arg object.\n" , __func__);

--- a/libenkf/tests/enkf_run_arg.c
+++ b/libenkf/tests/enkf_run_arg.c
@@ -48,6 +48,9 @@ void test_queue_index() {
     test_assert_false( run_arg_is_submitted( run_arg ) );
     test_assert_util_abort("run_arg_get_queue_index" , call_get_queue_index , run_arg );
 
+    int qi = run_arg_get_queue_index_safe( run_arg );
+    test_assert_int_equal( -1, qi );  // not submitted: index == -1
+
     run_arg_set_queue_index(run_arg, 78);
     test_assert_true( run_arg_is_submitted( run_arg ) );
     test_assert_int_equal( 78 , run_arg_get_queue_index( run_arg ));

--- a/python/python/res/enkf/run_arg.py
+++ b/python/python/res/enkf/run_arg.py
@@ -22,7 +22,7 @@ class RunArg(BaseCClass):
 
     _alloc_ENSEMBLE_EXPERIMENT = EnkfPrototype("run_arg_obj run_arg_alloc_ENSEMBLE_EXPERIMENT(char*, enkf_fs, int, int, char*, char*, subst_list)", bind = False)
     _free                      = EnkfPrototype("void run_arg_free(run_arg)")
-    _get_queue_index           = EnkfPrototype("int  run_arg_get_queue_index(run_arg)")
+    _get_queue_index_safe      = EnkfPrototype("int  run_arg_get_queue_index_safe(run_arg)")
     _is_submitted              = EnkfPrototype("bool run_arg_is_submitted(run_arg)")
     _get_run_id                = EnkfPrototype("char* run_arg_get_run_id(run_arg)")
     _get_geo_id                = EnkfPrototype("int run_arg_get_geo_id(run_arg)")
@@ -40,7 +40,10 @@ class RunArg(BaseCClass):
         self._free()
 
     def getQueueIndex(self):
-        return self._get_queue_index()
+        qi = self._get_queue_index_safe()
+        if qi < 0:
+            raise ValueError('Cannot get queue index before job is submitted.')
+        return qi
 
     def isSubmitted(self):
         return self._is_submitted()

--- a/python/python/res/server/simulation_context.py
+++ b/python/python/res/server/simulation_context.py
@@ -150,7 +150,11 @@ class SimulationContext(object):
             raise KeyError("No such simulation: %s" % iens)
 
         run_arg = self._run_args[iens]
-        queue_index = run_arg.getQueueIndex()
+        try:
+            # will throw if not yet submitted (is in a limbo state)
+            queue_index = run_arg.getQueueIndex()
+        except ValueError:
+            return None
         if self._queue_manager.isJobWaiting(queue_index):
             return None
 
@@ -166,5 +170,8 @@ class SimulationContext(object):
             raise KeyError("No such simulation: %s" % iens)
 
         run_arg = self._run_args[iens]
-        queue_index = run_arg.getQueueIndex()
+        try:
+            queue_index = run_arg.getQueueIndex()
+        except ValueError:
+            return None
         return self._queue_manager.getJobStatus(queue_index)

--- a/python/tests/res/enkf/test_run_context.py
+++ b/python/tests/res/enkf/test_run_context.py
@@ -26,6 +26,9 @@ class ErtRunContextTest(ResTest):
             run_id1 = run_context1.get_id( )
 
             run_arg0 = run_context1[0]
+            with self.assertRaises(ValueError):
+                run_arg0.getQueueIndex()
+
             self.assertEqual( run_id1 , run_arg0.get_run_id( ))
 
             run_context2 = ErtRunContext( EnkfRunType.ENSEMBLE_EXPERIMENT , sim_fs , target_fs, mask , runpath_fmt, jobname_fmt, subst_list , itr )


### PR DESCRIPTION
If you check `SimulationContext.progress` too early, libres will crash with
```
Error message: run_arg_get_queue_index: sorry internal error - asking for the queue_index in a not-initialized run_arg object.
```

This is due to job not even submitted before the queue index is looked up.

Check that job is submitted before calling `get_queue_index`.