### PR TITLE
Install opm/flow as part of travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,9 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
       - george-edison55-precise-backports
+      - sourceline: 'ppa:opm/ppa'
     packages:
+      - libopm-simulators
       - liblapack-dev
       - valgrind
       - gcc-4.8


### PR DESCRIPTION
After the merging of #477 libres has tests which can exercise the `flow` simulator - if it is found during the configure step. With this PR the ubuntu packages for flow are installed during the travis build.

See also: #471