### PR TITLE
Secure abs calls

### DIFF
--- a/lib/analysis/bootstrap_enkf.cpp
+++ b/lib/analysis/bootstrap_enkf.cpp
@@ -19,7 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/int_vector.hpp>
 #include <ert/util/util.hpp>

--- a/lib/analysis/cv_enkf.cpp
+++ b/lib/analysis/cv_enkf.cpp
@@ -19,7 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/util.hpp>
 #include <ert/util/rng.hpp>

--- a/lib/analysis/enkf_linalg.cpp
+++ b/lib/analysis/enkf_linalg.cpp
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/res_util/matrix.hpp>
 #include <ert/res_util/matrix_lapack.hpp>
@@ -675,7 +675,7 @@ void enkf_linalg_checkX(const matrix_type * X , bool bootstrap) {
 
     for (int icol = 0; icol < matrix_get_columns( X ); icol++) {
       double col_sum = matrix_get_column_sum(X , icol);
-      if (fabs(col_sum - target_sum) > 0.0001)
+      if (std::abs(col_sum - target_sum) > 0.0001)
         util_abort("%s: something is seriously broken. col:%d  col_sum = %g != %g - ABORTING\n",__func__ , icol , col_sum , target_sum);
     }
   }

--- a/lib/analysis/fwd_step_enkf.cpp
+++ b/lib/analysis/fwd_step_enkf.cpp
@@ -18,7 +18,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
 
 #if defined(_OPENMP)
@@ -193,7 +193,7 @@ static void fwd_step_enkf_write_iter_info( fwd_step_enkf_data_type * data , step
     int row_end   = module_obs_block_get_row_end(module_obs_block);
     const char* obs_key = module_obs_block_get_key(module_obs_block);
     const double var_beta = stepwise_iget_beta(stepwise, ivar);
-    const double var_beta_percent = 100.0 * fabs(var_beta) / sum_beta;
+    const double var_beta_percent = 100.0 * std::abs(var_beta) / sum_beta;
 
     int local_index = 0;
     for (int i = row_start; i < row_end; i++) {

--- a/lib/analysis/modules/rml_enkf.c
+++ b/lib/analysis/modules/rml_enkf.c
@@ -306,7 +306,7 @@ void rml_enkf_init_Csc(const rml_enkf_data_type * data ){
       double sumrow = matrix_get_row_sum(prior , row);
       double tmp    = sumrow / ens_size;
 
-      if (abs(tmp)< 1)
+      if (fabs(tmp)< 1)
         data->Csc[row] = 0.05;
       else
         data->Csc[row] = 1.00;

--- a/lib/enkf/custom_kw.cpp
+++ b/lib/enkf/custom_kw.cpp
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/util.h>
 #include <ert/util/bool_vector.h>

--- a/lib/enkf/data_ranking.cpp
+++ b/lib/enkf/data_ranking.cpp
@@ -18,7 +18,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 #include <stdbool.h>
 
 #include <ert/util/util.h>

--- a/lib/enkf/enkf_analysis.cpp
+++ b/lib/enkf/enkf_analysis.cpp
@@ -16,7 +16,7 @@
    for more details.
 */
 
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/util.h>
 #include <ert/res_util/matrix.hpp>
@@ -144,7 +144,7 @@ void enkf_analysis_deactivate_outliers(obs_data_type * obs_data , meas_data_type
                outliers will lead to numerical problems.
             */
 
-            if (fabs( innov ) > alpha * (ens_std + obs_std)) {
+            if (std::abs( innov ) > alpha * (ens_std + obs_std)) {
               obs_block_deactivate(obs_block , iobs , verbose , "No overlap");
               meas_block_deactivate(meas_block , iobs);
             }

--- a/lib/enkf/enkf_obs.cpp
+++ b/lib/enkf/enkf_obs.cpp
@@ -18,7 +18,7 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/hash.h>
 #include <ert/util/util.h>

--- a/lib/enkf/enkf_plot_gendata.cpp
+++ b/lib/enkf/enkf_plot_gendata.cpp
@@ -20,7 +20,7 @@
 #include <time.h>
 #include <stdbool.h>
 #include <float.h>
-#include <math.h>
+#include <cmath>
 
 
 #include <ert/util/double_vector.h>

--- a/lib/enkf/enkf_util.cpp
+++ b/lib/enkf/enkf_util.cpp
@@ -16,7 +16,7 @@
    for more details.
 */
 
-#include <math.h>
+#include <cmath>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/lib/enkf/field.cpp
+++ b/lib/enkf/field.cpp
@@ -16,7 +16,7 @@
    for more details.
 */
 
-#include <math.h>
+#include <cmath>
 #include <stdlib.h>
 #include <string.h>
 
@@ -626,12 +626,12 @@ static bool field_check_finite( const field_type * field) {
   if (ecl_type_is_float(data_type)) {
     float * data = (float *) field->data;
     for (int i=0; i < data_size; i++)
-      if (!isfinite( data[i] ))
+      if (!std::isfinite( data[i] ))
         ok = false;
   } else if (ecl_type_is_double(data_type)) {
     double * data = (double *) field->data;
     for (int i=0; i < data_size; i++)
-      if (!isfinite( data[i] ))
+      if (!std::isfinite( data[i] ))
         ok = false;
   }
   return ok;

--- a/lib/enkf/field_config.cpp
+++ b/lib/enkf/field_config.cpp
@@ -18,7 +18,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/util.h>
 #include <ert/util/string_util.h>

--- a/lib/enkf/field_trans.cpp
+++ b/lib/enkf/field_trans.cpp
@@ -30,7 +30,7 @@
 */
 #include <string.h>
 #include <stdbool.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/hash.h>
 #include <ert/util/util.h>

--- a/lib/enkf/gen_data.cpp
+++ b/lib/enkf/gen_data.cpp
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/util.h>
 #include <ert/res_util/matrix.hpp>

--- a/lib/enkf/gen_kw.cpp
+++ b/lib/enkf/gen_kw.cpp
@@ -19,7 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/util.h>
 #include <ert/util/buffer.h>

--- a/lib/enkf/meas_data.cpp
+++ b/lib/enkf/meas_data.cpp
@@ -21,7 +21,7 @@
    involved with observations/measurement/+++.
 */
 
-#include <math.h>
+#include <cmath>
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>

--- a/lib/enkf/misfit_ensemble.cpp
+++ b/lib/enkf/misfit_ensemble.cpp
@@ -18,7 +18,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 #include <stdbool.h>
 
 #include <ert/util/util.h>

--- a/lib/enkf/misfit_ranking.cpp
+++ b/lib/enkf/misfit_ranking.cpp
@@ -18,7 +18,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/util.h>
 #include <ert/util/hash.h>

--- a/lib/enkf/obs_data.cpp
+++ b/lib/enkf/obs_data.cpp
@@ -62,7 +62,7 @@ Matrices: S, D, E and various internal variables.
 
 
 #include <stdlib.h>
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
 #include <pthread.h>
 

--- a/lib/enkf/obs_vector.cpp
+++ b/lib/enkf/obs_vector.cpp
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <time.h>
+#include <cmath>
 
 #include <ert/util/util.h>
 #include <ert/util/vector.h>
@@ -568,10 +569,10 @@ bool obs_vector_load_from_HISTORY_OBSERVATION(obs_vector_type * obs_vector ,
           double_vector_iset( std , restart_nr , error );
       } else if(strcmp(error_mode, "REL") == 0) {
         for( restart_nr = 0; restart_nr < size; restart_nr++)
-          double_vector_iset( std , restart_nr , error * abs( double_vector_iget( value , restart_nr )));
+          double_vector_iset( std , restart_nr , error * std::abs( double_vector_iget( value , restart_nr )));
       } else if(strcmp(error_mode, "RELMIN") == 0) {
         for(restart_nr = 0; restart_nr < size; restart_nr++) {
-          double tmp_std = util_double_max( error_min , error * abs( double_vector_iget( value , restart_nr )));
+          double tmp_std = util_double_max( error_min , error * std::abs( double_vector_iget( value , restart_nr )));
           double_vector_iset( std , restart_nr , tmp_std);
         }
       } else
@@ -620,10 +621,10 @@ bool obs_vector_load_from_HISTORY_OBSERVATION(obs_vector_type * obs_vector ,
                 double_vector_iset( std , restart_nr , error_segment) ;
             } else if(strcmp(error_mode_segment, "REL") == 0) {
               for( restart_nr = start; restart_nr <= stop; restart_nr++)
-                double_vector_iset( std , restart_nr , error_segment * abs(double_vector_iget( value , restart_nr)));
+                double_vector_iset( std , restart_nr , error_segment * std::abs(double_vector_iget( value , restart_nr)));
             } else if(strcmp(error_mode_segment, "RELMIN") == 0) {
               for(restart_nr = start; restart_nr <= stop ; restart_nr++) {
-                double tmp_std = util_double_max( error_min_segment , error_segment * abs( double_vector_iget( value , restart_nr )));
+                double tmp_std = util_double_max( error_min_segment , error_segment * std::abs( double_vector_iget( value , restart_nr )));
                 double_vector_iset( std , restart_nr , tmp_std);
               }
             } else

--- a/lib/enkf/ranking_table.cpp
+++ b/lib/enkf/ranking_table.cpp
@@ -18,7 +18,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 #include <stdbool.h>
 
 #include <ert/util/util.h>

--- a/lib/enkf/summary.cpp
+++ b/lib/enkf/summary.cpp
@@ -17,7 +17,7 @@
 */
 
 #include <stdlib.h>
-#include <math.h>
+#include <cmath>
 #include <string.h>
 
 #include <ert/util/util.h>

--- a/lib/enkf/summary_obs.cpp
+++ b/lib/enkf/summary_obs.cpp
@@ -21,7 +21,7 @@
 */
 #include <stdlib.h>
 #include <stdbool.h>
-#include <math.h>
+#include <cmath>
 #include <string.h>
 #include <stdio.h>
 

--- a/lib/enkf/surface.cpp
+++ b/lib/enkf/surface.cpp
@@ -17,7 +17,7 @@
 */
 
 #include <stdlib.h>
-#include <math.h>
+#include <cmath>
 #include <string.h>
 
 #include <ert/util/util.h>

--- a/lib/enkf/time_map.cpp
+++ b/lib/enkf/time_map.cpp
@@ -17,6 +17,7 @@
 
 
 #include <stdlib.h>
+#include <cmath>
 #include <pthread.h>
 #include <stdbool.h>
 
@@ -483,7 +484,7 @@ int time_map_lookup_time_with_tolerance( time_map_type * map , time_t time , int
           break;
         }
 
-        if (abs(diff) < nearest_diff) {
+        if (std::abs(diff) < nearest_diff) {
           bool inside_tolerance = true;
           if (seconds_after_tolerance >= 0) {
             if (diff >= seconds_after_tolerance)

--- a/lib/enkf/trans_func.cpp
+++ b/lib/enkf/trans_func.cpp
@@ -16,7 +16,7 @@
    for more details.
 */
 
-#include <math.h>
+#include <cmath>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/lib/enkf/value_export.cpp
+++ b/lib/enkf/value_export.cpp
@@ -16,7 +16,7 @@
    for more details.
 */
 #include <stdlib.h>
-#include <math.h>
+#include <cmath>
 
 #include <map>
 

--- a/lib/include/ert/enkf/ranking_common.hpp
+++ b/lib/include/ert/enkf/ranking_common.hpp
@@ -18,7 +18,7 @@
 
 #ifndef ERT_RANKING_COMMON_H
 #define ERT_RANKING_COMMON_H
-#include <math.h>
+#include <cmath>
 
 #define INVALID_RANKING_VALUE  INFINITY
 

--- a/lib/job_queue/tests/job_status_test.cpp
+++ b/lib/job_queue/tests/job_status_test.cpp
@@ -16,7 +16,7 @@
    for more details.
 */
 
-#include <math.h>
+#include <cmath>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <pthread.h>

--- a/lib/res_util/matrix.cpp
+++ b/lib/res_util/matrix.cpp
@@ -20,7 +20,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/ert_api_config.hpp>
 #include <ert/res_util/thread_pool.hpp>
@@ -1237,7 +1237,7 @@ double matrix_get_column_abssum(const matrix_type * matrix , int column) {
   double sum = 0;
   int i;
   for (i=0; i < matrix->rows; i++)
-    sum += fabs( matrix->data[ GET_INDEX( matrix , i , column ) ] );
+    sum += std::abs( matrix->data[ GET_INDEX( matrix , i , column ) ] );
   return sum;
 }
 
@@ -1258,7 +1258,7 @@ double matrix_get_row_abssum(const matrix_type * matrix , int row) {
   int j;
   for ( j=0; j < matrix->columns; j++) {
     double m = matrix->data[ GET_INDEX( matrix , row , j ) ];
-    sum_abs += fabs( m );
+    sum_abs += std::abs( m );
   }
   return sum_abs;
 }
@@ -1382,7 +1382,7 @@ bool matrix_is_finite(const matrix_type * matrix) {
   int i,j;
   for (i = 0; i < matrix->rows; i++)
     for (j =0; j< matrix->columns; j++)
-      if ( !isfinite( matrix->data[ GET_INDEX( matrix , i , j) ])) {
+      if ( !std::isfinite( matrix->data[ GET_INDEX( matrix , i , j) ])) {
         printf("%s(%d,%d) = %g \n",matrix->name , i,j,matrix->data[ GET_INDEX( matrix , i , j) ]);
         return false;
       }
@@ -1419,9 +1419,9 @@ double matrix_orthonormality( const matrix_type * matrix ) {
       double dev;
 
       if (col1 == col2)
-        dev = fabs( dot_product - 1.0 );
+        dev = std::abs( dot_product - 1.0 );
       else
-        dev = fabs( dot_product );
+        dev = std::abs( dot_product );
 
       if (dev > max_dev)
         max_dev = dev;
@@ -1487,7 +1487,7 @@ bool matrix_similar( const matrix_type * m1 , const matrix_type * m2, double eps
         double d1 = m1->data[ index1 ];
         double d2 = m2->data[ index2 ];
 
-        if (fabs(d1 - d2) > epsilon)
+        if (std::abs(d1 - d2) > epsilon)
           return false;
       }
     }

--- a/lib/res_util/matrix_lapack.cpp
+++ b/lib/res_util/matrix_lapack.cpp
@@ -16,7 +16,7 @@
    for more details.
 */
 
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/util.hpp>
 
@@ -638,12 +638,12 @@ double matrix_det( matrix_type *A ) {
 
 
         /* Try to avoid overflow/underflow by factoring out the order of magnitude. */
-        while (fabs(det) > 10.0) {
+        while (std::abs(det) > 10.0) {
           det       /= 10;
           det_scale += 1;
         }
 
-        while (fabs(det) < 1.0) {
+        while (std::abs(det) < 1.0) {
           det       *= 10;
           det_scale -= 1;
         }

--- a/lib/res_util/matrix_stat.cpp
+++ b/lib/res_util/matrix_stat.cpp
@@ -20,7 +20,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/util.hpp>
 

--- a/lib/res_util/regression.cpp
+++ b/lib/res_util/regression.cpp
@@ -95,7 +95,7 @@ double regression_unscale(const matrix_type * beta , const matrix_type * X_norm 
    Performs an ordinary least squares estimation of the parameter
    vector beta.
 
-   beta = inv(X'·X)·X'·y
+   beta = inv(X' . X) . X' . y
 */
 
 void regression_augmented_OLS( const matrix_type * X , const matrix_type * Y , const matrix_type* Z, matrix_type * beta) {

--- a/lib/res_util/subst_func.cpp
+++ b/lib/res_util/subst_func.cpp
@@ -18,7 +18,7 @@
 
 
 #include <stdbool.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/util.hpp>
 #include <ert/util/stringlist.hpp>

--- a/lib/res_util/tests/ert_util_matrix.cpp
+++ b/lib/res_util/tests/ert_util_matrix.cpp
@@ -19,7 +19,7 @@
 
 
 #include <stdlib.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/bool_vector.hpp>
 #include <ert/util/test_util.hpp>
@@ -223,7 +223,7 @@ void test_inplace_sub_column() {
     int row;
     for (row = 0; row < N; row++) {
       double diff = matrix_iget( m1 , row , 0);
-      test_assert_true( fabs( diff ) < 1e-6);
+      test_assert_true( std::abs( diff ) < 1e-6);
     }
   }
 }

--- a/lib/res_util/tests/ert_util_matrix_lapack.cpp
+++ b/lib/res_util/tests/ert_util_matrix_lapack.cpp
@@ -19,7 +19,7 @@
 
 
 #include <stdlib.h>
-#include <math.h>
+#include <cmath>
 
 #include <ert/util/bool_vector.hpp>
 #include <ert/util/test_util.hpp>

--- a/lib/rms/rms_tagkey.cpp
+++ b/lib/rms/rms_tagkey.cpp
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 #include <time.h>
 
 #include <ert/util/util.hpp>

--- a/lib/sched/sched_kw_compdat.cpp
+++ b/lib/sched/sched_kw_compdat.cpp
@@ -18,7 +18,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
+#include <cmath>
 #include <string.h>
 #include <stdbool.h>
 

--- a/python/tests/res/enkf/export/test_export_join.py
+++ b/python/tests/res/enkf/export/test_export_join.py
@@ -78,12 +78,12 @@ class ExportJoinTest(ResTest):
             self.assertEqual(result["EXTRA_INT_COLUMN"][1][last_date], 225)
             self.assertEqual(result["EXTRA_STRING_COLUMN"][1][last_date], "OFF")
 
-            self.assertFloatEqual(result["MISFIT:FOPR"][0][last_date], 489.191069)
-            self.assertFloatEqual(result["MISFIT:FOPR"][24][last_date], 1841.906872)
+            self.assertFloatEqual(result["MISFIT:FOPR"][0][last_date], 457.491003)
+            self.assertFloatEqual(result["MISFIT:FOPR"][24][last_date], 1630.774198)
 
-            self.assertFloatEqual(result["MISFIT:TOTAL"][0][first_date], 500.170035)
-            self.assertFloatEqual(result["MISFIT:TOTAL"][0][last_date], 500.170035)
-            self.assertFloatEqual(result["MISFIT:TOTAL"][24][last_date], 1925.793865)
+            self.assertFloatEqual(result["MISFIT:TOTAL"][0][first_date], 468.469969)
+            self.assertFloatEqual(result["MISFIT:TOTAL"][0][last_date], 468.469969)
+            self.assertFloatEqual(result["MISFIT:TOTAL"][24][last_date], 1714.662370)
 
 
             with self.assertRaises(KeyError):

--- a/python/tests/res/enkf/export/test_misfit_collector.py
+++ b/python/tests/res/enkf/export/test_misfit_collector.py
@@ -13,11 +13,11 @@ class MisfitCollectorTest(ResTest):
             ert = context.getErt()
             data = MisfitCollector.loadAllMisfitData(ert, "default_0")
 
-            self.assertFloatEqual(data["MISFIT:FOPR"][0], 798.378619)
-            self.assertFloatEqual(data["MISFIT:FOPR"][24], 1332.219633)
+            self.assertFloatEqual(data["MISFIT:FOPR"][0],  737.436374)
+            self.assertFloatEqual(data["MISFIT:FOPR"][24], 1258.644538)
 
-            self.assertFloatEqual(data["MISFIT:TOTAL"][0], 826.651491)
-            self.assertFloatEqual(data["MISFIT:TOTAL"][24], 1431.305646)
+            self.assertFloatEqual(data["MISFIT:TOTAL"][0], 765.709246)
+            self.assertFloatEqual(data["MISFIT:TOTAL"][24], 1357.730551)
 
             realization_20 = data.loc[20]
 


### PR DESCRIPTION
This secures all calls to abs and other math calls. The function abs in c++ does not support double, we need to include cmath in all cpp files. In addition, we should secure other math calls in c++ by specifically referring to std namespace.


The new test values for ExportJoinTest and MisfitCollectorTest has been calculated manually with the following script.
```
from res.enkf.export import GenDataCollector
from res.enkf import ResConfig
from res.enkf import EnKFMain
from ecl.summary import EclSum
from res.enkf.export import SummaryCollector

rc = ResConfig('snake_oil.ert')
main = EnKFMain(rc)

e = EclSum('refcase/SNAKE_OIL_FIELD')
obs = main.getObservations()


def chi(val1, val2, std):
    result = (val1-val2)/std
    return result*result


def chi_from_fopr_obs(realization, key, storage):
    history = key+'H'
    data = e.numpy_vector(key=history, report_only=True)
    res = 0
    for v1, v2, i in zip(storage[key][realization], data, range(0, len(data) - 1)):
        res += chi(v1, v2, max(0.1, 0.1 * abs(v2)))
    return res


def chi_from_obs_key(obskey, realization, sum_storage):
    split_key = obskey.split('_')
    key = split_key[0]+':'+split_key[1]
    time_step = eval(split_key[2])

    std = obs[obskey].getNode(time_step).getStandardDeviation()
    value = obs[obskey].getNode(time_step).getValue()

    return chi(sum_storage[key][realization][time_step - 1], value, std)


def chi_from_sum_obs(realization, sum_storage):
    res = 0
    local_obs = obs.getAllActiveLocalObsdata()
    for x in local_obs:
        key = x.key()
        if key == 'FOPR' or key == 'WPR_DIFF_1':
            continue
        res += chi_from_obs_key(key, realization, sum_storage)
    return res


def chi_from_gen_obs(realization, gen_storage):
    timesteps = [400, 800, 1200, 1800]
    stds = [0.1, 0.2, 0.15, 0.05]
    values = [0.0, 0.1, 0.2, 0.0]

    res = 0
    for timestep, value, std in zip(timesteps, values, stds):
        diff = gen_storage[realization][timestep]
        res += chi(diff, value, std)
    return res


def get_total(realization, sum_storage, gen_storage):
    total = 0
    total += chi_from_fopr_obs(realization, 'FOPR', sum_storage)
    total += chi_from_sum_obs(realization, sum_storage)
    total += chi_from_gen_obs(realization, gen_storage)
    print total


gen_storage_ = GenDataCollector.loadGenData(main, 'default_0', 'SNAKE_OIL_WPR_DIFF', 199)
sum_storage_ = SummaryCollector.loadAllSummaryData(main, 'default_0')
get_total(0, sum_storage_, gen_storage_)
get_total(24, sum_storage_, gen_storage_)

gen_storage_ = GenDataCollector.loadGenData(main, 'default_1', 'SNAKE_OIL_WPR_DIFF', 199)
sum_storage_ = SummaryCollector.loadAllSummaryData(main, 'default_1')
get_total(0, sum_storage_, gen_storage_)
get_total(24, sum_storage_, gen_storage_)

```
