### PR TITLE
Use pkill to kill processes spawned by job_dispatch.py

### DIFF
--- a/lib/job_queue/local_driver.cpp
+++ b/lib/job_queue/local_driver.cpp
@@ -90,6 +90,11 @@ void local_driver_free_job( void * __job ) {
 
 void local_driver_kill_job( void * __driver , void * __job) {
   local_job_type    * job  = local_job_safe_cast( __job );
+
+  char buff[100];
+  snprintf(buff, sizeof(buff), "pkill -P %d", job->child_process);
+  system(buff);
+
   kill( job->child_process , SIGTERM );
 }
 


### PR DESCRIPTION
Resolves #417 

Uses "pkill -P" to kill child processes