### PR TITLE
Remove komodo from RMS PYTHONPATH

### DIFF
--- a/python/tests/res/fm/rms
+++ b/python/tests/res/fm/rms
@@ -14,11 +14,10 @@ if "target_file" in config:
 
 with open('env.json', 'w') as f:
     env = {}
-    for key in ("PATH", "RMS_TEST_VAR"):
+    for key in ("PATH", "RMS_TEST_VAR", "PYTHONPATH"):
         if key in os.environ:
             env[key] = os.environ[key]
 
     json.dump(env, f)
 
 sys.exit(config["exit_status"])
-

--- a/python/tests/res/fm/rms.sh
+++ b/python/tests/res/fm/rms.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# The only purpose of this funny little file is to serve as mock rms executable
-# for the rms2013 test, which just verifies that we have removed 'python' from
-# the PATH. Since we (hopefully ..) don't have Python in the path any longer the
-# script must be implemented in another language.
-
-echo $PATH > PATH


### PR DESCRIPTION
**Task**
Fix environment problem with `RMS 2013`. This is done by removing _komodo_ from `PYTHONPATH` passed to _RMS_ if _RMS_ version is `2013`.

I also cleaned up the tests a bit as we no longer depend on `python` not being available in `PATH`, as we thought earlier..

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
