### PR TITLE
Cast to numpy array before initializing DF in export

### DIFF
--- a/python/res/enkf/export/custom_kw_collector.py
+++ b/python/res/enkf/export/custom_kw_collector.py
@@ -1,4 +1,5 @@
 from pandas import DataFrame
+import numpy
 from res.enkf import ErtImplType, EnKFMain, EnkfFs, RealizationStateEnum, CustomKWConfig, EnkfNode, NodeId
 from res.enkf.key_manager import KeyManager
 
@@ -42,6 +43,7 @@ class CustomKWCollector(object):
         if keys is not None:
             custom_kw_keys = [key for key in keys if key in custom_kw_keys] # ignore keys that doesn't exist
 
+        realizations = numpy.array(realizations)
         custom_kw_data = DataFrame(index=realizations, columns=custom_kw_keys)
         custom_kw_data.index.name = "Realization"
 

--- a/python/res/enkf/export/gen_data_collector.py
+++ b/python/res/enkf/export/gen_data_collector.py
@@ -41,5 +41,6 @@ class GenDataCollector(object):
                         value = realization_vector[data_index]
                         data_array[data_index][realization_index] = value
 
+        realizations = numpy.array(realizations)
         return DataFrame( data = data_array , columns = realizations )
 


### PR DESCRIPTION
**Issue**
Resolves #494 

**Approach**
Creating a numpy array in advance before creating the pandas dataframe.

This requires the `realizations` to always be a list of lists, so still have som checking to do.