### PR TITLE
Std scale correlated obs will call deactivate outliers first

### DIFF
--- a/lib/enkf/enkf_main.cpp
+++ b/lib/enkf/enkf_main.cpp
@@ -994,17 +994,18 @@ static void enkf_main_update__(enkf_main_type * enkf_main, const int_vector_type
         local_obsdata_reset_tstep_list(obsdata, step_list);
 
         const analysis_config_type * analysis_config = enkf_main_get_analysis_config(enkf_main);
+        double alpha = analysis_config_get_alpha(analysis_config);
+        double std_cutoff = analysis_config_get_std_cutoff(analysis_config);
+
         if (analysis_config_get_std_scale_correlated_obs(analysis_config)) {
           double scale_factor = enkf_obs_scale_correlated_std(enkf_main->obs, source_fs,
-                                                              ens_active_list, obsdata, false);
+                                                              ens_active_list, obsdata, std_cutoff, alpha, false);
           res_log_finfo("Scaling standard deviation in obdsata set:%s with %g",
                         local_obsdata_get_name(obsdata), scale_factor);
         }
         enkf_obs_get_obs_and_measure_data(enkf_main->obs, source_fs, obsdata,
                                           ens_active_list, meas_data, obs_data);
 
-        double alpha = analysis_config_get_alpha(analysis_config);
-        double std_cutoff = analysis_config_get_std_cutoff(analysis_config);
         enkf_analysis_deactivate_outliers(obs_data, meas_data,
                                           std_cutoff, alpha, enkf_main->verbose);
 

--- a/lib/enkf/enkf_main_jobs.cpp
+++ b/lib/enkf/enkf_main_jobs.cpp
@@ -551,8 +551,12 @@ void * enkf_main_std_scale_correlated_obs_JOB(void * self, const stringlist_type
     }
 
 
-    if (local_obsdata_get_size(obsdata) > 0)
-      enkf_obs_scale_correlated_std(obs, fs, realizations, obsdata, verbose );
+    if (local_obsdata_get_size(obsdata) > 0) {
+      const analysis_config_type * analysis_config = enkf_main_get_analysis_config( enkf_main );
+      double alpha = analysis_config_get_alpha(analysis_config);
+      double std_cutoff = analysis_config_get_std_cutoff(analysis_config);
+      enkf_obs_scale_correlated_std(obs, fs, realizations, obsdata, alpha, std_cutoff, verbose );
+    }
     else if (verbose)
       printf("**Warning: Your list of arguments did not match any observation keys - no scaling performed.\n");
 

--- a/lib/include/ert/enkf/enkf_obs.hpp
+++ b/lib/include/ert/enkf/enkf_obs.hpp
@@ -96,7 +96,13 @@ extern "C" {
   void              enkf_obs_scale_std(enkf_obs_type * enkf_obs, double scale_factor);
   void enkf_obs_local_scale_std( const enkf_obs_type * enkf_obs , const local_obsdata_type * local_obsdata, double scale_factor);
   void              enkf_obs_add_local_nodes_with_data(const enkf_obs_type * enkf_obs , local_obsdata_type * local_obs , enkf_fs_type *fs , const bool_vector_type * ens_mask);
-  double            enkf_obs_scale_correlated_std(const enkf_obs_type * enkf_obs , enkf_fs_type * fs , const int_vector_type * ens_active_list , const local_obsdata_type * local_obsdata, bool verbose);
+  double            enkf_obs_scale_correlated_std(const enkf_obs_type * enkf_obs ,
+                                                  enkf_fs_type * fs ,
+                                                  const int_vector_type * ens_active_list ,
+                                                  const local_obsdata_type * local_obsdata,
+                                                  double alpha,
+                                                  double std_cutoff,
+                                                  bool verbose);
   local_obsdata_type * enkf_obs_alloc_all_active_local_obs( const enkf_obs_type * enkf_obs , const char * key);
   conf_class_type * enkf_obs_get_obs_conf_class();
   UTIL_IS_INSTANCE_HEADER( enkf_obs );


### PR DESCRIPTION
**Issue**
Resolves #459 


**Approach**
Make sure to call the functionality to deactivate outliers before the scaling is invoked.


**Depends on**
* Statoil/libecl#
