### PR TITLE
Robustify rms path cleaner

### DIFF
--- a/python/res/fm/rms/rms_run.py
+++ b/python/res/fm/rms/rms_run.py
@@ -21,6 +21,9 @@ def pushd(path):
 
 
 def _remove_python_from_path(path):
+    if path is None:
+        return path
+
     python_exec = 'python'
     path_elems = []
     for elem in path.split(os.pathsep):


### PR DESCRIPTION
You are not doing very well if the path passed to RMS is completely empty, but it is more informative if it crashes later on with an error indicating why this is not a good idea. Since we are patching a temporary fix that will blow up anyway, I did not add a test.