### PR TITLE
Fix run_analysis

### DIFF
--- a/lib/enkf/enkf_main.cpp
+++ b/lib/enkf/enkf_main.cpp
@@ -652,7 +652,7 @@ static int enkf_main_serialize_dataset( const ensemble_config_type * ens_config 
   for (int ikw=0; ikw < num_kw; ikw++) {
     const char             * key         = stringlist_iget(update_keys , ikw);
     enkf_config_node_type * config_node  = ensemble_config_get_node( ens_config , key );
-    if ((serialize_info[0].run_mode == SMOOTHER_UPDATE) && (enkf_config_node_get_var_type( config_node ) != PARAMETER)) {
+    if ((serialize_info[0].run_mode == SMOOTHER_RUN) && (enkf_config_node_get_var_type( config_node ) != PARAMETER)) {
       /* We have tried to serialize a dynamic node when we are
          smoother update mode; that does not make sense and we just
          continue. */
@@ -732,7 +732,7 @@ static void enkf_main_deserialize_dataset( ensemble_config_type * ensemble_confi
   for (int i = 0; i < stringlist_get_size( update_keys ); i++) {
     const char             * key         = stringlist_iget(update_keys , i);
     enkf_config_node_type * config_node  = ensemble_config_get_node( ensemble_config , key );
-    if ((serialize_info[0].run_mode == SMOOTHER_UPDATE) && (enkf_config_node_get_var_type( config_node ) != PARAMETER))
+    if ((serialize_info[0].run_mode == SMOOTHER_RUN) && (enkf_config_node_get_var_type( config_node ) != PARAMETER))
       /*
          We have tried to serialize a dynamic node when we are in
          smoother update mode; that does not make sense and we just
@@ -1253,7 +1253,7 @@ bool enkf_main_UPDATE(enkf_main_type * enkf_main , const int_vector_type * step_
 
 
 static bool enkf_main_smoother_update__(enkf_main_type * enkf_main , const int_vector_type * step_list , enkf_fs_type * source_fs, enkf_fs_type * target_fs) {
-  return enkf_main_UPDATE( enkf_main , step_list , source_fs , target_fs , 0 , SMOOTHER_UPDATE );
+  return enkf_main_UPDATE( enkf_main , step_list , source_fs , target_fs , 0 , SMOOTHER_RUN );
 }
 
 

--- a/lib/enkf/ert_run_context.cpp
+++ b/lib/enkf/ert_run_context.cpp
@@ -213,7 +213,6 @@ ert_run_context_type * ert_run_context_alloc_INIT_ONLY(enkf_fs_type * sim_fs,
 }
 
 
-
 ert_run_context_type * ert_run_context_alloc_SMOOTHER_RUN(enkf_fs_type * sim_fs , enkf_fs_type * target_update_fs ,
                                                           bool_vector_type * iactive ,
                                                           const path_fmt_type * runpath_fmt ,
@@ -221,7 +220,7 @@ ert_run_context_type * ert_run_context_alloc_SMOOTHER_RUN(enkf_fs_type * sim_fs 
 							  const subst_list_type * subst_list ,
                                                           int iter) {
 
-  ert_run_context_type * context = ert_run_context_alloc__( iactive , SMOOTHER_UPDATE , INIT_CONDITIONAL, sim_fs , target_update_fs , iter);
+  ert_run_context_type * context = ert_run_context_alloc__( iactive , SMOOTHER_RUN , INIT_CONDITIONAL, sim_fs , target_update_fs , iter);
   {
     stringlist_type * runpath_list = ert_run_context_alloc_runpath_list( iactive , runpath_fmt , subst_list , iter );
     stringlist_type * jobname_list = ert_run_context_alloc_jobname_list( iactive , jobname_fmt , subst_list );
@@ -245,6 +244,10 @@ ert_run_context_type * ert_run_context_alloc_SMOOTHER_RUN(enkf_fs_type * sim_fs 
   return context;
 }
 
+ert_run_context_type * ert_run_context_alloc_SMOOTHER_UPDATE(enkf_fs_type * sim_fs , enkf_fs_type * target_update_fs , bool_vector_type * iactive) {
+  return ert_run_context_alloc__( iactive , SMOOTHER_UPDATE , INIT_CONDITIONAL, sim_fs , target_update_fs , 0);
+}
+
 ert_run_context_type * ert_run_context_alloc(run_mode_type run_mode,
                                              init_mode_type init_mode,
                                              enkf_fs_type * sim_fs ,
@@ -256,7 +259,7 @@ ert_run_context_type * ert_run_context_alloc(run_mode_type run_mode,
                                              int iter) {
   switch (run_mode) {
 
-  case(SMOOTHER_UPDATE):
+  case(SMOOTHER_RUN):
     return ert_run_context_alloc_SMOOTHER_RUN( sim_fs , target_update_fs, iactive, runpath_fmt , jobname_fmt, subst_list , iter );
 
   case(ENSEMBLE_EXPERIMENT):

--- a/lib/include/ert/enkf/enkf_types.hpp
+++ b/lib/include/ert/enkf/enkf_types.hpp
@@ -153,8 +153,9 @@ typedef enum { TRUNCATE_NONE   = 0,
 
 typedef enum { //ENKF_ASSIMILATION       = 1,
                ENSEMBLE_EXPERIMENT     = 2,
-               SMOOTHER_UPDATE         = 4 ,
-               INIT_ONLY               = 8 } run_mode_type;
+               SMOOTHER_RUN            = 4 ,
+               INIT_ONLY               = 8 ,
+               SMOOTHER_UPDATE         = 16 } run_mode_type;
 
 
 #define ENKF_RUN_ENUM_DEFS {.value = 1 , .name = "ENKF_ASSIMILATION"},   \

--- a/lib/include/ert/enkf/ert_run_context.hpp
+++ b/lib/include/ert/enkf/ert_run_context.hpp
@@ -73,6 +73,8 @@ typedef struct ert_run_context_struct ert_run_context_type;
                                                             const subst_list_type * subst_list ,
                                                             int iter);
 
+  ert_run_context_type * ert_run_context_alloc_SMOOTHER_UPDATE(enkf_fs_type * sim_fs , enkf_fs_type * target_update_fs , bool_vector_type * iactive);
+
   void                     ert_run_context_set_sim_fs(ert_run_context_type * context, enkf_fs_type * sim_fs);
   void                     ert_run_context_set_update_target_fs(ert_run_context_type * context, enkf_fs_type * update_target_fs);
 

--- a/python/res/enkf/enums/enkf_run_enum.py
+++ b/python/res/enkf/enums/enkf_run_enum.py
@@ -25,5 +25,6 @@ class EnkfRunType(BaseCEnum):
 
 EnkfRunType.addEnum("ENKF_ASSIMILATION" , 1)
 EnkfRunType.addEnum("ENSEMBLE_EXPERIMENT" , 2)
-EnkfRunType.addEnum("SMOOTHER_UPDATE" , 4)
+EnkfRunType.addEnum("SMOOTHER_RUN" , 4)
 EnkfRunType.addEnum("INIT_ONLY" , 8)
+EnkfRunType.addEnum("SMOOTHER_UPDATE" , 16)

--- a/python/res/enkf/ert_run_context.py
+++ b/python/res/enkf/ert_run_context.py
@@ -27,6 +27,7 @@ class ErtRunContext(BaseCClass):
     _alloc              = ResPrototype("void* ert_run_context_alloc( enkf_run_mode_enum , enkf_init_mode_enum, enkf_fs , enkf_fs, bool_vector, path_fmt ,char*, subst_list, int)", bind = False)
     _alloc_ensemble_experiment = ResPrototype("ert_run_context_obj ert_run_context_alloc_ENSEMBLE_EXPERIMENT( enkf_fs, bool_vector, path_fmt ,char*, subst_list, int)", bind = False)
     _alloc_ensemble_smoother = ResPrototype("ert_run_context_obj ert_run_context_alloc_SMOOTHER_RUN( enkf_fs , enkf_fs, bool_vector, path_fmt ,char*, subst_list, int)", bind = False)
+    _alloc_ensemble_smoother_update = ResPrototype("ert_run_context_obj ert_run_context_alloc_SMOOTHER_UPDATE(enkf_fs , enkf_fs , bool_vector)", bind = False)
     _alloc_runpath_list = ResPrototype("stringlist_obj ert_run_context_alloc_runpath_list(bool_vector, path_fmt, subst_list, int)", bind = False)
     _alloc_runpath      = ResPrototype("char* ert_run_context_alloc_runpath(int, path_fmt, subst_list, int)", bind = False)
     _get_size           = ResPrototype("int ert_run_context_get_size( ert_run_context )")
@@ -74,6 +75,10 @@ class ErtRunContext(BaseCClass):
         run_context._subst_list = subst_list
 
         return run_context
+
+    @classmethod
+    def ensemble_smoother_update(cls, sim_fs, target_fs, mask):
+        return cls._alloc_ensemble_smoother_update( sim_fs, target_fs, mask)
 
 
     def is_active(self, index):

--- a/python/tests/res/enkf/test_es_update.py
+++ b/python/tests/res/enkf/test_es_update.py
@@ -33,11 +33,7 @@ class ESUpdateTest(ResTest):
             sim_fs = fsm.getFileSystem("default_0")
             target_fs = fsm.getFileSystem("target")
             mask = BoolVector( initial_size = ert.getEnsembleSize(), default_value = True)
-            model_config = ert.getModelConfig( )
-            path_fmt = model_config.getRunpathFormat( )
-            jobname_fmt = model_config.getJobnameFormat( )
-            subst_list = None
-            run_context = ErtRunContext.ensemble_smoother( sim_fs, target_fs, mask, path_fmt, jobname_fmt, subst_list, 0)
+            run_context = ErtRunContext.ensemble_smoother_update( sim_fs, target_fs, mask )
             es_update.smootherUpdate( run_context )
 
 


### PR DESCRIPTION
**Task**
There is a bug in program ert, due to an obsolete version of run_analysis. 


**Approach**
In repo Statoil/ert, run_analysis call es_update.smoother_update w/ run_context. To that regard, a classmethod is created in ErtRunContext, allowing for a simpler allocation of a run_context object.


**Pre un-WIP checklist**
- [x] Statoil tests pass locally
- [x] Have completed graphical integration test steps
