### PR TITLE
Expose ITER as magic string

### DIFF
--- a/lib/enkf/run_arg.cpp
+++ b/lib/enkf/run_arg.cpp
@@ -336,6 +336,9 @@ static void run_arg_update_subst(run_arg_type * run_arg)
   char * iens_str = util_alloc_sprintf("%d", run_arg->iens);
   subst_list_prepend_owned_ref(run_arg->subst_list, "<IENS>", iens_str, NULL);
 
+  char * iter_str = util_alloc_sprintf("%d", run_arg->iter);
+  subst_list_prepend_owned_ref(run_arg->subst_list, "<ITER>", iter_str, NULL);
+
   if (run_arg->geo_id != -1) {
     char * geo_id_str = util_alloc_sprintf("%d", run_arg->geo_id);
     subst_list_prepend_owned_ref(run_arg->subst_list, "<GEO_ID>", geo_id_str, NULL);

--- a/python/tests/res/enkf/test_runpath_list_dump.py
+++ b/python/tests/res/enkf/test_runpath_list_dump.py
@@ -1,4 +1,5 @@
 import unittest, os
+import itertools
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
@@ -10,13 +11,27 @@ from res.enkf import ResConfig, EnKFMain, EnkfFs, ErtRunContext
 from res.enkf.enums import EnKFFSType, EnkfRunType
 from res.util import PathFormat
 
+
+def render_dynamic_values(s, itr, iens, geo_id):
+    dynamic_magic_strings = {
+        "<GEO_ID>": geo_id,
+        "<ITER>": itr,
+        "<IENS>": iens,
+    }
+    for key, val in dynamic_magic_strings.items():
+        s = s.replace(key, str(val))
+
+    return s
+
+
 class RunpathListDumpTest(ResTest):
 
     def setUp(self):
         self.config_rel_path = "local/snake_oil_no_data/snake_oil_GEO_ID.ert"
         self.config_path = self.createTestPath(self.config_rel_path)
 
-    def test_add_all(self):
+
+    def _verify_runpath_rendering(self, itr, elementwise_runpath_creation=False):
         with ErtTestContext("add_all_runpath_dump", model_config=self.config_path) as ctx:
             res = ctx.getErt()
             fs_manager = res.getEnkfFsManager()
@@ -26,10 +41,9 @@ class RunpathListDumpTest(ResTest):
             mask = BoolVector(initial_size=num_realizations, default_value=True)
             mask[13] = False
 
-            runpath_fmt = "simulations/<GEO_ID>/realisation-%d/iter-%d"
+            runpath_fmt = "simulations/<GEO_ID>/realisation-%d/iter-%d/magic-real-<IENS>/magic-iter-<ITER>"
             jobname_fmt = "SNAKE_OIL_%d"
 
-            itr = 0
             subst_list = res.resConfig().subst_config.subst_list
             run_context = ErtRunContext.ensemble_experiment(sim_fs, mask, PathFormat(runpath_fmt), jobname_fmt, subst_list, itr)
 
@@ -38,8 +52,11 @@ class RunpathListDumpTest(ResTest):
             for i, run_arg in enumerate(run_context):
                 if mask[i]:
                     run_arg.geo_id = 10*i
+                    if elementwise_runpath_creation:
+                        res.createRunpath(run_context, i)
 
-            res.createRunpath(run_context)
+            if not elementwise_runpath_creation:
+                res.createRunpath(run_context)
 
             for i, run_arg in enumerate(run_context):
                 if not mask[i]:
@@ -51,9 +68,9 @@ class RunpathListDumpTest(ResTest):
             self.assertTrue(os.path.isfile(runpath_list_path))
 
             exp_runpaths = [
-                             runpath_fmt.replace("<GEO_ID>", str(run_arg.geo_id)) % (iens, itr)
-                             for iens, run_arg in enumerate(run_context) if mask[iens]
-                           ]
+                render_dynamic_values(runpath_fmt, itr, iens, run_arg.geo_id) % (iens, itr)
+                for iens, run_arg in enumerate(run_context) if mask[iens]
+            ]
             exp_runpaths = map(os.path.realpath, exp_runpaths)
 
             with open(runpath_list_path, 'r') as f:
@@ -62,46 +79,10 @@ class RunpathListDumpTest(ResTest):
             self.assertEqual(list(exp_runpaths), list(dumped_runpaths))
 
 
-    def test_add_one_by_one(self):
-        with ErtTestContext("add_one_by_one_runpath_dump", model_config=self.config_path) as ctx:
-            res = ctx.getErt()
-            fs_manager = res.getEnkfFsManager()
-            sim_fs = fs_manager.getFileSystem("sim_fs")
-
-            num_realizations = 25
-            mask = BoolVector(initial_size=num_realizations, default_value=True)
-            mask[13] = False
-
-            runpath_fmt = "simulations/<GEO_ID>/realisation-%d/iter-%d"
-            jobname_fmt = "SNAKE_OIL_%d"
-
-            itr = 0
-            subst_list = res.resConfig().subst_config.subst_list
-            run_context = ErtRunContext.ensemble_experiment(sim_fs, mask, PathFormat(runpath_fmt), jobname_fmt, subst_list, itr)
-
-            res.initRun(run_context)
-
-            for i, run_arg in enumerate(run_context):
-                if mask[i]:
-                    run_arg.geo_id = 10*i
-                    res.createRunpath(run_context, i)
-
-            for i, run_arg in enumerate(run_context):
-                if not mask[i]:
-                    continue
-
-                self.assertTrue(os.path.isdir("simulations/%d" % run_arg.geo_id))
-
-            runpath_list_path = ".ert_runpath_list"
-            self.assertTrue(os.path.isfile(runpath_list_path))
-
-            exp_runpaths = [
-                             runpath_fmt.replace("<GEO_ID>", str(run_arg.geo_id)) % (iens, itr)
-                             for iens, run_arg in enumerate(run_context) if mask[iens]
-                           ]
-            exp_runpaths = map(os.path.realpath, exp_runpaths)
-
-            with open(runpath_list_path, 'r') as f:
-                dumped_runpaths = list(zip(*[line.split() for line in f.readlines()]))[1]
-
-            self.assertEqual(list(exp_runpaths), list(dumped_runpaths))
+    def test_add_all(self):
+        test_base = itertools.product([0, 1, 2, 17], [True, False])
+        for itr, elementwise_creation in test_base:
+            self._verify_runpath_rendering(
+                    itr,
+                    elementwise_runpath_creation=elementwise_creation,
+                    )

--- a/test-data/local/snake_oil_no_data/snake_oil_GEO_ID.ert
+++ b/test-data/local/snake_oil_no_data/snake_oil_GEO_ID.ert
@@ -6,7 +6,7 @@ DEFINE <STORAGE> storage/<CONFIG_FILE_BASE>
 
 RANDOM_SEED 3593114179000630026631423308983283277868
 
-RUNPATH simulations/<GEO_ID>/realisation-%d/iter-%d
+RUNPATH simulations/<GEO_ID>/realisation-%d/iter-%d/magic-real-<IENS>/magic-iter-<ITER>
 ENSPATH <STORAGE>/ensemble
 ECLBASE SNAKE_OIL_FIELD
 SUMMARY *


### PR DESCRIPTION
This PR exposes the iteration number as a magic string similarly to how `GEO_ID` and `IENS` already is exposed. This implies that you can pass the iteration number to your forward model, encompass it in paths etc.

Cleaned up the runpath substitution tests while I was at it.
