### PR TITLE
Use cmake to find flow and configure ecl_config.yml

### DIFF
--- a/cmake/Modules/FindFlow.cmake
+++ b/cmake/Modules/FindFlow.cmake
@@ -1,0 +1,30 @@
+find_program(FLOW_EXECUTABLE
+  NAMES "flow"
+  DOC "Flow reservoir simulator")
+
+
+if(FLOW_EXECUTABLE)
+  execute_process(COMMAND ${FLOW_EXECUTABLE} --version
+                  OUTPUT_VARIABLE flow_version
+                  ERROR_QUIET
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if (flow_version MATCHES "^flow [0-9]")
+    string(REPLACE "flow " "" FLOW_VERSION "${flow_version}")
+  else()
+    # Eearly versions of flow do not respond to "flow --version", we therefor
+    # just guess that the version we have found is the last version before "flow
+    # --version" worked - i.e. 2018.10.
+    message(STATUS "\"flow --version\" did not return version information - assuming 2018.10")
+    set(FLOW_VERSION "2018.10")
+  endif()
+  unset(flow_version)
+endif()
+
+find_package_handle_standard_args(Flow
+                                  REQUIRED_VARS FLOW_EXECUTABLE
+                                  VERSION_VAR FLOW_VERSION)
+
+
+mark_as_advanced(FLOW_EXECUTABLE)
+mark_as_advanced(FLOW_VERSION)

--- a/python/res/fm/ecl/CMakeLists.txt
+++ b/python/res/fm/ecl/CMakeLists.txt
@@ -4,6 +4,32 @@ set(PYTHON_SOURCES
     ecl_run.py
 )
 
-add_python_package("python.res.fm.ecl" ${PYTHON_INSTALL_PREFIX}/res/fm/ecl "${PYTHON_SOURCES}" True)
+# We look for binary 'flow' using normal cmake operations, if we indeed find
+# flow we can create a valid flow entry in the ecl_config.yml file. That way the
+# installation should be usable with flow with zero additional configuration.
 
-install_example("ecl_config.yml" "${PYTHON_INSTALL_PREFIX}/res/fm/ecl")
+set(_ecl_config_file "${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/res/fm/ecl/ecl_config.yml")
+find_package(Flow)
+if (Flow_FOUND)
+  find_package(MPI)
+  if (MPIEXEC)
+    configure_file( ecl_config_mpi.yml.in ${_ecl_config_file})
+  else()
+    configure_file( ecl_config.yml.in ${_ecl_config_file})
+  endif()
+endif()
+
+
+if (NOT Flow_FOUND)
+  # flow has not been found we just make a ecl_config.yml file
+  # with dummy paths to the location of flow and the mpiexec
+  # executable, the resulting ecl_config.yml file must be
+  # edited before it can be used.
+  set(FLOW_EXECUTABLE "/example/path/to/flow")
+  set(FLOW_VERSION "2018.10")
+  set(MPIEXEC "/example/path/to/mpiexec")
+  configure_file( ecl_config_mpi.yml.in ${_ecl_config_file})
+endif()
+
+add_python_package("python.res.fm.ecl" ${PYTHON_INSTALL_PREFIX}/res/fm/ecl "${PYTHON_SOURCES}" True)
+install_example(${_ecl_config_file} "${PYTHON_INSTALL_PREFIX}/res/fm/ecl")

--- a/python/res/fm/ecl/ecl_config.yml.in
+++ b/python/res/fm/ecl/ecl_config.yml.in
@@ -1,0 +1,69 @@
+# NB: There are inter related dependencies between this file, the EclConfig
+#     class which essentially internalizes this file and the EclRun class
+#     which uses the EclConfig class.
+#
+# The information about an eclipse installation at a particular site is
+# stored in one such configuration file. The file has only one required
+# top level element: 'simulators' which describe the various simulators
+# which are installed. In additon you can optionally have a top level
+# element 'env' which is a dictionary representing environment variables
+# which should be set before the simulator starts.
+
+# The 'simulators' setting is a dictionary where the keys are the available
+# simulators. In the example below we have the simulators 'ecl100' and 'flow'.
+# Observe that the names 'flow' and 'ecl100' will be used as keys in the EclRun
+# class, i.e. these are *not* arbitrary strings.
+#
+# Each simulator can be installed in multiple versions, in the example below the
+# ecl100 simulator is installed in versions '2015.2' and '2017.2' whereas flow
+# is only installed in version '2018.04'. These version strings will be passed
+# as argv[1] when instantiating a EclRun instance.
+#
+# Finally each version of the programs can exist as a scalar single process
+# application and a parallell MPI application. When we have drilled all the way
+# down through simulators['ecl100']['2105.2']['scalar'] the only required
+# attribute is 'executable' which is the full path to the executable program. In
+# addition you can add an env: setting which will be a dictionary of environment
+# variables which will be set before the simulator is invoked. The 2015.2 mpi
+# version of ecl100 and the 2018.04 scalar version of flow have examples of
+# shuch env settings.
+#
+# If it is an MPI simulation you must in addition to the executable attribute
+# also set an 'mpirun' attribute.
+
+simulators:
+  ecl100:
+    '2015.2':  # without quotes this will be interpreted as a number
+      scalar:
+        executable: /path/ecl/2015.2/linux/x86_64/bin/eclipse100
+      mpi:
+        executable: /path/ecl/2015.2/linux/x86_64/bin/eclipse100_mpi
+        mpirun: /path/ecl/2015.2/intel/bin/mpirun
+        env:
+          MPI_ROOT: /path/to/mpi/root
+          LD_LIBRARY_PATH: /path/to/mpi/root/lib64:$LD_LIBRARY_PATH
+
+    '2017.2':
+      scalar:
+        executable: /path/ecl/2017.2/linux/x86_64/bin/eclipse100
+        env:
+      mpi:
+        executable: /path/ecl/2017.2/linux/x86_64/bin/eclipse100_mpi
+        mpirun: /path/ecl/2017.2/intel/bin/mpirun
+
+  flow:
+    '@FLOW_VERSION@':
+      scalar:
+        executable: @FLOW_EXECUTABLE@
+
+
+# You can have a shared 'env' attribute which is an environment variable map
+# which will be set before the simulator starts. If there are env settings in
+# the simulator as well they will be merged with these common settings, the
+# simulator specific take presedence.
+
+env:
+  LM_LICENSE_FILE: license@company.com
+  F_UFMTENDIAN: big
+  ARCH: x86_64
+

--- a/python/res/fm/ecl/ecl_config_mpi.yml.in
+++ b/python/res/fm/ecl/ecl_config_mpi.yml.in
@@ -52,12 +52,12 @@ simulators:
         mpirun: /path/ecl/2017.2/intel/bin/mpirun
 
   flow:
-    '2018.04':
+    '@FLOW_VERSION@':
       scalar:
-        executable: /path/flow/2018.04/bin/flow
-        env:
-          LD_LIBRARY_PATH: /path/flow/2018.04/lib64:$LD_LIBRARY_PATH
-
+        executable: @FLOW_EXECUTABLE@
+      mpi:
+        executable: @FLOW_EXECUTABLE@
+        mpirun: @MPIEXEC@
 
 # You can have a shared 'env' attribute which is an environment variable map
 # which will be set before the simulator starts. If there are env settings in

--- a/python/tests/res/fm/test_ecl_config.py
+++ b/python/tests/res/fm/test_ecl_config.py
@@ -15,6 +15,7 @@
 #  for more details.
 import os
 import stat
+import inspect
 import unittest
 import yaml
 from ecl.util.test import TestAreaContext
@@ -26,14 +27,14 @@ from res.fm.ecl import EclConfig
 class EclConfigTest(ResTest):
 
     def setUp(self):
-        pass
+        self.ecl_config_path = os.path.dirname( inspect.getsourcefile(EclConfig) )
 
     def test_load(self):
         os.environ["ECL_SITE_CONFIG"] = "file/does/not/exist"
         with self.assertRaises(IOError):
             conf = EclConfig()
 
-        os.environ["ECL_SITE_CONFIG"] = os.path.join(self.SOURCE_ROOT, "python/res/fm/ecl/ecl_config.yml")
+        os.environ["ECL_SITE_CONFIG"] = os.path.join(self.ecl_config_path, "ecl_config.yml")
         conf = EclConfig()
 
         with TestAreaContext("yaml_invalid"):
@@ -90,7 +91,7 @@ class EclConfigTest(ResTest):
             with self.assertRaises(OSError):
                 sim = conf.sim("flow", "2018.04")
 
-            # Fails because the 2018.04 mpir version points to a non existing mpirun binary
+            # Fails because the 2018.04 mpi version points to a non existing mpirun binary
             with self.assertRaises(OSError):
                 sim = conf.mpi_sim("flow", "2018.04")
 


### PR DESCRIPTION
**Issue**
Part of: #471

This PR contains two parts:

1. There is a cmake module `FindFlow` which will look for the `flow` executable and check the version[*].

2. The default `ecl_config.yml` file with configuration information of where Eclipse and flow is installed locally will be created with `configure_file()` and hence contain the correct path to `flow` - if found.


[*]: Observe that it is only [*very recently*](https://github.com/OPM/opm-simulators/pull/1677) that `flow` actually responds to the `--version` commandline option, if `--version` fails you will just get a guess of version `2018.10` which the latest version.