### PR TITLE
Adding .py extension to .gitattributes. 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 *.hpp text
 *.c text
 *.h text
+*.py text


### PR DESCRIPTION
**Task**
Adding .py extension to .gitattributes.  This will convert CRLF into LF for .py files when cloning repository on linux.


