### PR TITLE
Propagate version in RMS forward model

### DIFF
--- a/share/ert/forward-models/res/script/rms
+++ b/share/ert/forward-models/res/script/rms
@@ -10,4 +10,12 @@ export_path = sys.argv[5]
 import_path = sys.argv[6]
 workflow = sys.argv[7]
 
-run(iens, project, workflow, run_path, target_file=None, import_path=import_path, export_path=export_path)
+run(iens,
+    project,
+    workflow,
+    run_path,
+    target_file=None,
+    import_path=import_path,
+    export_path=export_path,
+    version=version,
+    )


### PR DESCRIPTION
**Task**
The very thin RMS script did not propagate the version. This is now fixed.
Resolves #452 

**Pre un-WIP checklist**
- [ ] Statoil tests pass locally