### PR TITLE
WIP: Smspec std::vector in api

### DIFF
--- a/lib/include/ert/enkf/block_obs.hpp
+++ b/lib/include/ert/enkf/block_obs.hpp
@@ -18,9 +18,7 @@
 
 #ifndef ERT_BLOCK_OBS_H
 #define ERT_BLOCK_OBS_H
-#ifdef __cplusplus
-extern "C" {
-#endif
+
 #include <ert/sched/history.hpp>
 
 #include <ert/config/conf.hpp>
@@ -33,6 +31,10 @@ extern "C" {
 #include <ert/enkf/field_config.hpp>
 #include <ert/enkf/field.hpp>
 #include <ert/enkf/active_list.hpp>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 

--- a/lib/include/ert/enkf/gen_data.hpp
+++ b/lib/include/ert/enkf/gen_data.hpp
@@ -18,9 +18,6 @@
 
 #ifndef ERT_GEN_DATA_H
 #define ERT_GEN_DATA_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/util/util.h>
 #include <ert/util/bool_vector.h>
@@ -34,6 +31,11 @@ extern "C" {
 #include <ert/enkf/gen_data_common.hpp>
 #include <ert/enkf/gen_data_config.hpp>
 #include <ert/enkf/forward_load_context.hpp>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 void                      gen_data_assert_size( gen_data_type * gen_data , int size , int report_step);
 bool                      gen_data_forward_load(gen_data_type * gen_data , const char * ecl_file , const forward_load_context_type * load_context);

--- a/lib/include/ert/enkf/model_config.hpp
+++ b/lib/include/ert/enkf/model_config.hpp
@@ -18,9 +18,7 @@
 
 #ifndef ERT_MODEL_CONFIG_H
 #define ERT_MODEL_CONFIG_H
-#ifdef __cplusplus
-extern "C" {
-#endif
+
 
 #include <stdbool.h>
 #include <time.h>
@@ -43,6 +41,11 @@ extern "C" {
 #include <ert/enkf/enkf_types.hpp>
 #include <ert/enkf/fs_types.hpp>
 #include <ert/enkf/time_map.hpp>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
   typedef struct model_config_struct model_config_type;
   const char *           model_config_get_data_root( const model_config_type * model_config );

--- a/lib/include/ert/sched/history.hpp
+++ b/lib/include/ert/sched/history.hpp
@@ -18,9 +18,6 @@
 
 #ifndef ERT_HISTORY_H
 #define ERT_HISTORY_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -33,6 +30,11 @@ extern "C" {
 #include <ert/ecl/ecl_sum.h>
 
 #include <ert/sched/sched_file.hpp>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 typedef enum {


### PR DESCRIPTION
**Task**
Smspec std::vector in api

moved include statements out of extern C for several objects.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#512
