### PR TITLE
Add methods to deactivate in es_testadata

### DIFF
--- a/lib/include/ert/res_util/es_testdata.hpp
+++ b/lib/include/ert/res_util/es_testdata.hpp
@@ -37,6 +37,8 @@ public:
   matrix_type * dObs;
   int active_obs_size;
   int active_ens_size;
+  bool_vector_type * obs_mask;
+  bool_vector_type * ens_mask;
   int state_size;
 
   es_testdata(const matrix_type* S, const matrix_type * R, const matrix_type * dObs, const matrix_type *D , const matrix_type * E);
@@ -47,6 +49,8 @@ public:
   void save_matrix(const std::string& name, const matrix_type * m) const;
   matrix_type * alloc_state(const std::string& name) const;
   void save(const std::string& path) const;
+  void deactivate_obs(int iobs);
+  void deactivate_realization(int iens);
 };
 
 }

--- a/lib/include/ert/res_util/matrix.hpp
+++ b/lib/include/ert/res_util/matrix.hpp
@@ -164,6 +164,8 @@ typedef struct matrix_struct matrix_type;
   void          matrix_diag_set(matrix_type * matrix , const double * diag);
   void          matrix_random_init(matrix_type * matrix , rng_type * rng);
   void          matrix_matlab_dump(const matrix_type * matrix, const char * filename);
+  void          matrix_delete_row(matrix_type * m1, int row);
+  void          matrix_delete_column(matrix_type * m1, int row);
 
   void          matrix_imul_col( matrix_type * matrix , int column , double factor);
   double        matrix_column_column_dot_product(const matrix_type * m1 , int col1 , const matrix_type * m2 , int col2);

--- a/lib/res_util/matrix.cpp
+++ b/lib/res_util/matrix.cpp
@@ -20,6 +20,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+
+#include <stdexcept>
 #include <cmath>
 
 #include <ert/util/ert_api_config.hpp>
@@ -1637,6 +1639,47 @@ void matrix_inplace_diag_sqrt(matrix_type *Cd)
         Cd->data[GET_INDEX(Cd , i , i)] = sqrt(Cd->data[GET_INDEX(Cd , i , i)]);
       }
   }
+}
+
+void matrix_delete_column(matrix_type * m1, int column) {
+  if (column < 0 || column >= matrix_get_columns(m1))
+    throw std::invalid_argument("Invalid column" + std::to_string(column));
+
+  matrix_type * m2 = matrix_alloc(matrix_get_rows(m1), matrix_get_columns(m1) - 1);
+  if (column > 0)
+    matrix_copy_block(m2, 0, 0,
+                      matrix_get_rows(m2), column,
+                      m1, 0, 0);
+
+  if (column < (matrix_get_columns(m1) - 1))
+    matrix_copy_block(m2, 0, column,
+                      matrix_get_rows(m2), matrix_get_columns(m2) - column,
+                      m1, 0, column + 1);
+
+  matrix_resize(m1, matrix_get_rows(m2), matrix_get_columns(m2), false);
+  matrix_assign(m1, m2);
+  matrix_free(m2);
+}
+
+
+void matrix_delete_row(matrix_type * m1, int row) {
+  if (row < 0 || row >= matrix_get_rows(m1))
+    throw std::invalid_argument("Invalid row" + std::to_string(row));
+
+  matrix_type * m2 = matrix_alloc(matrix_get_rows(m1) - 1, matrix_get_columns(m1));
+  if (row > 0)
+    matrix_copy_block(m2, 0, 0,
+                      row, matrix_get_columns(m2),
+                      m1, 0, 0);
+
+  if (row < (matrix_get_rows(m1) - 1))
+    matrix_copy_block(m2, row, 0,
+                      matrix_get_rows(m2) - row, matrix_get_columns(m2),
+                      m1, row + 1, 0);
+
+  matrix_resize(m1, matrix_get_rows(m2), matrix_get_columns(m2), false);
+  matrix_assign(m1, m2);
+  matrix_free(m2);
 }
 
 

--- a/lib/res_util/tests/ert_util_matrix.cpp
+++ b/lib/res_util/tests/ert_util_matrix.cpp
@@ -98,7 +98,7 @@ void test_dims() {
 
 
 void test_readwrite() {
-  test_work_area_type * test_area = test_work_area_alloc("matrix-test");
+  ecl::util::TestArea test_area("matrix_test");
   {
     rng_type * rng = rng_alloc(MZRAN , INIT_DEV_URANDOM );
     matrix_type * m1 = matrix_alloc(3  , 3);
@@ -136,7 +136,6 @@ void test_readwrite() {
     matrix_free( m1 );
     rng_free( rng );
   }
-  test_work_area_free( test_area );
 }
 
 
@@ -231,7 +230,7 @@ void test_inplace_sub_column() {
 
 
 void test_data() {
-  test_work_area_type * work_area = test_work_area_alloc("matrix_data");
+  ecl::util::TestArea("matrix_data");
   int rows = 11;
   int columns = 7;
   matrix_type * m1 = matrix_alloc(rows, columns);
@@ -269,7 +268,6 @@ void test_data() {
     fclose(stream);
   }
   matrix_free(m1);
-  test_work_area_free(work_area);
 }
 
 int main( int argc , char ** argv) {

--- a/lib/res_util/tests/es_testdata.cpp
+++ b/lib/res_util/tests/es_testdata.cpp
@@ -34,9 +34,30 @@ res::es_testdata make_testdata(int ens_size, int obs_size) {
     for (int i=0; i < matrix_get_rows(S); i++) {
       for (int j=0; j < matrix_get_columns(S); j++) {
         matrix_iset(S, i, j, v);
+        matrix_iset(E, i, j, v);
+        matrix_iset(D, i, j, v);
         v += 1;
       }
     }
+
+    v = 0;
+    for (int i=0; i < matrix_get_rows(dObs); i++) {
+      for (int j=0; j < matrix_get_columns(dObs); j++) {
+        matrix_iset(dObs, i, j, v);
+        v += 1;
+      }
+    }
+
+    v = 0;
+    for (int i=0; i < matrix_get_rows(R); i++) {
+      for (int j=0; j < matrix_get_columns(R); j++) {
+        matrix_iset(R, i, j, v);
+        v += 1;
+      }
+    }
+
+
+
   }
   res::es_testdata td(S,R,dObs,D,E);
 
@@ -49,6 +70,62 @@ res::es_testdata make_testdata(int ens_size, int obs_size) {
   return td;
 }
 
+void test_deactivate() {
+  int ens_size = 10;
+  int obs_size =  7;
+  int del_iobs = 3;
+  int del_iens = 7;
+  res::es_testdata td1 = make_testdata(ens_size, obs_size);
+  res::es_testdata td2 = make_testdata(ens_size, obs_size);
+
+
+
+  test_assert_throw(td1.deactivate_obs(10), std::invalid_argument);
+  td1.deactivate_obs(del_iobs);
+
+  for (int i1=0; i1 < matrix_get_rows(td1.R); i1++) {
+    int i2 = i1 + (i1 >= del_iobs ? 1 : 0);
+    for (int j1=0; j1 < matrix_get_columns(td1.R); j1++) {
+      int j2 = j1 + (j1 >= del_iobs ? 1 : 0);
+
+      test_assert_double_equal(matrix_iget(td1.R, i1, j1), matrix_iget(td2.R, i2, j2));
+    }
+
+    test_assert_double_equal(matrix_iget(td1.dObs, i1, 0), matrix_iget(td2.dObs, i2, 0));
+    test_assert_double_equal(matrix_iget(td1.dObs, i1, 1), matrix_iget(td2.dObs, i2, 1));
+    for (int j1=0; j1 < matrix_get_columns(td1.S); j1++) {
+      int j2 = j1;
+      test_assert_double_equal(matrix_iget(td1.S, i1, j1), matrix_iget(td2.S, i2, j2));
+
+      if (td1.E)
+        test_assert_double_equal(matrix_iget(td1.E, i1, j1), matrix_iget(td2.E, i2, j2));
+
+      if (td1.D)
+        test_assert_double_equal(matrix_iget(td1.D, i1, j1), matrix_iget(td2.D, i2, j2));
+    }
+  }
+
+  td1.deactivate_realization(del_iens);
+
+  for (int i1=0; i1 < matrix_get_rows(td1.S); i1++) {
+    int i2 = i1 + (i1 >= del_iobs ? 1 : 0);
+
+    for (int j1=0; j1 < matrix_get_columns(td1.S); j1++) {
+      int j2 = j1 + (j1 >= del_iens ? 1 : 0);
+
+      test_assert_double_equal(matrix_iget(td1.S, i1, j1), matrix_iget(td2.S, i2, j2));
+
+      if (td1.E)
+        test_assert_double_equal(matrix_iget(td1.E, i1, j1), matrix_iget(td2.E, i2, j2));
+
+      if (td1.D)
+        test_assert_double_equal(matrix_iget(td1.D, i1, j1), matrix_iget(td2.D, i2, j2));
+    }
+  }
+
+  test_assert_int_equal(td1.active_ens_size, ens_size - 1);
+  test_assert_int_equal(td1.active_obs_size, obs_size - 1);
+}
 
 
 void test_basic() {
@@ -57,10 +134,14 @@ void test_basic() {
   int obs_size =  7;
   res::es_testdata td1 = make_testdata(ens_size, obs_size);
   td1.save("path/sub/path");
-
   res::es_testdata td2("path/sub/path");
   test_assert_true( matrix_equal(td1.S, td2.S) );
 
+  test_assert_int_equal( bool_vector_size(td1.obs_mask), obs_size );
+  test_assert_int_equal( bool_vector_count_equal(td1.obs_mask, true), obs_size );
+
+  test_assert_int_equal( bool_vector_size(td1.ens_mask), ens_size );
+  test_assert_int_equal( bool_vector_count_equal(td1.ens_mask, true), ens_size );
 }
 
 
@@ -90,12 +171,13 @@ void test_load_state() {
   td0.save("PATH");
 
   res::es_testdata td("PATH");
-
+  td.deactivate_realization(5);
+  int active_ens_size = td.active_ens_size;
 
   test_assert_throw( td.alloc_state("DOES_NOT_EXIST"), std::invalid_argument);
 
   {
-    int invalid_size = 10 * ens_size + ens_size / 2;
+    int invalid_size = 10 * active_ens_size + active_ens_size / 2;
     FILE * stream = util_fopen("PATH/A0", "w");
     for (int i = 0; i < invalid_size; i++)
       fprintf(stream, "%d\n", i);
@@ -104,11 +186,11 @@ void test_load_state() {
   }
   {
     int state_size = 7;
-    int valid_size = state_size * ens_size;
+    int valid_size = state_size * active_ens_size;
     FILE * stream = util_fopen("PATH/A1", "w");
     double value = 0;
     for (int row=0; row < state_size; row++) {
-      for (int iens = 0; iens < ens_size; iens++) {
+      for (int iens = 0; iens < active_ens_size; iens++) {
         fprintf(stream, "%lg ", value);
         value++;
       }
@@ -118,18 +200,18 @@ void test_load_state() {
 
     matrix_type * A1 = td.alloc_state("A1");
     test_assert_int_equal(matrix_get_rows(A1), state_size);
-    test_assert_int_equal(matrix_get_columns(A1), ens_size);
+    test_assert_int_equal(matrix_get_columns(A1), active_ens_size);
 
     value = 0;
     for (int row=0; row < state_size; row++) {
-      for (int iens = 0; iens < ens_size; iens++) {
+      for (int iens = 0; iens < active_ens_size; iens++) {
         test_assert_double_equal(matrix_iget(A1, row, iens), value);
         value++;
       }
     }
 
     td.save_matrix("A2", A1);
-    matrix_type * A2 = td.alloc_matrix("A2", state_size, ens_size);
+    matrix_type * A2 = td.alloc_matrix("A2", state_size, active_ens_size);
     test_assert_true( matrix_equal(A1,A2) );
 
     matrix_free(A1);
@@ -140,5 +222,6 @@ void test_load_state() {
 int main() {
   test_basic();
   test_load_state();
+  test_deactivate();
   test_size_problems();
 }

--- a/lib/res_util/tests/es_testdata.cpp
+++ b/lib/res_util/tests/es_testdata.cpp
@@ -50,9 +50,9 @@ res::es_testdata make_testdata(int ens_size, int obs_size) {
 }
 
 
-void test_basic() {
-  test_work_area_type * work_area = test_work_area_alloc("es_testdata");
 
+void test_basic() {
+  ecl::util::TestArea work_area("es_testdata");
   int ens_size = 10;
   int obs_size =  7;
   res::es_testdata td1 = make_testdata(ens_size, obs_size);
@@ -61,12 +61,11 @@ void test_basic() {
   res::es_testdata td2("path/sub/path");
   test_assert_true( matrix_equal(td1.S, td2.S) );
 
-  test_work_area_free(work_area);
 }
 
 
 void test_load_state() {
-  test_work_area_type * work_area = test_work_area_alloc("es_testdata");
+  ecl::util::TestArea work_area("es_testdata");
   int ens_size = 10;
   int obs_size =  7;
   res::es_testdata td0 = make_testdata(ens_size, obs_size);
@@ -118,7 +117,6 @@ void test_load_state() {
     matrix_free(A1);
     matrix_free(A2);
   }
-  test_work_area_free(work_area);
 }
 
 int main() {

--- a/lib/res_util/tests/es_testdata.cpp
+++ b/lib/res_util/tests/es_testdata.cpp
@@ -64,6 +64,24 @@ void test_basic() {
 }
 
 
+void test_size_problems() {
+  ecl::util::TestArea work_area("es_testdata");
+  int ens_size = 10;
+  int obs_size =  7;
+  {
+    res::es_testdata td1 = make_testdata(ens_size, obs_size);
+    td1.save("path");
+  }
+  unlink("path/size");
+  test_assert_throw( res::es_testdata("path"), std::invalid_argument );
+  {
+    FILE * fp = util_fopen("path/size", "w");
+    fprintf(fp, "%d\n", ens_size);
+    fclose(fp);
+  }
+  test_assert_throw( res::es_testdata("path"), std::invalid_argument );
+}
+
 void test_load_state() {
   ecl::util::TestArea work_area("es_testdata");
   int ens_size = 10;
@@ -122,4 +140,5 @@ void test_load_state() {
 int main() {
   test_basic();
   test_load_state();
+  test_size_problems();
 }


### PR DESCRIPTION
This is another small step to enable proper testing of #422. 

In the ensemble smoother in general, and in the iterated ensemble smoother in particular, the book-keeping of realizations and observations which are killed off/deactivated for various reasons is quite complex. With this PR the class `es_testdata` has got the ability to deactivate observations and realizations, to test this functionality.