### PR TITLE
Properly internalize custom kw

### DIFF
--- a/lib/enkf/enkf_node.cpp
+++ b/lib/enkf/enkf_node.cpp
@@ -407,7 +407,11 @@ bool enkf_node_forward_load(enkf_node_type *enkf_node , const forward_load_conte
       /* Fast path for loading summary data. */
       loadOK = enkf_node->forward_load(enkf_node->data , NULL  , load_context);
     else {
-      char * input_file = enkf_config_node_alloc_infile(enkf_node->config , forward_load_context_get_load_step( load_context ));
+      char * input_file = NULL;
+      if (enkf_node_get_impl_type(enkf_node) == CUSTOM_KW)
+         input_file = enkf_config_node_alloc_infile(enkf_node->config, -1);
+      else
+        input_file = enkf_config_node_alloc_infile(enkf_node->config, forward_load_context_get_load_step(load_context));
 
       if (input_file != NULL) {
         char * file = util_alloc_filename( forward_load_context_get_run_path( load_context ) , input_file , NULL);

--- a/test-data/local/custom_kw/jobs/DUMP_PAIRS
+++ b/test-data/local/custom_kw/jobs/DUMP_PAIRS
@@ -1,0 +1,1 @@
+EXECUTABLE dump_pairs

--- a/test-data/local/custom_kw/jobs/dump_pairs
+++ b/test-data/local/custom_kw/jobs/dump_pairs
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import sys
+
+if __name__ == '__main__':
+    output_file = sys.argv[1]
+    idx = int(sys.argv[2])
+
+    data = {'A': 1, 'B': 2}
+    with open(output_file, 'w') as f:
+        for key, value in data.items():
+            f.write('{} {}\n'.format(key, value*idx))

--- a/test-data/local/custom_kw/minimal.ert
+++ b/test-data/local/custom_kw/minimal.ert
@@ -1,0 +1,12 @@
+JOBNAME CUSTOM_KW_%d
+QUEUE_SYSTEM LOCAL
+QUEUE_OPTION LOCAL MAX_RUNNING 5
+
+RUNPATH minimal_runpath/iteration_%d/realization_%d
+ENSPATH minimal_storage
+NUM_REALIZATIONS 5
+
+INSTALL_JOB dump_pairs jobs/DUMP_PAIRS
+SIMULATION_JOB dump_pairs pairs.out <IENS>
+
+CUSTOM_KW PAIRS pairs.out


### PR DESCRIPTION
**Task**
Make it possible to reload `custom_kw` data with a second `enkf_main` object.
Resolves #425 

**Approach**
- Fix bug that did not allow for only using data keyword `custom_kw`. Very simple fix, might have to come back to this one... Update: In particular I think `custom_kw` should just use the format string for the file name as is, instead of hacking around it by substituting by `-1`.
- Make a test that displays the lacking internalisation.

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps
