### PR TITLE
Fix arguments in Forward Model jobs

### DIFF
--- a/share/ert/forward-models/res/ECLIPSE300
+++ b/share/ert/forward-models/res/ECLIPSE300
@@ -1,4 +1,4 @@
-EXECUTABLE script/ecl100
+EXECUTABLE script/ecl300
 DEFAULT <VERSION> version
 DEFAULT <NUM_CPU> 1
 ARGLIST <ECLBASE> "--version=<VERSION>" "--num-cpu=<NUM_CPU>" "--ignore-errors"

--- a/share/ert/forward-models/res/FLOW
+++ b/share/ert/forward-models/res/FLOW
@@ -1,4 +1,4 @@
 EXECUTABLE script/flow
 DEFAULT <VERSION> default
 DEFAULT <NUM_CPU> 1
-ARGLIST <ECLBASE> --version=<VERSION> --num-cpu=<NUM_CPU>
+ARGLIST <ECLBASE> "--version=<VERSION>" "--num-cpu=<NUM_CPU>"

--- a/share/ert/forward-models/res/eclipse300
+++ b/share/ert/forward-models/res/eclipse300
@@ -1,0 +1,1 @@
+EXECUTABLE script/ecl300

--- a/share/ert/forward-models/res/script/ecl300
+++ b/share/ert/forward-models/res/script/ecl300
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+import sys
+from res.fm.ecl import run, Ecl300Config
+
+config = Ecl300Config()
+run(config, sys.argv[1:])


### PR DESCRIPTION
**Issue**
Resolves #490


**Approach**
Change how the arguments are input in the forward model job, otherwise they're ignored as comments. This is still a WIP as the other FM jobs must be updated as well, and the `--ignore-errors` isn't handled yet, i.e. it can't be toggled in the config file.
