### PR TITLE
Remove python from RMS 2013 path

### DIFF
--- a/python/res/fm/rms/rms_run.py
+++ b/python/res/fm/rms/rms_run.py
@@ -25,7 +25,9 @@ def _remove_python_from_path(path):
     path_elems = []
     for elem in path.split(os.pathsep):
         if os.path.isfile(os.path.join(elem, python_exec)):
-            print("**Warning: the path: {} is removed from $PATH to avoid conflict with RMS internal python interprete".format(elem))
+            print('**Warning: the path: {} is removed from $PATH to avoid '
+                  'conflict with RMS internal python interpreter. To avoid '
+                  'this, please use RMS 10 or newer.'.format(elem))
         else:
             path_elems.append(elem)
 
@@ -178,12 +180,12 @@ class RMSRun(object):
                     env.pop(key)
                     continue
 
-                value = value.strip()
+                value = str(value).strip()
                 if len(value) == 0:
                     env.pop(key)
                     continue
 
-                env[key] = str(value)
+                env[key] = value
 
             os.execve( self.config.executable , args, env )
         else:

--- a/python/res/fm/rms/rms_run.py
+++ b/python/res/fm/rms/rms_run.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 import os.path
@@ -171,11 +172,17 @@ class RMSRun(object):
 
         if exec_env:
             env = os.environ.copy()
-            for key,value in exec_env.iteritems():
-                if value:
+            keep_val = lambda v: (
+                    v is not None and (
+                        not isinstance(v, basestring)
+                        or len(v.strip()) > 0
+                    ))
+            for key, value in exec_env.items():
+                if keep_val(value):
                     env[key] = value
                 elif key in env:
-                    del env[key]
+                    env.pop(key)
+
             os.execve( self.config.executable , args, env )
         else:
             os.execv(self.config.executable, args )

--- a/python/res/job_queue/job_manager.py
+++ b/python/res/job_queue/job_manager.py
@@ -490,7 +490,8 @@ class JobManager(object):
 
         exec_env = job.get("exec_env")
         if exec_env:
-            with open("%s_exec_env.json" % job.get("name"), "w") as f:
+            exec_name,_ = os.path.splitext(os.path.basename(job.get('executable')))
+            with open("%s_exec_env.json" % exec_name, "w") as f:
                 f.write(json.dumps(exec_env))
 
         pid = os.fork()

--- a/python/tests/res/fm/rms
+++ b/python/tests/res/fm/rms
@@ -11,7 +11,11 @@ if "target_file" in config:
         f.write("this is the target file\n")
 
 with open('env.json', 'w') as f:
-    json.dump({ 'PATH': os.environ['PATH'] }, f)
+    json.dump({
+        key: os.environ[key]
+        for key in ('PATH', 'RMS_TEST_VAR')
+        if key in os.environ
+    }, f)
 
 sys.exit(config["exit_status"])
 

--- a/python/tests/res/fm/rms
+++ b/python/tests/res/fm/rms
@@ -10,5 +10,8 @@ if "target_file" in config:
     with open(config["target_file"], "w") as f:
         f.write("this is the target file\n")
 
+with open('env.json', 'w') as f:
+    json.dump({ 'PATH': os.environ['PATH'] }, f)
+
 sys.exit(config["exit_status"])
 

--- a/python/tests/res/fm/rms
+++ b/python/tests/res/fm/rms
@@ -4,18 +4,21 @@ import json
 import sys
 import os
 
-config = json.load(open("action.json"))
+config = {"exit_status" : 0}
+if os.path.isfile("action.json"):
+    config = json.load(open("action.json"))
 
 if "target_file" in config:
     with open(config["target_file"], "w") as f:
         f.write("this is the target file\n")
 
 with open('env.json', 'w') as f:
-    json.dump({
-        key: os.environ[key]
-        for key in ('PATH', 'RMS_TEST_VAR')
-        if key in os.environ
-    }, f)
+    env = {}
+    for key in ("PATH", "RMS_TEST_VAR"):
+        if key in os.environ:
+            env[key] = os.environ[key]
+
+    json.dump(env, f)
 
 sys.exit(config["exit_status"])
 

--- a/python/tests/res/fm/rms.sh
+++ b/python/tests/res/fm/rms.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# The only purpose of this funny little file is to serve as mock rms executable
+# for the rms2013 test, which just verifies that we have removed 'python' from
+# the PATH. Since we (hopefully ..) don't have Python in the path any longer the
+# script must be implemented in another language.
+
+echo $PATH > PATH

--- a/python/tests/res/job_queue/test_jobmanager.py
+++ b/python/tests/res/job_queue/test_jobmanager.py
@@ -247,7 +247,6 @@ class JobManagerTest(TestCase):
             exit_status, msg = jobm.runJob(jobm[0])
             self.assertEqual(exit_status, 1)
 
-
     def test_verify_executable(self):
         with TestAreaContext(gen_area_name("no_executable", create_jobs_json)):
             with self.assertRaises(IOError):
@@ -434,7 +433,7 @@ class JobManagerTest(TestCase):
                 f.write("""#!/usr/bin/env python\n
 import os
 import json
-with open("EXEC_ENV_exec_env.json") as f:
+with open("exec_env_exec_env.json") as f:
      exec_env = json.load(f)
 assert exec_env["TEST_ENV"] == "123"
 assert exec_env["NOT_SET"] is None

--- a/share/ert/forward-models/res/script/rms
+++ b/share/ert/forward-models/res/script/rms
@@ -10,4 +10,4 @@ export_path = sys.argv[5]
 import_path = sys.argv[6]
 workflow = sys.argv[7]
 
-run(iens, project, workflow, run_path, target_file=target_file, import_path=import_path, export_path=export_path)
+run(iens, project, workflow, run_path, target_file=None, import_path=import_path, export_path=export_path)


### PR DESCRIPTION
**Task**
RMS was failing when using version 2013, because it picked up the Komodo Python from PATH, and hence also Python 2 packages.

**Approach**
If version is 2013, filter path for folders containing Python when running RMS.

**Pre un-WIP checklist**
- [x] Statoil tests pass locally

I have fixed some more minor Python3 things + made sure rms mock executable can run without Python
