### PR TITLE
Use pointer to const for all the matrices in the analysis update

### DIFF
--- a/lib/analysis/analysis_module.cpp
+++ b/lib/analysis/analysis_module.cpp
@@ -252,12 +252,12 @@ void analysis_module_free__( void * arg) {
 
 void analysis_module_initX(analysis_module_type * module ,
                            matrix_type * X ,
-                           matrix_type * A ,
-                           matrix_type * S ,
-                           matrix_type * R ,
-                           matrix_type * dObs ,
-                           matrix_type * E ,
-                           matrix_type * D,
+                           const matrix_type * A ,
+                           const matrix_type * S ,
+                           const matrix_type * R ,
+                           const matrix_type * dObs ,
+                           const matrix_type * E ,
+                           const matrix_type * D,
                            rng_type * rng) {
 
 
@@ -267,11 +267,11 @@ void analysis_module_initX(analysis_module_type * module ,
 
 void analysis_module_updateA(analysis_module_type * module ,
                              matrix_type * A ,
-                             matrix_type * S ,
-                             matrix_type * R ,
-                             matrix_type * dObs ,
-                             matrix_type * E ,
-                             matrix_type * D ,
+                             const matrix_type * S ,
+                             const matrix_type * R ,
+                             const matrix_type * dObs ,
+                             const matrix_type * E ,
+                             const matrix_type * D ,
                              const module_info_type* module_info,
                              rng_type * rng) {
 

--- a/lib/analysis/bootstrap_enkf.cpp
+++ b/lib/analysis/bootstrap_enkf.cpp
@@ -133,11 +133,11 @@ static void free_iens_resample( int ** iens_resample, int ens_size ) {
 
 void bootstrap_enkf_updateA(void * module_data ,
                             matrix_type * A ,
-                            matrix_type * S ,
-                            matrix_type * R ,
-                            matrix_type * dObs ,
-                            matrix_type * E ,
-                            matrix_type * D ,
+                            const matrix_type * S ,
+                            const matrix_type * R ,
+                            const matrix_type * dObs ,
+                            const matrix_type * E ,
+                            const matrix_type * D ,
                             const module_info_type* module_info,
                             rng_type * rng) {
 

--- a/lib/analysis/cv_enkf.cpp
+++ b/lib/analysis/cv_enkf.cpp
@@ -526,12 +526,12 @@ static void getW_prin_comp(cv_enkf_data_type * cv_data , matrix_type *W , const 
 
 void cv_enkf_initX(void * module_data ,
                    matrix_type * X ,
-                   matrix_type * A ,
-                   matrix_type * S ,
-                   matrix_type * R ,
-                   matrix_type * dObs ,
-                   matrix_type * E ,
-                   matrix_type * D,
+                   const matrix_type * A ,
+                   const matrix_type * S ,
+                   const matrix_type * R ,
+                   const matrix_type * dObs ,
+                   const matrix_type * E ,
+                   const matrix_type * D,
                    rng_type * rng) {
 
 

--- a/lib/analysis/fwd_step_enkf.cpp
+++ b/lib/analysis/fwd_step_enkf.cpp
@@ -241,11 +241,11 @@ static void fwd_step_enkf_write_iter_info( fwd_step_enkf_data_type * data , step
 /*Main function: */
 void fwd_step_enkf_updateA(void * module_data ,
                            matrix_type * A ,
-                           matrix_type * S ,
-                           matrix_type * R ,
-                           matrix_type * dObs ,
-                           matrix_type * E ,
-                           matrix_type * D ,
+                           const matrix_type * S0 ,
+                           const matrix_type * R ,
+                           const matrix_type * dObs ,
+                           const matrix_type * E ,
+                           const matrix_type * D ,
                            const module_info_type* module_info,
                            rng_type * rng) {
 
@@ -255,6 +255,7 @@ void fwd_step_enkf_updateA(void * module_data ,
   fwd_step_log_open(fwd_step_data->fwd_step_log);
   module_data_block_vector_type * data_block_vector = module_info_get_data_block_vector(module_info);
   printf("Running Forward Stepwise regression:\n");
+  matrix_type * S = matrix_alloc_copy(S0);
   {
 
     int ens_size    = matrix_get_columns( S );
@@ -372,7 +373,7 @@ void fwd_step_enkf_updateA(void * module_data ,
 
 
   }
-
+  matrix_free(S);
   fwd_step_log_close( fwd_step_data->fwd_step_log );
 }
 

--- a/lib/analysis/null_enkf.cpp
+++ b/lib/analysis/null_enkf.cpp
@@ -32,14 +32,14 @@
 
 
 void null_enkf_initX(void * module_data ,
-                    matrix_type * X ,
-                    matrix_type * A ,
-                    matrix_type * S ,
-                    matrix_type * R ,
-                    matrix_type * dObs ,
-                    matrix_type * E ,
-                    matrix_type * D,
-                    rng_type * rng) {
+                     matrix_type * X ,
+                     const matrix_type * A ,
+                     const matrix_type * S ,
+                     const matrix_type * R ,
+                     const matrix_type * dObs ,
+                     const matrix_type * E ,
+                     const matrix_type * D,
+                     rng_type * rng) {
 
   matrix_diag_set_scalar( X , 1.0 );
 

--- a/lib/analysis/sqrt_enkf.cpp
+++ b/lib/analysis/sqrt_enkf.cpp
@@ -104,16 +104,17 @@ bool sqrt_enkf_set_int( void * arg , const char * var_name , int value) {
 
 void sqrt_enkf_initX(void * module_data ,
                      matrix_type * X ,
-                     matrix_type * A ,
-                     matrix_type * S ,
-                     matrix_type * R ,
-                     matrix_type * dObs ,
-                     matrix_type * E ,
-                     matrix_type *D,
+                     const matrix_type * A ,
+                     const matrix_type * S0 ,
+                     const matrix_type * R ,
+                     const matrix_type * dObs ,
+                     const matrix_type * E ,
+                     const matrix_type *D,
                      rng_type * rng) {
 
   sqrt_enkf_data_type * data = sqrt_enkf_data_safe_cast( module_data );
   {
+    matrix_type * S   = matrix_alloc_copy(S0);
     int ncomp         = std_enkf_get_subspace_dimension( data->std_data );
     double truncation = std_enkf_get_truncation( data->std_data );
     int nrobs         = matrix_get_rows( S );
@@ -129,6 +130,7 @@ void sqrt_enkf_initX(void * module_data ,
     free( eig );
 
     enkf_linalg_checkX( X , false );
+    matrix_free(S);
   }
 }
 

--- a/lib/analysis/std_enkf.cpp
+++ b/lib/analysis/std_enkf.cpp
@@ -148,16 +148,17 @@ void std_enkf_data_free( void * data ) {
 
 
 static void std_enkf_initX__( matrix_type * X ,
-                              matrix_type * S ,
-                              matrix_type * R ,
-                              matrix_type * E ,
-                              matrix_type * D ,
+                              const matrix_type * S0 ,
+                              const matrix_type * R ,
+                              const matrix_type * E ,
+                              const matrix_type * D ,
                               double truncation,
                               int    ncomp,
                               bool   bootstrap ,
                               bool   use_EE ,
                               bool   use_GE) {
 
+  matrix_type * S   = matrix_alloc_copy(S0);
   int nrobs         = matrix_get_rows( S );
   int ens_size      = matrix_get_columns( S );
   int nrmin         = util_int_min( ens_size , nrobs);
@@ -190,6 +191,7 @@ static void std_enkf_initX__( matrix_type * X ,
   enkf_linalg_init_stdX( X , S , D , W , eig , bootstrap);
 
   matrix_free( W );
+  matrix_free( S );
   free( eig );
   enkf_linalg_checkX( X , bootstrap );
 }
@@ -200,12 +202,12 @@ static void std_enkf_initX__( matrix_type * X ,
 
 void std_enkf_initX(void * module_data ,
                     matrix_type * X ,
-                    matrix_type * A ,
-                    matrix_type * S ,
-                    matrix_type * R ,
-                    matrix_type * dObs ,
-                    matrix_type * E ,
-                    matrix_type * D,
+                    const matrix_type * A ,
+                    const matrix_type * S ,
+                    const matrix_type * R ,
+                    const matrix_type * dObs ,
+                    const matrix_type * E ,
+                    const matrix_type * D,
                     rng_type * rng) {
 
 

--- a/lib/include/ert/analysis/analysis_module.hpp
+++ b/lib/include/ert/analysis/analysis_module.hpp
@@ -81,22 +81,22 @@ typedef enum {
 
   void analysis_module_initX(analysis_module_type * module ,
                              matrix_type * X ,
-                             matrix_type * A ,
-                             matrix_type * S ,
-                             matrix_type * R ,
-                             matrix_type * dObs ,
-                             matrix_type * E ,
-                             matrix_type * D,
+                             const matrix_type * A ,
+                             const matrix_type * S ,
+                             const matrix_type * R ,
+                             const matrix_type * dObs ,
+                             const matrix_type * E ,
+                             const matrix_type * D,
                              rng_type * rng);
 
 
   void analysis_module_updateA(analysis_module_type * module ,
                                matrix_type * A ,
-                               matrix_type * S ,
-                               matrix_type * R ,
-                               matrix_type * dObs ,
-                               matrix_type * E ,
-                               matrix_type * D ,
+                               const matrix_type * S ,
+                               const matrix_type * R ,
+                               const matrix_type * dObs ,
+                               const matrix_type * E ,
+                               const matrix_type * D ,
                                const module_info_type* module_info,
                                rng_type * rng);
 

--- a/lib/include/ert/analysis/analysis_table.hpp
+++ b/lib/include/ert/analysis/analysis_table.hpp
@@ -15,23 +15,23 @@ extern "C" {
 
   typedef void (analysis_updateA_ftype) (void * module_data ,
                                          matrix_type * A ,
-                                         matrix_type * S ,
-                                         matrix_type * R ,
-                                         matrix_type * dObs ,
-                                         matrix_type * E ,
-                                         matrix_type * D ,
+                                         const matrix_type * S ,
+                                         const matrix_type * R ,
+                                         const matrix_type * dObs ,
+                                         const matrix_type * E ,
+                                         const matrix_type * D ,
                                          const module_info_type* module_info,
                                          rng_type * rng);
 
 
   typedef void (analysis_initX_ftype)       (void * module_data ,
                                              matrix_type * X ,
-                                             matrix_type * A ,
-                                             matrix_type * S ,
-                                             matrix_type * R ,
-                                             matrix_type * dObs ,
-                                             matrix_type * E ,
-                                             matrix_type * D,
+                                             const matrix_type * A ,
+                                             const matrix_type * S ,
+                                             const matrix_type * R ,
+                                             const matrix_type * dObs ,
+                                             const matrix_type * E ,
+                                             const matrix_type * D,
                                              rng_type * rng);
 
 

--- a/lib/include/ert/analysis/cv_enkf.hpp
+++ b/lib/include/ert/analysis/cv_enkf.hpp
@@ -41,12 +41,12 @@ void cv_enkf_init_update( void * arg ,
 
 void cv_enkf_initX(void * module_data ,
                    matrix_type * X ,
-                   matrix_type * A ,
-                   matrix_type * S ,
-                   matrix_type * R ,
-                   matrix_type * dObs ,
-                   matrix_type * E ,
-                   matrix_type * D,
+                   const matrix_type * A ,
+                   const matrix_type * S ,
+                   const matrix_type * R ,
+                   const matrix_type * dObs ,
+                   const matrix_type * E ,
+                   const matrix_type * D,
                    rng_type * rng);
 
 bool        cv_enkf_set_double( void * arg , const char * var_name , double value);

--- a/lib/include/ert/analysis/std_enkf.hpp
+++ b/lib/include/ert/analysis/std_enkf.hpp
@@ -42,12 +42,12 @@ extern "C" {
   bool   std_enkf_set_double( void * arg , const char * var_name , double value);
   void   std_enkf_initX(void * module_data ,
                         matrix_type * X ,
-                        matrix_type * A ,
-                        matrix_type * S ,
-                        matrix_type * R ,
-                        matrix_type * dObs ,
-                        matrix_type * E ,
-                        matrix_type * D,
+                        const matrix_type * A ,
+                        const matrix_type * S ,
+                        const matrix_type * R ,
+                        const matrix_type * dObs ,
+                        const matrix_type * E ,
+                        const matrix_type * D,
                         rng_type * rng);
 
 #ifdef __cplusplus


### PR DESCRIPTION
**Issue**
The analysis modules take pointers to five matrices as arguments, these matrices should "in general" not be modified by the analysis modules - however they are passed as pointers to mutable objects, and the main calling scope does not access this memory afterwards, so "some changes" have been safe. For a better communication of intent - and for testing, it would be better to use pointers to const matrices.


**Approach**
The function signatures in the analysis modules have changed from `matrix_type *` to `const matrix_type *`. A few functions actually modified the input argument, for those a local copy is created.

