### PR TITLE
WIP: Xxx vector type resize w default

### DIFF
--- a/lib/enkf/enkf_state.cpp
+++ b/lib/enkf/enkf_state.cpp
@@ -408,7 +408,7 @@ static bool enkf_state_internalize_dynamic_eclipse_results(ensemble_config_type 
         const int step2  = ecl_sum_get_last_report_step( summary );  /* Step2 is just taken from the number of steps found in the summary file. */
 
         int_vector_iset_block( time_index , 0 , load_start , -1 );
-        int_vector_resize( time_index , step2 + 1);
+        int_vector_resize( time_index , step2 + 1, -1);
 
         const ecl_smspec_type * smspec = ecl_sum_get_smspec(summary);
 

--- a/lib/enkf/summary.cpp
+++ b/lib/enkf/summary.cpp
@@ -114,7 +114,7 @@ void summary_read_from_buffer(summary_type * summary,
     double default_value = buffer_fread_double(buffer);
 
     double_vector_set_default(summary->data_vector, default_value);
-    double_vector_resize(summary->data_vector, size);
+    double_vector_resize(summary->data_vector, size, default_value);
     buffer_fread(buffer,
                  double_vector_get_ptr(summary->data_vector),
                  double_vector_element_size(summary->data_vector),

--- a/lib/enkf/time_map.cpp
+++ b/lib/enkf/time_map.cpp
@@ -550,7 +550,7 @@ void time_map_summary_upgrade107( time_map_type * map , const ecl_sum_type * ecl
   int first_step = ecl_sum_get_first_report_step( ecl_sum );
   int last_step  = ecl_sum_get_last_report_step( ecl_sum );
 
-  time_t_vector_resize( map->map , last_step + 1);
+  time_t_vector_resize( map->map , last_step + 1, 0);
   time_t_vector_iset_block( map->map , 0 , first_step , DEFAULT_TIME);
   for (int step=first_step; step <= last_step; step++) {
     if (ecl_sum_has_report_step(ecl_sum , step)) {

--- a/lib/enkf/time_map.cpp
+++ b/lib/enkf/time_map.cpp
@@ -550,7 +550,7 @@ void time_map_summary_upgrade107( time_map_type * map , const ecl_sum_type * ecl
   int first_step = ecl_sum_get_first_report_step( ecl_sum );
   int last_step  = ecl_sum_get_last_report_step( ecl_sum );
 
-  time_t_vector_resize( map->map , last_step + 1, 0);
+  time_t_vector_resize( map->map , last_step + 1, DEFAULT_TIME);
   time_t_vector_iset_block( map->map , 0 , first_step , DEFAULT_TIME);
   for (int step=first_step; step <= last_step; step++) {
     if (ecl_sum_has_report_step(ecl_sum , step)) {

--- a/lib/include/ert/enkf/block_obs.hpp
+++ b/lib/include/ert/enkf/block_obs.hpp
@@ -18,9 +18,7 @@
 
 #ifndef ERT_BLOCK_OBS_H
 #define ERT_BLOCK_OBS_H
-#ifdef __cplusplus
-extern "C" {
-#endif
+
 #include <ert/sched/history.hpp>
 
 #include <ert/config/conf.hpp>
@@ -33,6 +31,10 @@ extern "C" {
 #include <ert/enkf/field_config.hpp>
 #include <ert/enkf/field.hpp>
 #include <ert/enkf/active_list.hpp>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 

--- a/lib/include/ert/enkf/gen_data.hpp
+++ b/lib/include/ert/enkf/gen_data.hpp
@@ -18,9 +18,6 @@
 
 #ifndef ERT_GEN_DATA_H
 #define ERT_GEN_DATA_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <ert/util/util.h>
 #include <ert/util/bool_vector.h>
@@ -34,6 +31,11 @@ extern "C" {
 #include <ert/enkf/gen_data_common.hpp>
 #include <ert/enkf/gen_data_config.hpp>
 #include <ert/enkf/forward_load_context.hpp>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 void                      gen_data_assert_size( gen_data_type * gen_data , int size , int report_step);
 bool                      gen_data_forward_load(gen_data_type * gen_data , const char * ecl_file , const forward_load_context_type * load_context);

--- a/lib/include/ert/enkf/model_config.hpp
+++ b/lib/include/ert/enkf/model_config.hpp
@@ -18,9 +18,7 @@
 
 #ifndef ERT_MODEL_CONFIG_H
 #define ERT_MODEL_CONFIG_H
-#ifdef __cplusplus
-extern "C" {
-#endif
+
 
 #include <stdbool.h>
 #include <time.h>
@@ -43,6 +41,11 @@ extern "C" {
 #include <ert/enkf/enkf_types.hpp>
 #include <ert/enkf/fs_types.hpp>
 #include <ert/enkf/time_map.hpp>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
   typedef struct model_config_struct model_config_type;
   const char *           model_config_get_data_root( const model_config_type * model_config );

--- a/lib/include/ert/sched/history.hpp
+++ b/lib/include/ert/sched/history.hpp
@@ -18,9 +18,6 @@
 
 #ifndef ERT_HISTORY_H
 #define ERT_HISTORY_H
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -33,6 +30,11 @@ extern "C" {
 #include <ert/ecl/ecl_sum.h>
 
 #include <ert/sched/sched_file.hpp>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 typedef enum {


### PR DESCRIPTION
**Task**
As a part of converting libecl/libres/ert code to c++, the xxx_vector_type objects are under removal, and will be replaced by std::vector. To facilitate the removal, the API of xxx_vector_type is made similar to std::vector. One obstacle is the use of the default_value parameter. This is memorized and used for resize operations, whereas for std::vector, this parameter has to be specified for each resize operation (or 0 is used).

This PR disregards the setting of default_value for the function xxx_vector_resize.


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#515
