### PR TITLE
Suggestions for new PR template in libecl, libres and ERT repos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-**Task**
-_Short description of the task_
+**Issue**
+Resolves #my_issue
 
 
 **Approach**
@@ -7,8 +7,8 @@ _Short description of the approach_
 
 
 **Pre un-WIP checklist**
-- [ ] Statoil tests pass locally
 - [ ] Have completed graphical integration test steps
+
 
 **Depends on**
 * Statoil/libecl#


### PR DESCRIPTION
Since the original template was created we've started using GitHub issues and we have a Jenkins job running all the internal tests as well. I've made a suggestion for an updated template based on this. Will merge the same one in _libecl_ and _ERT_ (besides the _depends on_-section), when this one is approved.

------------------------------------------------------------------
**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_


**Pre _ready for review_ checklist**
- [ ] Have completed graphical integration test steps


**Depends on**
* Statoil/libecl#

------------------------------------------------------------------

**Task**
_Short description of the task_


**Approach**
_Short description of the approach_


**Pre un-WIP checklist**
- [ ] Statoil tests pass locally
- [ ] Have completed graphical integration test steps

**Depends on**
* Statoil/libecl#
