### PR TITLE
Adapt to libecl removal of test_work_are_set_store()

### DIFF
--- a/.libecl_version
+++ b/.libecl_version
@@ -1,1 +1,1 @@
-export LIBECL_VERSION=2.4.rc1
+export LIBECL_VERSION=2.4.rc2

--- a/lib/enkf/ert_test_context.cpp
+++ b/lib/enkf/ert_test_context.cpp
@@ -44,7 +44,7 @@ struct ert_test_context_struct {
 UTIL_IS_INSTANCE_FUNCTION( ert_test_context , ERT_TEST_CONTEXT_TYPE_ID )
 
 
-static ert_test_context_type * ert_test_context_alloc__( test_work_area_type * work_area, res_config_type * res_config, const char * ui_mode) {
+static ert_test_context_type * ert_test_context_alloc_internal( test_work_area_type * work_area, res_config_type * res_config, const char * ui_mode) {
   ert_test_context_type * test_context = (ert_test_context_type *)util_malloc( sizeof * test_context );
   UTIL_TYPE_ID_INIT( test_context , ERT_TEST_CONTEXT_TYPE_ID );
 
@@ -62,24 +62,26 @@ static ert_test_context_type * ert_test_context_alloc__( test_work_area_type * w
 }
 
 
-ert_test_context_type * ert_test_context_alloc( const char * test_name , const char * model_config) {
+ert_test_context_type * ert_test_context_alloc__( const char * test_name , const char * model_config, bool store_area) {
   if (!util_file_exists(model_config))
     return NULL;
 
-  test_work_area_type * work_area = test_work_area_alloc(test_name);
-  test_work_area_set_store( work_area , false );
+  test_work_area_type * work_area = test_work_area_alloc__(test_name, store_area);
   test_work_area_copy_parent_content(work_area , model_config );
 
   char * config_file = util_split_alloc_filename( model_config );
   res_config_type * res_config = res_config_alloc_load(config_file);
   free( config_file );
 
-  return ert_test_context_alloc__( work_area, res_config, "tui");
+  return ert_test_context_alloc_internal( work_area, res_config, "tui");
 }
 
+ert_test_context_type * ert_test_context_alloc( const char * test_name , const char * model_config) {
+  return ert_test_context_alloc__(test_name, model_config, false);
+}
 
 ert_test_context_type * ert_test_context_alloc_python( test_work_area_type * work_area, res_config_type * res_config) {
-  return ert_test_context_alloc__( work_area, res_config , "gui");
+  return ert_test_context_alloc_internal( work_area, res_config , "gui");
 }
 
 
@@ -122,6 +124,7 @@ bool ert_test_context_install_workflow_job( ert_test_context_type * test_context
   } else
     return false;
 }
+
 
 
 bool ert_test_context_install_workflow( ert_test_context_type * test_context , const char * workflow_name , const char * workflow_file) {
@@ -180,6 +183,3 @@ bool ert_test_context_run_worklow_job( ert_test_context_type * test_context , co
 }
 
 
-void ert_test_context_set_store( ert_test_context_type * test_context , bool store) {
-  test_work_area_set_store( test_context->work_area , store );
-}

--- a/lib/enkf/tests/enkf_forward_init_transform.cpp
+++ b/lib/enkf/tests/enkf_forward_init_transform.cpp
@@ -76,10 +76,9 @@ int main(int argc , char ** argv) {
   const char * init_file   = argv[3];
   const char * forward_init_string = argv[4];
 
-  test_work_area_type * work_area = test_work_area_alloc(config_file );
+  test_work_area_type * work_area = test_work_area_alloc__(config_file, true);
   test_work_area_copy_directory_content( work_area , root_path );
   test_work_area_install_file( work_area , init_file );
-  test_work_area_set_store(work_area, true);
 
   bool strict = true;
   res_config_type * res_config = res_config_alloc_load(config_file);

--- a/lib/enkf/tests/enkf_main_fs_current_file_test.cpp
+++ b/lib/enkf/tests/enkf_main_fs_current_file_test.cpp
@@ -86,8 +86,7 @@ void test_change_case(const char * model_config) {
 
 int main(int argc, char ** argv) {
   const char * config_file = argv[1];
-  test_work_area_type * work_area = test_work_area_alloc( "enkf_main_fs_current_file_test" );
-  test_work_area_set_store(work_area, true);
+  test_work_area_type * work_area = test_work_area_alloc__( "enkf_main_fs_current_file_test", true);
   char * model_config;
   util_alloc_file_components( config_file , NULL , &model_config , NULL);
   test_work_area_copy_parent_content( work_area , config_file );

--- a/lib/enkf/tests/enkf_obs_invalid_path.cpp
+++ b/lib/enkf/tests/enkf_obs_invalid_path.cpp
@@ -25,7 +25,7 @@
 
 
 void test_invalid_path() {
-  test_work_area_type * work_area = test_work_area_alloc("conf");
+  test_work_area_type * work_area = test_work_area_alloc__("conf", true);
   util_make_path("obs_path");
   {
     FILE * stream = util_fopen("obs_path/conf.txt","w");
@@ -51,7 +51,6 @@ void test_invalid_path() {
   test_assert_false(conf_instance_validate(enkf_conf));
 
   conf_instance_free(enkf_conf);
-  test_work_area_set_store(work_area, true);
 
   test_work_area_free(work_area);
 }

--- a/lib/enkf/tests/enkf_plot_data_fs.cpp
+++ b/lib/enkf/tests/enkf_plot_data_fs.cpp
@@ -107,10 +107,9 @@ int main(int argc, char ** argv) {
   util_install_signals();
   {
     const char * config_file = argv[1];
-    test_work_area_type * work_area = test_work_area_alloc( "enkf_main_fs" );
+    test_work_area_type * work_area = test_work_area_alloc__( "enkf_main_fs", true);
     char * model_config;
     util_alloc_file_components( config_file , NULL , &model_config , NULL);
-    test_work_area_set_store( work_area , true );
     test_work_area_copy_parent_content( work_area , config_file );
     {
       res_config_type * res_config = res_config_alloc_load(model_config);

--- a/lib/enkf/tests/enkf_workflow_job_test2.cpp
+++ b/lib/enkf/tests/enkf_workflow_job_test2.cpp
@@ -31,9 +31,8 @@
 
 
 ert_test_context_type * create_context( const char * config_file, const char * name ) {
-  ert_test_context_type * test_context = ert_test_context_alloc(name , config_file);
+  ert_test_context_type * test_context = ert_test_context_alloc__(name , config_file, true);
   usleep( 2 * 100000 );
-  ert_test_context_set_store( test_context , true );
   return test_context;
 }
 

--- a/lib/include/ert/enkf/ert_test_context.hpp
+++ b/lib/include/ert/enkf/ert_test_context.hpp
@@ -34,8 +34,8 @@ extern "C" {
 
 typedef struct ert_test_context_struct ert_test_context_type;
 
-void                    ert_test_context_set_store( ert_test_context_type * test_context , bool store);
 ert_test_context_type * ert_test_context_alloc( const char * test_name , const char * model_config);
+ert_test_context_type * ert_test_context_alloc__( const char * test_name , const char * model_config, bool store_area);
 ert_test_context_type * ert_test_context_alloc_python( test_work_area_type * work_area, res_config_type * res_config);
 void                    ert_test_context_free( ert_test_context_type * test_context );
 enkf_main_type        * ert_test_context_get_main( ert_test_context_type * test_context );

--- a/lib/job_queue/tests/job_queue_timeout_test.cpp
+++ b/lib/job_queue/tests/job_queue_timeout_test.cpp
@@ -139,8 +139,7 @@ int main(int argc, char ** argv) {
   const int running_timeout = 0; // Pretend that the node running the job is dead
   const int sec = 1000*1000;
 
-  test_work_area_type * work_area = test_work_area_alloc("job_timeout");
-  test_work_area_set_store(work_area, true);
+  test_work_area_type * work_area = test_work_area_alloc__("job_timeout", true);
 
   job_type **jobs = alloc_jobs(number_of_jobs, argv[1]);
 

--- a/python/res/test/ert_test_context.py
+++ b/python/res/test/ert_test_context.py
@@ -25,7 +25,6 @@ class ErtTest(BaseCClass):
     TYPE_NAME = "ert_test"
 
     _alloc         = ResPrototype("void* ert_test_context_alloc_python( test_area , res_config)", bind = False)
-    _set_store     = ResPrototype("void* ert_test_context_set_store( ert_test , bool)")
     _free          = ResPrototype("void  ert_test_context_free( ert_test )")
     _get_cwd       = ResPrototype("char* ert_test_context_get_cwd( ert_test )")
     _get_enkf_main = ResPrototype("enkf_main_ref ert_test_context_get_main( ert_test )")
@@ -36,7 +35,7 @@ class ErtTest(BaseCClass):
         if model_config is None and config_dict is None:
             raise ValueError("Must supply either model_config or config_dict argument")
 
-        work_area = TestArea( test_name )
+        work_area = TestArea( test_name, store_area = store_area )
         work_area.convertToCReference( self )
 
         if model_config:
@@ -49,13 +48,9 @@ class ErtTest(BaseCClass):
         res_config.convertToCReference( self )
         c_ptr = self._alloc(work_area, res_config)
         super(ErtTest, self).__init__(c_ptr)
-        self.setStore(store_area)
 
         self.__ert = None
 
-
-    def setStore(self, store):
-        self._set_store(store)
 
     def getErt(self):
         """ @rtype: EnKFMain """


### PR DESCRIPTION
As part of https://github.com/equinor/libecl/pull/562 the ability set the `store_area` flag of a `test_area` was removed, you had to pass the `store_area` flag when the test_area was created. This PR just follows up on the required API changes in libres.

~~I have added a commit which targets libecl 2.4.rc1 - where this change is; I don't know if that is the way to go?~~

Hmmm: Looking at the [network graph for libecl](https://github.com/equinor/libecl/network) it seems that C++ test_area changes will come in the next version after 2.4? In the final commit I have set the LIBECL_VERSON to `master`- I realize that is not the way it should be; but I had no other idea - please advise.