### PR TITLE
Es testcase

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -11,6 +11,7 @@ endif ()
 
 add_library(res res_util/res_log.cpp
                 res_util/log.cpp
+                res_util/es_testdata.cpp
                 res_util/arg_pack.cpp
                 res_util/ui_return.cpp
                 res_util/subst_list.cpp
@@ -288,6 +289,7 @@ endif()
 foreach(name ert_util_logh
              ert_util_arg_pack
              ert_util_matrix
+             es_testdata
              ert_util_matrix_lapack
              ert_util_subst_list
              ert_util_block_fs

--- a/lib/include/ert/res_util/es_testdata.hpp
+++ b/lib/include/ert/res_util/es_testdata.hpp
@@ -1,0 +1,54 @@
+/*
+  Copyright (C) 2019  Equinor ASA, Norway.
+  This file is part of ERT - Ensemble based Reservoir Tool.
+
+  ERT is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE.
+
+  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+  for more details.
+*/
+
+
+#ifndef ES_TESTDATA_HPP
+#define ES_TESTDATA_HPP
+
+#include <string>
+
+#include <ert/util/bool_vector.hpp>
+
+#include <ert/res_util/matrix.hpp>
+
+namespace res {
+class es_testdata {
+public:
+  std::string path;
+
+  matrix_type * S;
+  matrix_type * E;
+  matrix_type * R;
+  matrix_type * D;
+  matrix_type * dObs;
+  int active_obs_size;
+  int active_ens_size;
+  int state_size;
+
+  es_testdata(const matrix_type* S, const matrix_type * R, const matrix_type * dObs, const matrix_type *D , const matrix_type * E);
+  es_testdata(const char * path);
+  ~es_testdata();
+
+  matrix_type * alloc_matrix(const std::string& name, int rows, int columns);
+  void save_matrix(const std::string& name, const matrix_type * m);
+  matrix_type * alloc_state(const std::string& name);
+  void save(const std::string& path) const;
+};
+
+}
+
+#endif

--- a/lib/res_util/es_testdata.cpp
+++ b/lib/res_util/es_testdata.cpp
@@ -1,0 +1,238 @@
+/*
+  Copyright (C) 2019  Equinor ASA, Norway.
+  This file  is part of ERT - Ensemble based Reservoir Tool.
+
+  ERT is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE.
+
+  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+  for more details.
+*/
+
+
+#include <stdexcept>
+#include <string>
+#include <array>
+#include <vector>
+
+
+#include <ert/res_util/matrix.hpp>
+
+#include <ert/res_util/es_testdata.hpp>
+
+#define ROW_MAJOR_STORAGE true
+
+namespace res {
+
+namespace {
+
+class pushd {
+public:
+  pushd(const std::string& path, bool mkdir = false) {
+    if (!util_is_directory(path.c_str())) {
+      if (mkdir)
+        util_make_path(path.c_str());
+    }
+
+    if (!util_is_directory(path.c_str()))
+      throw std::invalid_argument("The path: " + path + " does not exist - can not proceed");
+
+    this->org_cwd = util_alloc_cwd();
+    util_chdir(path.c_str());
+  }
+
+
+  ~pushd() {
+    util_chdir(this->org_cwd);
+    free(this->org_cwd);
+  }
+
+private:
+  char * org_cwd;
+};
+
+matrix_type * alloc_load(const std::string& name, int rows, int columns) {
+  if (!util_file_exists(name.c_str()))
+    return NULL;
+
+  FILE * stream = util_fopen(name.c_str(), "r");
+  matrix_type * m = matrix_alloc(rows, columns);
+  matrix_fscanf_data(m, ROW_MAJOR_STORAGE, stream);
+  fclose(stream);
+
+  return m;
+}
+
+void save_matrix_data(const std::string& name, const matrix_type * m) {
+  FILE * stream = util_fopen(name.c_str(), "w");
+  matrix_fprintf_data(m, ROW_MAJOR_STORAGE, stream);
+  fclose(stream);
+}
+
+
+std::array<int,2> load_size() {
+  int active_ens_size, active_obs_size;
+
+  FILE * stream = fopen("size", "r");
+  fscanf(stream, "%d %d", &active_ens_size, &active_obs_size);
+  fclose(stream);
+
+  return {active_ens_size, active_obs_size};
+}
+
+void save_size(int ens_size, int obs_size) {
+  FILE * stream = util_fopen("size", "w");
+  fprintf(stream, "%d %d\n", ens_size, obs_size);
+  fclose(stream);
+}
+
+matrix_type * safe_copy(const matrix_type * m) {
+  if (m)
+    return matrix_alloc_copy(m);
+
+  return nullptr;
+}
+
+
+}
+
+
+
+
+
+matrix_type * es_testdata::alloc_matrix(const std::string& fname, int rows, int columns) {
+  pushd tmp_path(this->path);
+
+  matrix_type * m = alloc_load(fname, rows, columns);
+  return m;
+}
+
+
+void es_testdata::save_matrix(const std::string& name, const matrix_type * m) {
+  pushd tmp_path(this->path);
+
+  FILE * stream = util_fopen(name.c_str(), "w");
+  matrix_fprintf_data(m, ROW_MAJOR_STORAGE, stream);
+  fclose(stream);
+}
+
+es_testdata::es_testdata(const matrix_type* S, const matrix_type * R, const matrix_type * dObs, const matrix_type *D , const matrix_type * E)
+  : S(safe_copy(S)),
+    R(safe_copy(R)),
+    dObs(safe_copy(dObs)),
+    D(safe_copy(D)),
+    E(safe_copy(E)),
+    active_ens_size(matrix_get_columns(S)),
+    active_obs_size(matrix_get_rows(S))
+{
+}
+
+es_testdata::es_testdata(const char * path) :
+  path(path),
+  S(nullptr),
+  E(nullptr),
+  R(nullptr),
+  D(nullptr),
+  dObs(nullptr)
+{
+  pushd tmp_path(this->path);
+
+  auto size = load_size();
+  this->active_ens_size = size[0];
+  this->active_obs_size = size[1];
+
+  this->S = alloc_load("S", this->active_obs_size, this->active_ens_size);
+  this->E = alloc_load("E", this->active_obs_size, this->active_ens_size);
+  this->R = alloc_load("R", this->active_obs_size, this->active_obs_size);
+  this->D = alloc_load("D", this->active_obs_size, this->active_ens_size);
+  this->dObs = alloc_load("dObs", this->active_obs_size, 2);
+}
+
+
+es_testdata::~es_testdata() {
+  if (this->S)
+    matrix_free(this->S);
+
+  if (this->E)
+    matrix_free(this->E);
+
+  if (this->R)
+    matrix_free(this->R);
+
+  if (this->D)
+    matrix_free(this->D);
+
+  if (this->dObs)
+    matrix_free(this->dObs);
+}
+
+
+void es_testdata::save(const std::string& path) const {
+  pushd tmp_path(path, true);
+  save_size(this->active_ens_size, this->active_obs_size);
+
+  if (this->S)
+    save_matrix_data("S", S);
+
+  if (this->E)
+    save_matrix_data("E", E);
+
+  if (this->R)
+    save_matrix_data("R", R);
+
+  if (this->D)
+    save_matrix_data("D", D);
+
+  if (this->dObs)
+    save_matrix_data("dObs", dObs);
+}
+
+
+/*
+  This function will allocate a matrix based on data found on disk. The data on
+  disk is only the actual content of the matrix, in row_major order. Before the
+  matrix is constructed it is verified that the number of elements is a multiple
+  of this->active_ens_size.
+*/
+
+matrix_type * es_testdata::alloc_state(const std::string& name) {
+  std::vector<double> data;
+  {
+    pushd tmp_path(this->path);
+    FILE * stream = fopen(name.c_str(), "r");
+    if (!stream)
+      throw std::invalid_argument("No such state matrix: " + this->path + "/" + name);
+
+    while (true) {
+      double value;
+      int read_count = fscanf(stream, "%lg", &value);
+      if (read_count == 1)
+        data.push_back(value);
+      else
+        break;
+    }
+
+    fclose(stream);
+  }
+
+  if ((data.size() % this->active_ens_size) != 0)
+    throw std::invalid_argument("Number of elements in file with state informaton must be a multiple of ensemble_size: " + std::to_string(this->active_ens_size));
+
+  int state_size = data.size() / this->active_ens_size;
+  matrix_type * state = matrix_alloc(state_size, this->active_ens_size);
+  for (int is=0; is < state_size; is++) {
+    for (int iens=0; iens < this->active_ens_size; iens++) {
+      matrix_iset(state, is, iens, data[ iens + is * this->active_ens_size ]);
+    }
+  }
+
+  return state;
+}
+
+}

--- a/lib/res_util/tests/es_testdata.cpp
+++ b/lib/res_util/tests/es_testdata.cpp
@@ -1,0 +1,127 @@
+/*
+  Copyright (C) 2019  Equinor ASA, Norway.
+  This file  is part of ERT - Ensemble based Reservoir Tool.
+
+  ERT is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE.
+
+  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+  for more details.
+*/
+#include <stdexcept>
+
+#include <ert/res_util/es_testdata.hpp>
+#include <ert/util/test_work_area.hpp>
+#include <ert/util/test_util.hpp>
+
+
+
+res::es_testdata make_testdata(int ens_size, int obs_size) {
+  matrix_type * S = matrix_alloc(obs_size, ens_size);
+  matrix_type * E = matrix_alloc(obs_size, ens_size);
+  matrix_type * R = matrix_alloc(obs_size, obs_size);
+  matrix_type * D = matrix_alloc(obs_size, ens_size);
+  matrix_type * dObs = matrix_alloc(obs_size, 2);
+
+  {
+    double v = 0;
+    for (int i=0; i < matrix_get_rows(S); i++) {
+      for (int j=0; j < matrix_get_columns(S); j++) {
+        matrix_iset(S, i, j, v);
+        v += 1;
+      }
+    }
+  }
+  res::es_testdata td(S,R,dObs,D,E);
+
+  matrix_free(S);
+  matrix_free(R);
+  matrix_free(dObs);
+  matrix_free(D);
+  matrix_free(E);
+
+  return td;
+}
+
+
+void test_basic() {
+  test_work_area_type * work_area = test_work_area_alloc("es_testdata");
+
+  int ens_size = 10;
+  int obs_size =  7;
+  res::es_testdata td1 = make_testdata(ens_size, obs_size);
+  td1.save("path/sub/path");
+
+  res::es_testdata td2("path/sub/path");
+  test_assert_true( matrix_equal(td1.S, td2.S) );
+
+  test_work_area_free(work_area);
+}
+
+
+void test_load_state() {
+  test_work_area_type * work_area = test_work_area_alloc("es_testdata");
+  int ens_size = 10;
+  int obs_size =  7;
+  res::es_testdata td0 = make_testdata(ens_size, obs_size);
+  td0.save("PATH");
+
+  res::es_testdata td("PATH");
+
+
+  test_assert_throw( td.alloc_state("DOES_NOT_EXIST"), std::invalid_argument);
+
+  {
+    int invalid_size = 10 * ens_size + ens_size / 2;
+    FILE * stream = util_fopen("PATH/A0", "w");
+    for (int i = 0; i < invalid_size; i++)
+      fprintf(stream, "%d\n", i);
+    fclose(stream);
+    test_assert_throw( td.alloc_state("A0"), std::invalid_argument);
+  }
+  {
+    int state_size = 7;
+    int valid_size = state_size * ens_size;
+    FILE * stream = util_fopen("PATH/A1", "w");
+    double value = 0;
+    for (int row=0; row < state_size; row++) {
+      for (int iens = 0; iens < ens_size; iens++) {
+        fprintf(stream, "%lg ", value);
+        value++;
+      }
+      fputs("\n", stream);
+    }
+    fclose(stream);
+
+    matrix_type * A1 = td.alloc_state("A1");
+    test_assert_int_equal(matrix_get_rows(A1), state_size);
+    test_assert_int_equal(matrix_get_columns(A1), ens_size);
+
+    value = 0;
+    for (int row=0; row < state_size; row++) {
+      for (int iens = 0; iens < ens_size; iens++) {
+        test_assert_double_equal(matrix_iget(A1, row, iens), value);
+        value++;
+      }
+    }
+
+    td.save_matrix("A2", A1);
+    matrix_type * A2 = td.alloc_matrix("A2", state_size, ens_size);
+    test_assert_true( matrix_equal(A1,A2) );
+
+    matrix_free(A1);
+    matrix_free(A2);
+  }
+  test_work_area_free(work_area);
+}
+
+int main() {
+  test_basic();
+  test_load_state();
+}


### PR DESCRIPTION
More preparations for proper testing in #422. The content of this PR is a small class `es_testcase` which is used load the matrices `S, R, D, E` and `dObs` which are used in the analysis update code. The intention is that a directory `some_path` contains the testfiles, then the testdata (fixture) can be instantiated as:
```C++
res::es_testdata td("some_path");
...
analysis_module_init_update( td.S, td.E, td.D, ....);
...
```
In additon to instantiation/loading like this it is quite simple to create a (regression based ...) test-case from the hot code path in `enkf_main_UPDATE()`
```
....
res::es_testdata td(S, R, dObs, D, E);
td.save("/tmp/test/CASE_123");
```
when this has run the directory `/tmp/test/CASE_123` can be copied to the source tree and added as a test fixture.

The matrices are stored on disk as "matrix-like" blocks of formatted numbers; i.e. like this:
```
0.63  0.88  0.98  0.72  0.88
1.02  1.08  1.09  0.99  0.98
...
```
the thought has been to ensure that the data is "easy to look at", and also simple to work with using other matrix representations.



This PR is on top of #486 which must be merged before - or as part of this PR.
