### PR TITLE
WIP: fix compiler error in forward_load_context

### DIFF
--- a/lib/enkf/forward_load_context.cpp
+++ b/lib/enkf/forward_load_context.cpp
@@ -92,7 +92,7 @@ static void forward_load_context_load_ecl_sum(forward_load_context_type * load_c
     }
 
     if ((header_file != NULL) && (stringlist_get_size(data_files) > 0)) {
-      summary = ecl_sum_fread_alloc(header_file , data_files , SUMMARY_KEY_JOIN_STRING , false );
+      summary = ecl_sum_fread_alloc(header_file , data_files , SUMMARY_KEY_JOIN_STRING , false , false );
       {
         time_t end_time = ecl_config_get_end_date( load_context->ecl_config );
         if (end_time > 0) {


### PR DESCRIPTION
**Task**
There is a compiler error in forward_load_context.ccp.


**Approach**
In line 95: ecl_sum is loaded w/ lazy_bool=false.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

