### PR TITLE
Initialisation is explicitly serial - avoid thread_pool

### DIFF
--- a/lib/enkf/enkf_main_manage_fs.cpp
+++ b/lib/enkf/enkf_main_manage_fs.cpp
@@ -123,7 +123,6 @@ void enkf_main_initialize_from_scratch(enkf_main_type * enkf_main ,
                                        const ert_run_context_type * run_context) {
   int num_cpu = 4;
   int ens_size               = enkf_main_get_ensemble_size( enkf_main );
-  thread_pool_type * tp     = thread_pool_alloc( num_cpu , true );
   arg_pack_type ** arg_list = (arg_pack_type **) util_calloc( ens_size , sizeof * arg_list );
 
   for (int iens = 0; iens < ens_size; iens++) {
@@ -135,15 +134,13 @@ void enkf_main_initialize_from_scratch(enkf_main_type * enkf_main ,
       arg_pack_append_int( arg_list[iens] , iens );
       arg_pack_append_int( arg_list[iens] ,ert_run_context_get_init_mode(run_context));
 
-      thread_pool_add_job( tp , enkf_main_initialize_from_scratch_mt , arg_list[iens]);
+      enkf_main_initialize_from_scratch_mt(arg_list[iens]);
     }
   }
-  thread_pool_join( tp );
   for (int iens = 0; iens < ens_size; iens++){
     arg_pack_free( arg_list[iens] );
   }
   free( arg_list );
-  thread_pool_free( tp );
 }
 
 


### PR DESCRIPTION
In the testing phase for version 2.3 a worrying bug has surfaced. When running an ensemble of e.g. 100 realizations the enkf_fs storage becomes corrupted for some - e.g. two - realisations. At a superficial level I think it it is clear what happens: [Here](https://github.com/Statoil/libres/blob/master/lib/res_util/block_fs.cpp#L1313) is a code sequence which first seeks to correct location in a file, and then afterwards it writes.

In approx 1% of the cases the write ends up in a wrong location (the location prior to the seek); and then everything breaks. This PR "fixes it" by serializing the initialization. There is a performance hit with this; hopefully it can be reverted - but my feeling is that version 2.3 must be based on this.