### PR TITLE
Site config installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,22 +175,22 @@ if (RST_DOC)
 endif()
 
 foreach(share_dir workflows gui forward-models)
-  install(DIRECTORY "share/ert/${share_dir}" DESTINATION share/ert)
+  install(DIRECTORY "share/ert/${share_dir}" DESTINATION ${SHARE_DIR})
 endforeach()
-install_example("share/ert/site-config" "share/ert")
+install_example("share/ert/site-config" ${SHARE_DIR})
 install(PROGRAMS bin/job_dispatch.py DESTINATION bin )
 
 
 foreach (script ecl100 flow rms)
-  install(PROGRAMS "share/ert/forward-models/res/script/${script}" DESTINATION "share/ert/forward-models/res/script")
+  install(PROGRAMS "share/ert/forward-models/res/script/${script}" DESTINATION "${SHARE_DIR}/forward-models/res/script")
 endforeach()
 
 foreach (script careful_copy_file copy_directory copy_file delete_directory delete_file make_directory move_file symlink)
-  install(PROGRAMS "share/ert/forward-models/shell/script/${script}" DESTINATION "share/ert/forward-models/shell/script")
+  install(PROGRAMS "share/ert/forward-models/shell/script/${script}" DESTINATION "${SHARE_DIR}/forward-models/shell/script")
 endforeach()
 
 foreach (script template_render)
-    install(PROGRAMS "share/ert/forward-models/templating/script/${script}" DESTINATION "share/ert/forward-models/templating/script")
+    install(PROGRAMS "share/ert/forward-models/templating/script/${script}" DESTINATION "${SHARE_DIR}/forward-models/templating/script")
 endforeach()
 
 install(EXPORT res-config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,17 @@ set( SHARE_DIR "share/ert")
 # or stale version of the site configuration file. Irrespective of the value of
 # SITE_CONFIG_FILE the environment variable ERT_SITE_CONFIG will be set to point
 # to the in-source version of the site-config file for testing.
-set( SITE_CONFIG_FILE "${CMAKE_INSTALL_PREFIX}/${SHARE_DIR}/site-config" CACHE FILEPATH "Path to global ERT Configuration file")
+#
+# The variable SITE_CONFIG_FILE can be set by the user, if that is set it will
+# take presedence. If the user has not explicitly set the SITE_CONFIG_FILE variable
+# we will use the default path based on the install prefix.
+set( SITE_CONFIG_FILE "" CACHE FILEPATH "Path to global ERT Configuration file")
+set( __SITE_CONFIG_FILE "${CMAKE_INSTALL_PREFIX}/${SHARE_DIR}/site-config")
+if (SITE_CONFIG_FILE)
+  set( __SITE_CONFIG_FILE ${SITE_CONFIG_FILE})
+endif()
+message(STATUS "The path ${__SITE_CONFIG_FILE} will be compiled into the libres library as the location of the site configuration file")
+
 
 if (BUILD_PYTHON)
   if (NOT ENABLE_PYTHON)
@@ -149,7 +159,7 @@ function(install_example src_file destination)
   if (EXISTS "${_full_destination}/${src_file}")
     message(STATUS "File: ${_full_destination}/${src_file} already exists - will not be updated")
   else()
-    message(STATUS "An example ${src_file} will be installed ${_full_destination}")
+    message(STATUS "An example ${src_file} will be installed as ${_full_destination}")
     install(FILES ${src_file} DESTINATION "${_full_destination}")
   endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -260,7 +260,7 @@ target_compile_definitions(res PRIVATE
             -DRES_VERSION_MINOR=${RES_VERSION_MINOR}
             -DRES_VERSION_MICRO=${RES_VERSION_MICRO}
             -DCOMPILE_TIME_STAMP="${RES_BUILD_TIME}"
-            -DSITE_CONFIG_FILE=\"${SITE_CONFIG_FILE}\"
+            -DSITE_CONFIG_FILE=\"${__SITE_CONFIG_FILE}\"
 )
 
 


### PR DESCRIPTION
**Issue**
When building libres the path to a site wide configuration file is embedded in the compiled code (for good and for bad ...). The path to this file can be given with `-DSITE_CONFIG_FILE=/path/to/som/file`; if that option is not given the path will be `${CMAKE_INSTALL_PREFIX}/share/ert/site-config`.

Prior to this PR the cmake variable `SITE_CONFIG_FILE` was initialized/set the the first time cmake was run, and then *not updated* on subsequent invocations. The consequence of this was that if you reran with an update install prefix, i.e. a sequence like this:
```
bash% cmake .. -DCMAKE_INSTALL_PREFIX=/preifx1 
...
bash% cmake .. -DCMAKE_INSTALL_PREFIX=/prefix2
```
the embedded path would be `/prefix1/share/ert/site-config`.  

**Approach**
Split the handling of the `SITE_CONFIG_FILE` in one CACHE variable which is set by the user - and takes presedence if it is set; and one local variable  `__SITE_CONFIG_FILE` which is reset to the current value of `CMAKE_INSTALL_PREFIX` for every run.

