### PR TITLE
Fix bug in matrix_fscanf_data()

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -287,6 +287,7 @@ endif()
 
 foreach(name ert_util_logh
              ert_util_arg_pack
+             ert_util_matrix
              ert_util_matrix_lapack
              ert_util_subst_list
              ert_util_block_fs

--- a/lib/include/ert/res_util/matrix.hpp
+++ b/lib/include/ert/res_util/matrix.hpp
@@ -72,6 +72,7 @@ typedef struct matrix_struct matrix_type;
   void          matrix_fwrite(const matrix_type * matrix , FILE * stream);
   bool          matrix_check_dims( const matrix_type * m , int rows , int columns);
   void          matrix_fscanf_data( matrix_type * matrix , bool row_major_order , FILE * stream );
+  void          matrix_fprintf_data( const matrix_type * matrix , bool row_major_order, FILE * stream );
   void          matrix_fprintf( const matrix_type * matrix , const char * fmt , FILE * stream );
   void          matrix_dump_csv( const matrix_type * matrix  ,const char * filename);
   void          matrix_pretty_fprint(const matrix_type * matrix , const char * name , const char * fmt , FILE * stream);

--- a/lib/res_util/matrix.cpp
+++ b/lib/res_util/matrix.cpp
@@ -557,6 +557,7 @@ void matrix_fprintf( const matrix_type * matrix , const char * fmt , FILE * stre
 }
 
 
+
 void matrix_dump_csv( const matrix_type * matrix  ,const char * filename) {
   FILE * stream = util_fopen(filename , "w");
   for (int i=0; i < matrix->rows; i++) {
@@ -659,16 +660,43 @@ static void __fscanf_and_set( matrix_type * matrix , int row , int col , FILE * 
 void matrix_fscanf_data( matrix_type * matrix , bool row_major_order , FILE * stream ) {
   int row,col;
   if (row_major_order) {
-    for (row = 0; row < matrix->columns; row++) {
+    for (row = 0; row < matrix->rows; row++) {
       for (col = 0; col < matrix->columns; col++) {
         __fscanf_and_set( matrix , row , col ,stream);
       }
     }
   } else {
-    for (row = 0; row < matrix->columns; row++) {
-      for (col = 0; col < matrix->columns; col++) {
+    for (col = 0; col < matrix->columns; col++) {
+      for (row = 0; row < matrix->rows; row++) {
         __fscanf_and_set( matrix , row , col , stream);
       }
+    }
+  }
+}
+
+/*
+  If the matrix is printed in row_major_order it is printed so that it looks
+  visually like a matrix; i.e. with one row on each line in the file. When it is
+  written with row_major_order == false it is just written with one number on
+  each line.
+
+  As long as the matrix is loaded again with the matrix_fscanf_data() - or a
+  similar function which is not line oriented, the presence of newlines make no
+  difference anyway.
+*/
+
+void matrix_fprintf_data( const matrix_type * matrix , bool row_major_order, FILE * stream ) {
+  int i,j;
+  if (row_major_order) {
+    for (i=0; i < matrix->rows; i++) {
+      for (j=0; j < matrix->columns; j++)
+        fprintf(stream , "%lg ", matrix_iget( matrix , i , j));
+      fprintf(stream , "\n");
+    }
+  } else {
+    for (j=0; j < matrix->columns; j++)
+      for (i=0; i < matrix->rows; i++) {
+        fprintf(stream , "%lg\n" , matrix_iget( matrix , i , j));
     }
   }
 }

--- a/lib/res_util/tests/ert_util_matrix.cpp
+++ b/lib/res_util/tests/ert_util_matrix.cpp
@@ -25,9 +25,10 @@
 #include <ert/util/test_util.hpp>
 #include <ert/util/statistics.hpp>
 #include <ert/util/test_work_area.hpp>
-#include <ert/util/matrix.hpp>
 #include <ert/util/rng.hpp>
 #include <ert/util/mzran.hpp>
+
+#include <ert/res_util/matrix.hpp>
 
 
 void test_resize() {
@@ -228,6 +229,49 @@ void test_inplace_sub_column() {
 }
 
 
+
+void test_data() {
+  test_work_area_type * work_area = test_work_area_alloc("matrix_data");
+  int rows = 11;
+  int columns = 7;
+  matrix_type * m1 = matrix_alloc(rows, columns);
+  double value = 0.0;
+  for (int i=0; i < rows; i++) {
+    for (int j=0; j < columns; j++) {
+      matrix_iset(m1, i, j, value);
+      value += 1;
+    }
+  }
+  {
+    FILE * stream = util_fopen("row_major.txt", "w");
+    matrix_fprintf_data(m1, true, stream);
+    fclose(stream);
+  }
+  {
+    FILE * stream = util_fopen("column_major.txt", "w");
+    matrix_fprintf_data(m1, false, stream);
+    fclose(stream);
+  }
+  {
+    FILE * stream = util_fopen("row_major.txt", "r");
+    matrix_type * m2 = matrix_alloc(rows, columns);
+    matrix_fscanf_data(m2, true, stream);
+    test_assert_true(matrix_equal(m1,m2));
+    matrix_free(m2);
+    fclose(stream);
+  }
+  {
+    FILE * stream = util_fopen("column_major.txt", "r");
+    matrix_type * m2 = matrix_alloc(rows, columns);
+    matrix_fscanf_data(m2, false, stream);
+    test_assert_true(matrix_equal(m1,m2));
+    matrix_free(m2);
+    fclose(stream);
+  }
+  matrix_free(m1);
+  test_work_area_free(work_area);
+}
+
 int main( int argc , char ** argv) {
   test_create_invalid();
   test_resize();
@@ -238,5 +282,6 @@ int main( int argc , char ** argv) {
   test_diag_std();
   test_masked_copy();
   test_inplace_sub_column();
+  test_data();
   exit(0);
 }


### PR DESCRIPTION
While working to add tests to: #422 a severe bug in the `matrix_fscanf_data()` function was discovered; it was also discovered that a test file: `ert_util_matrix.cpp` was not compiled at all.
