### PR TITLE
Some minor python 3 fixes.

### DIFF
--- a/python/res/util/ui_return.py
+++ b/python/res/util/ui_return.py
@@ -43,19 +43,13 @@ class UIReturn(BaseCClass):
         else:
             raise ValueError('Unable to construct UIReturn with status = %s' % str(status))
 
-
+    #For python 3, corresponds to __nonzero__
     def __bool__(self):
-        if self.status() == UIReturnStatusEnum.UI_RETURN_OK:
-            return True
-        else:
-            return False
+        return self.status() == UIReturnStatusEnum.UI_RETURN_OK
 
-
+    #For python 2
     def __nonzero__(self):
-        if self.status() == UIReturnStatusEnum.UI_RETURN_OK:
-            return True
-        else:
-            return False
+        return self.__bool__()
 
 
     def __len__(self):

--- a/python/res/util/ui_return.py
+++ b/python/res/util/ui_return.py
@@ -44,6 +44,13 @@ class UIReturn(BaseCClass):
             raise ValueError('Unable to construct UIReturn with status = %s' % str(status))
 
 
+    def __bool__(self):
+        if self.status() == UIReturnStatusEnum.UI_RETURN_OK:
+            return True
+        else:
+            return False
+
+
     def __nonzero__(self):
         if self.status() == UIReturnStatusEnum.UI_RETURN_OK:
             return True

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -54,7 +54,7 @@ def statoil_test():
     Will mark a test method or an entire test class as dependent on Statoil testdata.
     """
     def decorator(test_item):
-        if not isinstance(test_item, (type, types.ClassType)):
+        if not isinstance(test_item, type):
             if not ResTest.STATOIL_DATA:
                 @functools.wraps(test_item)
                 def skip_wrapper(*args, **kwargs):


### PR DESCRIPTION
**Task**
Because the python 3 version of libecl/libres is currently on "Allowed Failures", python3-incompatible code can still be accepted by TRAVIS. Here are some fixes to that. 

**Approach**
tests/__init__.py: removed types.ClassType.
ui_return.py: added __bool__ method, replacing the __nonzero__ from python 2. 

**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
