### PR TITLE
Default log

### DIFF
--- a/lib/enkf/enkf_main.cpp
+++ b/lib/enkf/enkf_main.cpp
@@ -1900,7 +1900,6 @@ void enkf_main_clear_data_kw( enkf_main_type * enkf_main ) {
 static enkf_main_type * enkf_main_alloc_empty( ) {
   enkf_main_type * enkf_main = (enkf_main_type *)util_malloc(sizeof * enkf_main);
   UTIL_TYPE_ID_INIT(enkf_main , ENKF_MAIN_ID);
-  res_log_open_empty();
   enkf_main->ensemble           = NULL;
   enkf_main->local_config       = NULL;
   enkf_main->rng_manager        = NULL;
@@ -2206,19 +2205,6 @@ int enkf_main_get_observation_count( const enkf_main_type * enkf_main, const cha
 }
 
 
-
-void enkf_main_log_fprintf_config( const enkf_main_type * enkf_main , FILE * stream ) {
-  fprintf( stream , CONFIG_COMMENTLINE_FORMAT );
-  fprintf( stream , CONFIG_COMMENT_FORMAT  , "Here comes configuration information about the ERT logging.");
-  fprintf( stream , CONFIG_KEY_FORMAT      , LOG_FILE_KEY );
-  fprintf( stream , CONFIG_ENDVALUE_FORMAT , res_log_get_filename());
-  fprintf(stream , CONFIG_KEY_FORMAT      , LOG_LEVEL_KEY );
-  fprintf(stream , CONFIG_INT_FORMAT , res_log_get_log_level());
-  fprintf(stream , "\n");
-
-  fprintf(stream , "\n");
-  fprintf(stream , "\n");
-}
 
 
 void enkf_main_install_SIGNALS(void) {

--- a/lib/enkf/log_config.cpp
+++ b/lib/enkf/log_config.cpp
@@ -22,6 +22,7 @@
 #include <ert/enkf/log_config.hpp>
 #include <ert/enkf/config_keys.hpp>
 #include <ert/enkf/model_config.hpp>
+#include <ert/enkf/enkf_defaults.hpp>
 
 struct log_config_struct {
 

--- a/lib/include/ert/enkf/enkf_defaults.hpp
+++ b/lib/include/ert/enkf/enkf_defaults.hpp
@@ -12,6 +12,8 @@
 #define ERT_ENKF_DEFAULT
 #include <stdbool.h>
 
+#define DEFAULT_LOG_FILE     "log.txt"
+
 #define DEFAULT_RUNPATH_KEY  "DEFAULT_RUNPATH"
 #define RERUN_RUNPATH_KEY    "DEFAULT_RERUN_PATH"
 

--- a/lib/include/ert/enkf/enkf_plot_gendata.hpp
+++ b/lib/include/ert/enkf/enkf_plot_gendata.hpp
@@ -19,9 +19,6 @@
 #ifndef ERT_ENKF_PLOT_GENDATA_H
 #define ERT_ENKF_PLOT_GENDATA_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/util/type_macros.h>
 #include <ert/util/double_vector.h>
@@ -31,6 +28,9 @@ extern "C" {
 #include <ert/enkf/enkf_config_node.hpp>
 #include <ert/enkf/enkf_plot_genvector.hpp>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 typedef struct enkf_plot_gendata_struct enkf_plot_gendata_type;

--- a/lib/include/ert/enkf/enkf_state.hpp
+++ b/lib/include/ert/enkf/enkf_state.hpp
@@ -18,9 +18,6 @@
 
 #ifndef ERT_ENKF_STATE_H
 #define ERT_ENKF_STATE_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <stdbool.h>
 
@@ -52,6 +49,10 @@ extern "C" {
 #include <ert/enkf/enkf_util.hpp>
 #include <ert/enkf/enkf_serialize.hpp>
 #include <ert/enkf/run_arg.hpp>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct enkf_state_struct    enkf_state_type;
 

--- a/lib/include/ert/res_util/log.hpp
+++ b/lib/include/ert/res_util/log.hpp
@@ -19,13 +19,13 @@
 #ifndef ERT_LOG_H
 #define ERT_LOG_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 //Same as pythons default log levels, but with different numeric values.
 typedef enum {
@@ -51,9 +51,11 @@ typedef enum {
 
 
 typedef struct log_struct log_type;
+  log_type   * log_open_file(const char *filename, message_level_type log_level);
+  log_type   * log_open_stream(FILE * stream, message_level_type log_level);
+
   void         log_add_message_stream(FILE * stream, bool add_timestamp, message_level_type message_level, const char * message);
   FILE       * log_get_stream(log_type * logh );
-  log_type   * log_open(const char *filename, message_level_type log_level);
   void         log_add_message(log_type *logh, message_level_type message_level,  const char* message);
   void         log_add_message_str(log_type *logh, message_level_type message_level , const char* message);
   void         log_add_fmt_message(log_type * logh , message_level_type message_level, const char * fmt , ...);
@@ -69,4 +71,5 @@ typedef struct log_struct log_type;
 #ifdef __cplusplus
 }
 #endif
+
 #endif

--- a/lib/include/ert/res_util/res_log.hpp
+++ b/lib/include/ert/res_util/res_log.hpp
@@ -19,22 +19,20 @@
 #ifndef RESLOG_H
 #define RESLOG_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdio.h>
 #include <stdbool.h>
 
 #include <ert/res_util/log.hpp>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 bool res_log_init_log(message_level_type log_level,const char * log_file_name, bool verbose);
 bool res_log_init_log_default_log_level(const char * log_file_name, bool verbose);
-bool res_log_init_log_default( bool verbose);
 void res_log_close();
-int res_log_get_log_level();
 const char * res_log_get_filename();
-void res_log_open_empty();
 
 void res_log_add_message(message_level_type message_level, const char* message);
 

--- a/lib/include/ert/res_util/res_util_defaults.hpp
+++ b/lib/include/ert/res_util/res_util_defaults.hpp
@@ -3,4 +3,3 @@
 */
 
 #define DEFAULT_LOG_LEVEL LOG_WARNING
-#define DEFAULT_LOG_FILE  "log.txt"

--- a/lib/res_util/tests/ert_util_logh.cpp
+++ b/lib/res_util/tests/ert_util_logh.cpp
@@ -30,13 +30,13 @@
 void test_open() {
   test_work_area_type * work_area = test_work_area_alloc("util/logh");
   {
-    log_type * logh = log_open( LOG_FILE , LOG_DEBUG);
+    log_type * logh = log_open_file( LOG_FILE , LOG_DEBUG);
     test_assert_not_NULL(logh);
     log_close( logh );
   }
 
   {
-    log_type * logh = log_open( LOG_FILE , LOG_DEBUG );
+    log_type * logh = log_open_file( LOG_FILE , LOG_DEBUG );
     log_add_message( logh , LOG_DEBUG , "Message");
     test_assert_int_equal( 1 , log_get_msg_count( logh ));
     log_close( logh );
@@ -49,7 +49,7 @@ void test_open() {
 void test_delete_empty() {
   test_work_area_type * work_area = test_work_area_alloc("logh_delete_empty");
   {
-    log_type * logh = log_open( LOG_FILE , LOG_DEBUG );
+    log_type * logh = log_open_file( LOG_FILE , LOG_DEBUG );
     test_assert_not_NULL(logh);
     log_close( logh );
 
@@ -57,19 +57,19 @@ void test_delete_empty() {
   }
 
   {
-    log_type * logh = log_open( LOG_FILE , LOG_DEBUG);
+    log_type * logh = log_open_file( LOG_FILE , LOG_DEBUG);
     log_close( logh );
 
     test_assert_false( util_file_exists( LOG_FILE ));
   }
 
   {
-    log_type * logh = log_open( LOG_FILE , LOG_DEBUG );
+    log_type * logh = log_open_file( LOG_FILE , LOG_DEBUG );
     log_add_message( logh , LOG_DEBUG , "Message");
     log_close( logh );
     test_assert_true( util_file_exists( LOG_FILE ));
 
-    logh = log_open( LOG_FILE , LOG_DEBUG );
+    logh = log_open_file( LOG_FILE , LOG_DEBUG );
     log_close( logh );
     test_assert_true( util_file_exists( LOG_FILE ));
   }
@@ -83,11 +83,11 @@ void test_delete_empty() {
 */
 void test_invalid_input() {
   test_work_area_type * work_area = test_work_area_alloc("logh_invalid_input");
-  test_assert_NULL( log_open( NULL, LOG_DEBUG));
+  test_assert_NULL( log_open_file( NULL, LOG_DEBUG));
 
   util_mkdir_p("read_only");
   chmod("read_only", 0500);
-  test_assert_NULL( log_open( "read_only/log.txt", LOG_DEBUG));
+  test_assert_NULL( log_open_file( "read_only/log.txt", LOG_DEBUG));
 
   test_work_area_free(work_area);
 }
@@ -98,7 +98,7 @@ void test_invalid_input() {
 */
 
 void test_file_deleted() {
-  log_type * logh = log_open( LOG_FILE , LOG_DEBUG );
+  log_type * logh = log_open_file( LOG_FILE , LOG_DEBUG );
   log_add_message( logh , LOG_DEBUG , "Message");
   util_unlink( LOG_FILE );
   test_assert_false( util_file_exists( LOG_FILE ));
@@ -106,10 +106,26 @@ void test_file_deleted() {
   test_assert_false( util_file_exists( LOG_FILE ));
 }
 
+
+void test_stream_open() {
+  test_work_area_type * work_area = test_work_area_alloc("logh_stream_open");
+  FILE * stream = util_fopen("log_file.txt", "w");
+  {
+    log_type * logh = log_open_stream( stream , LOG_DEBUG);
+    log_add_message(logh, LOG_DEBUG, "Message");
+    log_close(logh);
+  }
+  fputs("Can still write to stream \n", stream);
+  fclose(stream);
+  test_work_area_free(work_area);
+}
+
+
 int main(int argc , char ** argv) {
   test_open();
   test_delete_empty();
   test_file_deleted( );
   test_invalid_input();
+  test_stream_open( );
   exit(0);
 }

--- a/python/res/util/log.py
+++ b/python/res/util/log.py
@@ -21,9 +21,8 @@ from res.util.enums import MessageLevelEnum
 
 
 class Log(BaseCClass):
-    _open_log = ResPrototype("void* log_open(char*, message_level_enum)", bind=False)
+    _open_log = ResPrototype("void* log_open_file(char*, message_level_enum)", bind=False)
     _get_filename = ResPrototype("char* log_get_filename(log)")
-    _get_level = ResPrototype("message_level_enum log_get_level(log)")
     _set_level = ResPrototype("void log_set_level(log, message_level_enum)")
 
     def __init__(self, log_filename, log_level):
@@ -33,12 +32,8 @@ class Log(BaseCClass):
         else:
             raise IOError("Failed to open log handle at:%s" % log_filename)
 
-
     def get_filename(self):
         return self._get_filename()
-
-    def get_level(self):
-        return self._get_level()
 
     def set_level(self, level):
         self._set_level(self, level)


### PR DESCRIPTION
There is a bit of chicken and egg problem with the log system when there is an attempt to log something before the logging system has been set up. Previously if the log system tried to log something before logging was set up a default log file (`log.txt`) would be opened and the message written there, and then the proper log file would be written afterwards. This has been specially problematic because some of these logging calls have been issued when cwd has been in a read-only location filesystem wise, so opening the default log file `log.txt` has actually failed.

With the current PR we have added the capability to create logger instances around an already open `FILE *` object, and an in the case of attepting-to-log-before-log-has-been-initialized we will open a log object around `stdout`.

