### PR TITLE
Remove summary auto corrf

### DIFF
--- a/lib/enkf/obs_vector.c
+++ b/lib/enkf/obs_vector.c
@@ -289,8 +289,13 @@ void obs_vector_install_node(obs_vector_type * obs_vector , int index , void * n
    observation key - the two can be different.
 */
 
-static void obs_vector_add_summary_obs( obs_vector_type * obs_vector , int obs_index , const char * summary_key , const char * obs_key , double value , double std , const char * auto_corrf_name , double auto_corrf_param) {
-  summary_obs_type * summary_obs = summary_obs_alloc( summary_key , obs_key , value , std , auto_corrf_name , auto_corrf_param);
+static void obs_vector_add_summary_obs( obs_vector_type * obs_vector,
+                                        int obs_index,
+                                        const char * summary_key,
+                                        const char * obs_key,
+                                        double value,
+                                        double std) {
+  summary_obs_type * summary_obs = summary_obs_alloc( summary_key , obs_key , value , std);
   obs_vector_install_node( obs_vector , obs_index , summary_obs );
 }
 
@@ -442,7 +447,7 @@ void obs_vector_load_from_SUMMARY_OBSERVATION(obs_vector_type * obs_vector , con
       else if (strcmp( error_mode , "RELMIN") == 0)
         obs_error  = util_double_max( min_error , obs_error * obs_value );
 
-      obs_vector_add_summary_obs( obs_vector , obs_restart_nr , sum_key , obs_key , obs_value , obs_error , NULL , 0);
+      obs_vector_add_summary_obs( obs_vector , obs_restart_nr , sum_key , obs_key , obs_value , obs_error);
     }
   }
 }
@@ -533,24 +538,10 @@ bool obs_vector_load_from_HISTORY_OBSERVATION(obs_vector_type * obs_vector ,
     double_vector_type * std                = double_vector_alloc(0,0);
     bool_vector_type   * valid              = bool_vector_alloc(0 , false);
 
-    /* The auto_corrf parameters can not be "segmentized" */
-    double auto_corrf_param                 = -1;
-    const char * auto_corrf_name            = NULL;
-
-
     double         error      = conf_instance_get_item_value_double(conf_instance, "ERROR"     );
     double         error_min  = conf_instance_get_item_value_double(conf_instance, "ERROR_MIN" );
     const char *   error_mode = conf_instance_get_item_value_ref(   conf_instance, "ERROR_MODE");
     const char *   sum_key    = conf_instance_get_name_ref(         conf_instance              );
-
-    if(conf_instance_has_item(conf_instance, "AUTO_CORRF")) {
-      auto_corrf_name  = conf_instance_get_item_value_ref( conf_instance , "AUTO_CORRF");
-      auto_corrf_param = conf_instance_get_item_value_double(conf_instance, "AUTO_CORRF_PARAM");
-      if(conf_instance_has_item(conf_instance, "AUTO_CORRF_PARAM"))
-        auto_corrf_param = conf_instance_get_item_value_double(conf_instance, "AUTO_CORRF_PARAM");
-      else
-        util_abort("%s: When specifying AUTO_CORRF you must also give a vlaue for AUTO_CORRF_PARAM",__func__);
-    }
 
 
     // Get time series data from history object and allocate
@@ -635,8 +626,7 @@ bool obs_vector_load_from_HISTORY_OBSERVATION(obs_vector_type * obs_vector ,
         if (bool_vector_safe_iget( valid , restart_nr)) {
           if (double_vector_iget( std , restart_nr) > std_cutoff) {
             obs_vector_add_summary_obs( obs_vector , restart_nr , sum_key , sum_key ,
-                                        double_vector_iget( value ,restart_nr) , double_vector_iget( std , restart_nr ) ,
-                                        auto_corrf_name , auto_corrf_param);
+                                        double_vector_iget( value ,restart_nr) , double_vector_iget( std , restart_nr ));
           } else
             fprintf(stderr,"** Warning: to small observation error in observation %s:%d - ignored. \n", sum_key , restart_nr);
         }

--- a/lib/enkf/summary_obs.c
+++ b/lib/enkf/summary_obs.c
@@ -45,38 +45,9 @@ struct summary_obs_struct {
   double    value;          /** Observation value. */
   double    std;            /** Standard deviation of observation. */
   double    std_scaling;
-
-  auto_corrf_ftype   * auto_corrf;
-  double               auto_corrf_param;
 };
 
 
-
-static double auto_corrf_exp( double tlag , double param ) {
-  return exp(-fabs(tlag) / param );
-}
-
-static double auto_corrf_gauss( double tlag , double param ) {
-  double x = tlag / param;
-  return exp(-0.5 * x * x);
-}
-
-
-
-static auto_corrf_ftype * summary_obs_lookup_auto_corrf( const char * fname ) {
-  if (fname == NULL)
-    return NULL;
-  else {
-    if (strcmp( fname , AUTO_CORRF_EXP) == 0)
-      return auto_corrf_exp;
-    else if (strcmp( fname , AUTO_CORRF_GAUSS) == 0)
-      return auto_corrf_gauss;
-    else {
-      util_abort("%s: correlation function:%s not recognized \n",__func__ , fname);
-      return NULL;  /* Compiler shut up. */
-    }
-  }
-}
 
 
 
@@ -95,9 +66,7 @@ static auto_corrf_ftype * summary_obs_lookup_auto_corrf( const char * fname ) {
 summary_obs_type * summary_obs_alloc(const char   * summary_key,
                                      const char   * obs_key ,
                                      double value ,
-                                     double std   ,
-                                     const char * auto_corrf_name ,
-                                     double auto_corrf_param) {
+                                     double std) {
 
   summary_obs_type * obs = util_malloc(sizeof * obs );
   UTIL_TYPE_ID_INIT( obs , SUMMARY_OBS_TYPE_ID )
@@ -107,8 +76,6 @@ summary_obs_type * summary_obs_alloc(const char   * summary_key,
   obs->value            = value;
   obs->std              = std;
   obs->std_scaling      = 1.0;
-  obs->auto_corrf       = summary_obs_lookup_auto_corrf( auto_corrf_name );
-  obs->auto_corrf_param = auto_corrf_param;
 
   return obs;
 }
@@ -128,14 +95,6 @@ void summary_obs_free(summary_obs_type * summary_obs) {
 
 
 
-
-auto_corrf_ftype * summary_obs_get_auto_corrf( const summary_obs_type * summary_obs ) {
-  return summary_obs->auto_corrf;
-}
-
-double summary_obs_get_auto_corrf_param( const summary_obs_type * summary_obs ) {
-  return summary_obs->auto_corrf_param;
-}
 
 
 

--- a/lib/enkf/tests/enkf_obs_tests.c
+++ b/lib/enkf/tests/enkf_obs_tests.c
@@ -37,17 +37,17 @@ int main(int argc, char ** argv) {
   enkf_obs_type * enkf_obs = enkf_obs_alloc(history , external_time_map , grid , refcase , ensemble_config);
 
   obs_vector_type * obs_vector = obs_vector_alloc(SUMMARY_OBS, "WWCT", NULL, 2);
-  summary_obs_type * summary_obs1 = summary_obs_alloc( "SummaryKey" , "ObservationKey" , 43.2, 2.0 , AUTO_CORRF_EXP, 42);
+  summary_obs_type * summary_obs1 = summary_obs_alloc( "SummaryKey" , "ObservationKey" , 43.2, 2.0);
   obs_vector_install_node( obs_vector , 0 , summary_obs1 );
 
-  summary_obs_type * summary_obs2 = summary_obs_alloc( "SummaryKey2" , "ObservationKey2" , 4.2, 0.1 , AUTO_CORRF_EXP, 42);
+  summary_obs_type * summary_obs2 = summary_obs_alloc( "SummaryKey2" , "ObservationKey2" , 4.2, 0.1);
   obs_vector_install_node( obs_vector , 1 , summary_obs2 );
 
   obs_vector_type * obs_vector2 = obs_vector_alloc(SUMMARY_OBS, "WWCT2", NULL, 2);
-  summary_obs_type * summary_obs3 = summary_obs_alloc( "SummaryKey" , "ObservationKey" , 43.2, 2.0 , AUTO_CORRF_EXP, 42);
+  summary_obs_type * summary_obs3 = summary_obs_alloc( "SummaryKey" , "ObservationKey" , 43.2, 2.0);
   obs_vector_install_node( obs_vector2 , 0 , summary_obs3 );
 
-  summary_obs_type * summary_obs4 = summary_obs_alloc( "SummaryKey2" , "ObservationKey2" , 4.2, 0.1 , AUTO_CORRF_EXP, 42);
+  summary_obs_type * summary_obs4 = summary_obs_alloc( "SummaryKey2" , "ObservationKey2" , 4.2, 0.1);
   obs_vector_install_node( obs_vector2 , 1 , summary_obs4 );
 
   enkf_obs_add_obs_vector(enkf_obs, obs_vector);

--- a/lib/enkf/tests/enkf_obs_vector.c
+++ b/lib/enkf/tests/enkf_obs_vector.c
@@ -40,21 +40,21 @@ void test_create(enkf_config_node_type * config_node ) {
     const int_vector_type * step_list = obs_vector_get_step_list( obs_vector );
 
     {
-      summary_obs_type * obs_node = summary_obs_alloc( "FOPT" , "FOPT" , 10 , 1 , NULL , 0);
+      summary_obs_type * obs_node = summary_obs_alloc( "FOPT" , "FOPT" , 10 , 1);
       obs_vector_install_node( obs_vector , 10 , obs_node );
       test_assert_int_equal( 1 , int_vector_size( step_list ));
       test_assert_int_equal( 10 , int_vector_iget( step_list , 0));
     }
 
     {
-      summary_obs_type * obs_node = summary_obs_alloc( "FOPT" , "FOPT" , 10 , 1 , NULL , 0);
+      summary_obs_type * obs_node = summary_obs_alloc( "FOPT" , "FOPT" , 10 , 1 );
       obs_vector_install_node( obs_vector , 10 , obs_node );
       test_assert_int_equal( 1 , int_vector_size( step_list ));
       test_assert_int_equal( 10 , int_vector_iget( step_list , 0));
     }
 
     {
-      summary_obs_type * obs_node = summary_obs_alloc( "FOPT" , "FOPT" , 10 , 1 , NULL , 0);
+      summary_obs_type * obs_node = summary_obs_alloc( "FOPT" , "FOPT" , 10 , 1);
       obs_vector_install_node( obs_vector , 5 , obs_node );
       test_assert_int_equal( 2 , int_vector_size( step_list ));
       test_assert_int_equal( 5 , int_vector_iget( step_list , 0));
@@ -62,7 +62,7 @@ void test_create(enkf_config_node_type * config_node ) {
     }
 
     {
-      summary_obs_type * obs_node = summary_obs_alloc( "FOPT" , "FOPT" , 10 , 1 , NULL , 0);
+      summary_obs_type * obs_node = summary_obs_alloc( "FOPT" , "FOPT" , 10 , 1);
       obs_vector_install_node( obs_vector , 15 , obs_node );
       test_assert_int_equal( 3 , int_vector_size( step_list ));
       test_assert_int_equal( 5 , int_vector_iget( step_list , 0));

--- a/lib/enkf/tests/obs_vector_tests.c
+++ b/lib/enkf/tests/obs_vector_tests.c
@@ -1,19 +1,19 @@
 /*
-   Copyright (C) 2013  Statoil ASA, Norway. 
-    
-   The file 'enkf_obs_vector_tests.c' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2013  Statoil ASA, Norway.
+
+   The file 'enkf_obs_vector_tests.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
  */
 
 #include <ert/util/test_util.h>
@@ -41,7 +41,7 @@ bool scale_std_summary_nodata_no_errors() {
 
 bool scale_std_summarysingleobservation_no_errors() {
   obs_vector_type * obs_vector = obs_vector_alloc(SUMMARY_OBS, "WHAT", NULL, 1);
-  summary_obs_type * summary_obs = summary_obs_alloc("SummaryKey", "ObservationKey", 43.2, 2.0, AUTO_CORRF_EXP, 42);
+  summary_obs_type * summary_obs = summary_obs_alloc("SummaryKey", "ObservationKey", 43.2, 2.0);
   obs_vector_install_node(obs_vector, 0, summary_obs);
   test_assert_double_equal(2.0, summary_obs_get_std(summary_obs));
   test_assert_double_equal(1.0, summary_obs_get_std_scaling(summary_obs));
@@ -67,7 +67,7 @@ bool scale_std_summarymanyobservations_no_errors() {
 
   summary_obs_type * observations[num_observations];
   for (int i = 0; i < num_observations; i++) {
-    summary_obs_type * summary_obs = summary_obs_alloc("SummaryKey", "ObservationKey", 43.2, i, AUTO_CORRF_EXP, 42);
+    summary_obs_type * summary_obs = summary_obs_alloc("SummaryKey", "ObservationKey", 43.2, i);
     obs_vector_install_node(obs_vector, i, summary_obs);
     observations[i] = summary_obs;
   }
@@ -127,17 +127,17 @@ block_obs_type * create_block_obs(ecl_grid_type * grid, int size, double value, 
   free(obs_value);
   free(obs_std);
   field_config_free( field_config );
-        
+
   return block_obs;
 }
 
 bool scale_std_block100observations_no_errors() {
   int num_observations = 100;
   int num_points = 10;
-  
+
   obs_vector_type * obs_vector = obs_vector_alloc(BLOCK_OBS, "WHAT", NULL, num_observations);
   ecl_grid_type * grid = ecl_grid_alloc_rectangular(num_points, num_points, num_points, 1.0, 1.0, 1.0, NULL);
-  
+
   double scale_factor = 3.3;
   double obs_value = 44;
   double obs_std = 3.2;

--- a/lib/include/ert/enkf/obs_vector.h
+++ b/lib/include/ert/enkf/obs_vector.h
@@ -99,9 +99,9 @@ extern "C" {
   enkf_config_node_type * obs_vector_get_config_node(const obs_vector_type * );
   const char            * obs_vector_get_obs_key( const obs_vector_type * obs_vector);
   local_obsdata_node_type * obs_vector_alloc_local_node(const obs_vector_type * obs_vector);
-  
-  
-  
+
+
+
   UTIL_IS_INSTANCE_HEADER(obs_vector);
   UTIL_SAFE_CAST_HEADER(obs_vector);
   VOID_FREE_HEADER(obs_vector);

--- a/lib/include/ert/enkf/summary_obs.h
+++ b/lib/include/ert/enkf/summary_obs.h
@@ -1,25 +1,25 @@
 /*
-   Copyright (C) 2011  Statoil ASA, Norway. 
-    
-   The file 'summary_obs.h' is part of ERT - Ensemble based Reservoir Tool. 
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+   Copyright (C) 2011  Statoil ASA, Norway.
+
+   The file 'summary_obs.h' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef ERT_SUMMARY_OBS_H
 #define ERT_SUMMARY_OBS_H
 
-#ifdef __cplusplus 
+#ifdef __cplusplus
 extern "C" {
 #endif
 #include <stdbool.h>
@@ -36,13 +36,8 @@ extern "C" {
 #include <ert/enkf/active_list.h>
 
 
-#define AUTO_CORRF_EXP     "EXP"
-#define AUTO_CORRF_GAUSS   "GAUSS"
-
 
 typedef struct summary_obs_struct summary_obs_type;
-
-typedef double (auto_corrf_ftype) ( double , double );
 
 
 void summary_obs_free(
@@ -50,19 +45,14 @@ void summary_obs_free(
 
 summary_obs_type * summary_obs_alloc(
   const char   * summary_key,
-  const char * obs_key , 
+  const char * obs_key ,
   double  value ,
-  double  std,
-  const char * auto_corrf_name , 
-  double auto_corrf_param);
+  double  std);
 
 
   double summary_obs_get_value( const summary_obs_type * summary_obs );
   double summary_obs_get_std( const summary_obs_type * summary_obs );
   double summary_obs_get_std_scaling( const summary_obs_type * summary_obs );
-  
-auto_corrf_ftype * summary_obs_get_auto_corrf( const summary_obs_type * summary_obs );
-double             summary_obs_get_auto_corrf_param( const summary_obs_type * summary_obs );
 
 bool summary_obs_default_used(
   const summary_obs_type * summary_obs,


### PR DESCRIPTION
It is currently possible to assign a function to be used as auto correlation function for history observations, which will be used to estimate a covariance matrix. The idea might have been good - but it is not used.

Removing to simplify code, and enable further simplification and refactoring.

