### PR TITLE
Make jobs sent to kibana ordered as job_list

### DIFF
--- a/python/res/job_queue/job_manager.py
+++ b/python/res/job_queue/job_manager.py
@@ -167,7 +167,7 @@ class JobManager(object):
                         "python_version": python_vs,
                         "kernel_version": release,
                         }
-        logged_fields.update({"jobs": self._job_map.values()})
+        logged_fields.update({"jobs": self._ordered_job_map_values()})
         self.postMessage(extra_fields=logged_fields)
         cond_unlink("EXIT")
         cond_unlink(self.EXIT_file)
@@ -256,9 +256,14 @@ class JobManager(object):
                 if job["stdout"]:
                    job["stdout"] = "%s.%d" % (job["stdout"], index)
 
+    def _ordered_job_map_values(self):
+        ordered_map_values = []
+        for index, job in enumerate(self.job_list):
+            ordered_map_values.append(self._job_map[job["name"]])
+        return ordered_map_values
+
     def __contains__(self, key):
         return key in self._job_map
-
 
     def __len__(self):
         return len(self.job_list)

--- a/python/tests/res/job_queue/test_jobmanager.py
+++ b/python/tests/res/job_queue/test_jobmanager.py
@@ -368,7 +368,7 @@ class JobManagerTest(TestCase):
             self.assertEqual( "/path/to/data" , os.environ["DATA_ROOT"])
             self.assertEqual( "ERT_RUN_ID", os.environ["ERT_RUN_ID"])
 
-    def test_data_from_forward_model_json(self):
+    def test_data_from_forward_model_json_no_root(self):
         with TestAreaContext("json_from_forward_model_NO_DATA_ROOT"):
             with open("jobs.json", "w") as f:
                 f.write(JSON_STRING_NO_DATA_ROOT)
@@ -460,6 +460,21 @@ assert exec_env["NOT_SET"] is None
             self.assertEqual(len(exec_env), 2)
             exit_status, msg = jobm.runJob(job0)
             self.assertEqual(exit_status, 0)
+
+    def test_job_list(self):
+          with TestAreaContext("json_from_forward_model"):
+            with open("jobs.json", "w") as f:
+                f.write(JSON_STRING)
+            job_manager = JobManager()
+            job_manager.job_list = [{'name': 'job1'}, {'name': 'job2'}, {'name': 'another_job3'}, {'name': 'another_job01'}]
+            job_manager._job_map = {'job1': {'name': 'job1'}, 'job2': {'name': 'job2'}, 'another_job3': {'name': 'another_job3'}, 'another_job01': {'name': 'another_job01'}}
+            vals = job_manager._ordered_job_map_values()
+            
+            # Verify _job_map.values() is indeed giving us values in wrong order
+            self.assertNotEqual(job_manager.job_list, job_manager._job_map.values())
+
+            # Verify _ordered_job_map_values is giving us values in same order as job_list
+            self.assertEqual(job_manager.job_list, vals)
 
 
 

--- a/python/tests/res/job_queue/test_jobmanager.py
+++ b/python/tests/res/job_queue/test_jobmanager.py
@@ -461,16 +461,16 @@ assert exec_env["NOT_SET"] is None
             exit_status, msg = jobm.runJob(job0)
             self.assertEqual(exit_status, 0)
 
-    def test_job_list(self):
+    def test_job_list_to_log_ordering(self):
           with TestAreaContext("json_from_forward_model"):
             with open("jobs.json", "w") as f:
                 f.write(JSON_STRING)
             job_manager = JobManager()
-            job_manager.job_list = [{'name': 'job1'}, {'name': 'job2'}, {'name': 'another_job3'}, {'name': 'another_job01'}]
-            job_manager._job_map = {'job1': {'name': 'job1'}, 'job2': {'name': 'job2'}, 'another_job3': {'name': 'another_job3'}, 'another_job01': {'name': 'another_job01'}}
+            job_manager.job_list = [{'name': 'b'}, {'name': 'd'}, {'name': 'a'}, {'name': 'c'}]
+            job_manager._job_map = {'b': {'name': 'b'}, 'd': {'name': 'd'}, 'a': {'name': 'a'}, 'c': {'name': 'c'}}
             vals = job_manager._ordered_job_map_values()
             
-            # Verify _job_map.values() is indeed giving us values in wrong order
+            # Verify _job_map.values() is indeed giving us values in not wanted order
             self.assertNotEqual(job_manager.job_list, job_manager._job_map.values())
 
             # Verify _ordered_job_map_values is giving us values in same order as job_list


### PR DESCRIPTION
**dict**.values() gives all values in _alphabetical order_ sorted by key names. Made a method creating the array in correct order from job_list

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#

Resolves #421 