### PR TITLE
Raise userwarning if workflows can't be run

### DIFF
--- a/python/res/job_queue/workflow.py
+++ b/python/res/job_queue/workflow.py
@@ -60,17 +60,21 @@ class Workflow(BaseCClass):
         """
         self.__running = True
         success = self._try_compile(context)
+        if not success:
+            msg = "** Warning: The workflow file {} is not valid - "\
+                  "make sure the workflow jobs are defined accordingly\n"
+            sys.stderr.write(msg.format(workflow.src_file))
 
-        if success:
-            for job, args in self:
-                self.__current_job = job
-                if not self.__cancelled:
-                    return_value = job.run(ert, args, verbose)
+            self.__running = False
+            return False
 
-                    if job.hasFailed():
-                        print(return_value)
+        for job, args in self:
+            self.__current_job = job
+            if not self.__cancelled:
+                return_value = job.run(ert, args, verbose)
 
-                    #todo store results?
+                if job.hasFailed():
+                    print(return_value)
 
         self.__current_job = None
         self.__running = False


### PR DESCRIPTION
**Issue**
If a workflow configuration was invalid, libres would not raise any warning. 

This does not completely solve issue: https://github.com/equinor/ert/issues/194, but it improves.

Handling issue 194 involves a bit more, e.g. if the config file is to include a stdout/stderror like the forward models, then parsing the file must be updated. It remains to find out if that is worth doing in c (as it is now), or if we should implement parsing yml config in python while retaining the old parsing for backwards compatibility.
