### PR TITLE
Log perm denied fixup

### DIFF
--- a/lib/include/ert/res_util/log.h
+++ b/lib/include/ert/res_util/log.h
@@ -51,12 +51,12 @@ typedef enum {
 
 
 typedef struct log_struct log_type;
-
+  void         log_add_message_stream(FILE * stream, bool add_timestamp, message_level_type message_level, const char * message);
   FILE       * log_get_stream(log_type * logh );
   log_type   * log_open(const char *filename, message_level_type log_level);
-  void         log_add_message(log_type *logh, message_level_type message_level , FILE * dup_stream , const char* message);
+  void         log_add_message(log_type *logh, message_level_type message_level,  const char* message);
   void         log_add_message_str(log_type *logh, message_level_type message_level , const char* message);
-  void         log_add_fmt_message(log_type * logh , message_level_type message_level , FILE * dup_stream , const char * fmt , ...);
+  void         log_add_fmt_message(log_type * logh , message_level_type message_level, const char * fmt , ...);
   void         log_set_level( log_type * logh , message_level_type new_level);
   void         log_close( log_type * logh );
   void         log_sync(log_type * logh);

--- a/lib/include/ert/res_util/log.h
+++ b/lib/include/ert/res_util/log.h
@@ -62,7 +62,6 @@ typedef struct log_struct log_type;
   void         log_sync(log_type * logh);
   const char * log_get_filename( const log_type * logh );
   void         log_set_level( log_type * logh , message_level_type log_level);
-  bool         log_is_open( const log_type * logh);
   int          log_get_msg_count(const log_type * logh);
   message_level_type log_get_level( const log_type * logh);
   message_level_type log_get_level( const log_type * logh);

--- a/lib/include/ert/res_util/res_log.h
+++ b/lib/include/ert/res_util/res_log.h
@@ -1,19 +1,19 @@
 /*
    Copyright (C) 2017  Statoil ASA, Norway.
-    
+
    The file 'res_log.h' is part of ERT - Ensemble based Reservoir Tool.
-    
-   ERT is free software: you can redistribute it and/or modify 
-   it under the terms of the GNU General Public License as published by 
-   the Free Software Foundation, either version 3 of the License, or 
-   (at your option) any later version. 
-    
-   ERT is distributed in the hope that it will be useful, but WITHOUT ANY 
-   WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-   FITNESS FOR A PARTICULAR PURPOSE.   
-    
-   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html> 
-   for more details. 
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
 */
 
 #ifndef RESLOG_H

--- a/lib/include/ert/res_util/res_log.h
+++ b/lib/include/ert/res_util/res_log.h
@@ -28,9 +28,9 @@ extern "C" {
 
 #include <ert/res_util/log.h>
 
-void res_log_init_log(message_level_type log_level,const char * log_file_name, bool verbose);
-void res_log_init_log_default_log_level(const char * log_file_name, bool verbose);
-void res_log_init_log_default( bool verbose);
+bool res_log_init_log(message_level_type log_level,const char * log_file_name, bool verbose);
+bool res_log_init_log_default_log_level(const char * log_file_name, bool verbose);
+bool res_log_init_log_default( bool verbose);
 void res_log_close();
 int res_log_get_log_level();
 const char * res_log_get_filename();

--- a/lib/res_util/res_log.c
+++ b/lib/res_util/res_log.c
@@ -156,11 +156,12 @@ void res_log_init_log_default( bool verbose){
 
 
 void res_log_close() {
-    if (log_is_open(logh))
-      log_add_message(logh, false, NULL, "Exiting ert application normally - "
+  if (logh) {
+    log_add_message(logh, false, NULL, "Exiting ert application normally - "
                                           "all is fine(?)");
     log_close( logh );
-    logh = NULL;
+  }
+  logh = NULL;
 }
 
 void res_log_set_log_level(message_level_type log_level){

--- a/lib/res_util/tests/ert_util_logh.c
+++ b/lib/res_util/tests/ert_util_logh.c
@@ -30,13 +30,6 @@
 void test_open() {
   test_work_area_type * work_area = test_work_area_alloc("util/logh");
   {
-    log_type * logh = log_open( NULL , 0 );
-    test_assert_int_equal( 0 , log_get_msg_count( logh ));
-    test_assert_false( log_is_open( logh ));
-    log_close( logh );
-  }
-
-  {
     log_type * logh = log_open( LOG_FILE , 0 );
     test_assert_not_NULL(logh);
     log_close( logh );
@@ -44,7 +37,6 @@ void test_open() {
 
   {
     log_type * logh = log_open( LOG_FILE , 1 );
-    test_assert_true( log_is_open( logh ));
     log_add_message( logh , 1 , NULL , "Message");
     test_assert_int_equal( 1 , log_get_msg_count( logh ));
     log_close( logh );

--- a/lib/res_util/tests/ert_util_logh.c
+++ b/lib/res_util/tests/ert_util_logh.c
@@ -37,7 +37,7 @@ void test_open() {
 
   {
     log_type * logh = log_open( LOG_FILE , 1 );
-    log_add_message( logh , 1 , NULL , "Message");
+    log_add_message( logh , 1 , "Message");
     test_assert_int_equal( 1 , log_get_msg_count( logh ));
     log_close( logh );
   }
@@ -65,7 +65,7 @@ void test_delete_empty() {
 
   {
     log_type * logh = log_open( LOG_FILE , 1 );
-    log_add_message( logh , 1 , NULL , "Message");
+    log_add_message( logh , 1 , "Message");
     log_close( logh );
     test_assert_true( util_file_exists( LOG_FILE ));
 
@@ -79,12 +79,27 @@ void test_delete_empty() {
 
 
 /*
+  Invalid input - return NULL.
+*/
+void test_invalid_input() {
+  test_work_area_type * work_area = test_work_area_alloc("logh_invalid_input");
+  test_assert_NULL( log_open( NULL, 1));
+
+  util_mkdir_p("read_only");
+  chmod("read_only", 0500);
+  test_assert_NULL( log_open( "read_only/log.txt", 1));
+
+  test_work_area_free(work_area);
+}
+
+
+/*
    Someone else deletes the file before closing - that should not kill the thing.
 */
 
 void test_file_deleted() {
   log_type * logh = log_open( LOG_FILE , 1 );
-  log_add_message( logh , 1 , NULL , "Message");
+  log_add_message( logh , 1 , "Message");
   util_unlink( LOG_FILE );
   test_assert_false( util_file_exists( LOG_FILE ));
   log_close( logh );
@@ -95,5 +110,6 @@ int main(int argc , char ** argv) {
   test_open();
   test_delete_empty();
   test_file_deleted( );
+  test_invalid_input();
   exit(0);
 }

--- a/python/res/util/log.py
+++ b/python/res/util/log.py
@@ -14,23 +14,28 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from __future__ import print_function
 from cwrap import BaseCClass
+
 from res import ResPrototype
 from res.util.enums import MessageLevelEnum
 
 
 class Log(BaseCClass):
+    _open_log = ResPrototype("void* log_open(char*, message_level_enum)", bind=False)
     _get_filename = ResPrototype("char* log_get_filename(log)")
     _get_level = ResPrototype("message_level_enum log_get_level(log)")
     _set_level = ResPrototype("void log_set_level(log, message_level_enum)")
 
-    def __init__(self):
-        raise NotImplementedError("Class can not be instantiated directly!")
+    def __init__(self, log_filename, log_level):
+        c_ptr = self._open_log(log_filename, log_level)
+        if c_ptr:
+            super(Log, self).__init__(c_ptr)
+        else:
+            raise IOError("Failed to open log handle at:%s" % log_filename)
+
 
     def get_filename(self):
         return self._get_filename()
-        # return "ert_config.log"
 
     def get_level(self):
         return self._get_level()

--- a/python/res/util/res_log.py
+++ b/python/res/util/res_log.py
@@ -3,13 +3,15 @@ from res.util.enums import MessageLevelEnum
 
 
 class ResLog(object):
-    _init = ResPrototype("void res_log_init_log(message_level_enum, char*, bool)", bind=False)
+    _init = ResPrototype("bool res_log_init_log(message_level_enum, char*, bool)", bind=False)
     _write_log = ResPrototype("void res_log_add_message(message_level_enum, char*)", bind=False)
     _get_filename = ResPrototype("char* res_log_get_filename()", bind=False)
 
     @classmethod
     def init(cls, log_level, log_filename, verbose):
-        cls._init(MessageLevelEnum.to_enum(log_level), log_filename, verbose)
+        if not cls._init(MessageLevelEnum.to_enum(log_level), log_filename, verbose):
+            raise IOError("Failed to open log handle for file:%s" % log_filename)
+
 
     @classmethod
     def log(cls, log_level, message):

--- a/python/tests/res/util/test_res_log.py
+++ b/python/tests/res/util/test_res_log.py
@@ -1,10 +1,12 @@
 import os
-from res.util import ResLog
+from res.util import ResLog, Log
 from ecl.util.test import TestAreaContext
 from tests import ResTest
+from res.util.enums import MessageLevelEnum
 
 
 class ResLogTest(ResTest):
+
 
     def test_log(self):
         with TestAreaContext("python/res_log/log") as work_area:
@@ -29,4 +31,22 @@ class ResLogTest(ResTest):
             ResLog.log(1, message)
 
             self.assertEqual(ResLog.getFilename(), test_log_filename)
+
+
+    def test_log(self):
+        with TestAreaContext("python/log"):
+            logh = Log("logfile", MessageLevelEnum.LOG_DEBUG)
+
+            os.mkdir("read_only")
+            os.chmod("read_only", 0o500)
+            with self.assertRaises(IOError):
+                logh = Log("read_only/logfile.txt", MessageLevelEnum.LOG_DEBUG)
+
+
+    def test_init_perm_denied(self):
+        with TestAreaContext("python/res_log"):
+            os.mkdir("read_only")
+            os.chmod("read_only", 0o500)
+            with self.assertRaises(IOError):
+                ResLog.init(1, "read_only/logfile.txt", True)
 


### PR DESCRIPTION
Will not crash if opening a log handle fails. Important messages will go to `stderr` if no log has been opened.

Statoil Tests pass:
 [x]