### PR TITLE
Use standard fseek() instead of util_fseek()

### DIFF
--- a/lib/enkf/gen_kw.cpp
+++ b/lib/enkf/gen_kw.cpp
@@ -369,7 +369,7 @@ bool gen_kw_fload(gen_kw_type * gen_kw , const char * filename) {
     if (!readOK) {
       int counter = 0;
       readOK = true;
-      util_fseek( stream , 0 , SEEK_SET );
+      fseek( stream , 0 , SEEK_SET );
 
       while ((counter < size) && readOK) {
         char key[128];

--- a/lib/res_util/log.cpp
+++ b/lib/res_util/log.cpp
@@ -246,7 +246,7 @@ void log_sync(log_type * logh) {
 #ifdef HAVE_FSYNC
   fsync( logh->fd );
 #endif
-  util_fseek( logh->stream , 0 , SEEK_END );
+  fseek( logh->stream , 0 , SEEK_END );
 }
 
 

--- a/lib/res_util/tests/ert_util_matrix.cpp
+++ b/lib/res_util/tests/ert_util_matrix.cpp
@@ -121,7 +121,7 @@ void test_readwrite() {
       matrix_fread( m1 , stream );
       test_assert_int_equal( matrix_get_rows(m1) , matrix_get_rows( m2));
       test_assert_int_equal( matrix_get_columns(m1) , matrix_get_columns( m2));
-      util_fseek( stream , 0 , SEEK_SET);
+      fseek( stream , 0 , SEEK_SET);
       {
         matrix_type * m3 = matrix_fread_alloc( stream );
         test_assert_true( matrix_equal( m2 , m3 ));

--- a/lib/rms/rms_file.cpp
+++ b/lib/rms/rms_file.cpp
@@ -246,7 +246,7 @@ rms_tag_type * rms_file_fread_alloc_tag(rms_file_type * rms_file,
   rms_file_fopen_r(rms_file);
 
   long int start_pos = util_ftell(rms_file->stream);
-  util_fseek(rms_file->stream , 0 , SEEK_SET);
+  fseek(rms_file->stream , 0 , SEEK_SET);
   rms_file_init_fread(rms_file);
   while (true) {
     bool eof_tag = false;  // will be set by rms_tag
@@ -264,7 +264,7 @@ rms_tag_type * rms_file_fread_alloc_tag(rms_file_type * rms_file,
   }
 
   if (tag == NULL) {
-    util_fseek(rms_file->stream , start_pos , SEEK_SET);
+    fseek(rms_file->stream , start_pos , SEEK_SET);
     util_abort("%s: could not find tag: \"%s\" (with %s=%s) in file:%s - aborting.\n",
                __func__,
                tagname,
@@ -450,14 +450,14 @@ bool rms_file_is_roff(FILE * stream) {
   bool roff_file             = false;
 
   /* Skipping #roff-bin#0#  WILL Fail with formatted files */
-  util_fseek(stream, 1 + 1 + 8, SEEK_CUR);
+  fseek(stream, 1 + 1 + 8, SEEK_CUR);
 
 
   rms_util_fread_string(header , len+1 , stream);
   if (strncmp(rms_comment1 , header , len) == 0)
     roff_file = true;
 
-  util_fseek(stream , current_pos , SEEK_SET);
+  fseek(stream , current_pos , SEEK_SET);
   free(header);
   return roff_file;
 }

--- a/lib/rms/rms_tag.cpp
+++ b/lib/rms/rms_tag.cpp
@@ -205,7 +205,7 @@ static bool rms_tag_at_endtag(FILE *stream) {
     at_endtag = false;
 
   if (!at_endtag)
-    util_fseek(stream , init_pos , SEEK_SET);
+    fseek(stream , init_pos , SEEK_SET);
   return at_endtag;
 }
 

--- a/lib/rms/rms_tagkey.cpp
+++ b/lib/rms/rms_tagkey.cpp
@@ -432,7 +432,7 @@ static void rms_tagkey_set_data_size(rms_tagkey_type *tagkey , FILE *stream , in
       for (i=0; i < tagkey->size; i++)
         rms_util_fskip_string(stream);
       tagkey->data_size = util_ftell(stream) - init_pos;
-      util_fseek(stream , init_pos , SEEK_SET);
+      fseek(stream , init_pos , SEEK_SET);
     } else
       tagkey->data_size = strlen + 1;
   } else

--- a/lib/rms/rms_util.cpp
+++ b/lib/rms/rms_util.cpp
@@ -105,7 +105,7 @@ int rms_util_fread_strlen(FILE *stream) {
   int len;
   rms_util_fskip_string(stream);
   len = util_ftell(stream) - init_pos;
-  util_fseek(stream , init_pos , SEEK_SET);
+  fseek(stream , init_pos , SEEK_SET);
   return len;
 }
 
@@ -128,7 +128,7 @@ bool rms_util_fread_string(char *string , int max_length , FILE *stream) {
       if (max_length > 0) {
         if (pos == max_length) {
           read_ok = false;
-          util_fseek(stream , init_pos , SEEK_SET);
+          fseek(stream , init_pos , SEEK_SET);
           cont = false;
         }
       }


### PR DESCRIPTION
Step towards removing/hiding utility functions from libecl.