### PR TITLE
Keep stdout stderr

### DIFF
--- a/python/res/job_queue/ert_script.py
+++ b/python/res/job_queue/ert_script.py
@@ -102,7 +102,7 @@ class ErtScript(object):
     __module_count = 0 # Need to have unique modules in case of identical object naming in scripts
 
     def outputStackTrace(self, error=None):
-        stack_trace = error or "".join(traceback.format_exception(sys.exc_type, sys.exc_value, sys.exc_traceback))
+        stack_trace = error or "".join(traceback.format_exception(*sys.exc_info()))
         msg = "The script '{}' caused an error while running:\n{}"
 
         sys.stderr.write(msg.format(self.__class__.__name__, stack_trace))

--- a/python/res/job_queue/workflow_job.py
+++ b/python/res/job_queue/workflow_job.py
@@ -171,6 +171,13 @@ class WorkflowJob(BaseCClass):
     def free(self):
         self._free( )
 
+    def stdoutdata(self):
+        """ @rtype: str """
+        return self.__script.stdoutdata
+
+    def stderrdata(self):
+        """ @rtype: str """
+        return self.__script.stderrdata
 
     @classmethod
     def createCReference(cls, c_pointer, parent=None):

--- a/python/res/job_queue/workflow_runner.py
+++ b/python/res/job_queue/workflow_runner.py
@@ -49,6 +49,10 @@ class WorkflowRunner(object):
         """ @rtype: bool or None """
         return self.__workflow_result
 
+    def workflowReport(self):
+        """ @rtype: {dict} """
+        return self.__workflow.getJobsReport()
+
     def workflowError(self):
         """ @rtype: str """
         error = self.__workflow.getLastError()

--- a/python/tests/res/job_queue/test_workflow_job.py
+++ b/python/tests/res/job_queue/test_workflow_job.py
@@ -85,9 +85,23 @@ class WorkflowJobTest(ResTest):
             argTypes = job.argumentTypes()
             self.assertEqual( argTypes , [str , str] )
             self.assertIsNone(job.run(None, ["test", "text"]))
+            self.assertEqual(job.stdoutdata(), "Hello World\n")
 
             with open("test", "r") as f:
                 self.assertEqual(f.read(), "text")
+
+    def test_error_handling_external_job(self):
+
+        with TestAreaContext("python/job_queue/workflow_job") as work_area:
+            WorkflowCommon.createExternalDumpJob()
+
+            config = self._alloc_config()
+            job = self._alloc_from_file("DUMP", config, "dump_failing_job")
+
+            self.assertFalse(job.isInternal())
+            argTypes = job.argumentTypes()
+            self.assertTrue(job.run(None, []).startswith('Traceback'))
+            self.assertTrue(job.stderrdata().startswith('Traceback'))
 
 
     def test_run_internal_script(self):

--- a/python/tests/res/job_queue/test_workflow_job.py
+++ b/python/tests/res/job_queue/test_workflow_job.py
@@ -100,7 +100,7 @@ class WorkflowJobTest(ResTest):
 
             self.assertFalse(job.isInternal())
             argTypes = job.argumentTypes()
-            self.assertTrue(job.run(None, []).startswith('Traceback'))
+            self.assertIsNone(job.run(None, []))
             self.assertTrue(job.stderrdata().startswith('Traceback'))
 
 

--- a/python/tests/res/job_queue/workflow_common.py
+++ b/python/tests/res/job_queue/workflow_common.py
@@ -12,6 +12,9 @@ class WorkflowCommon(object):
             f.write("MAX_ARG 2\n")
             f.write("ARG_TYPE 0 STRING\n")
 
+        with open("dump_failing_job", "w") as f:
+            f.write("INTERNAL FALSE\n")
+            f.write("EXECUTABLE dump_failing.py\n")
 
         with open("dump.py", "w") as f:
             f.write("#!/usr/bin/env python\n")
@@ -19,9 +22,17 @@ class WorkflowCommon(object):
             f.write("f = open('%s' % sys.argv[1], 'w')\n")
             f.write("f.write('%s' % sys.argv[2])\n")
             f.write("f.close()\n")
+            f.write("print(\"Hello World\")")
+
+        with open("dump_failing.py", "w") as f:
+            f.write("#!/usr/bin/env python\n")
+            f.write("print(\"Hello Failing\")\n")
+            f.write("raise Exception")
 
         st = os.stat("dump.py")
         os.chmod("dump.py", st.st_mode | stat.S_IEXEC) # | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        st = os.stat("dump_failing.py")
+        os.chmod("dump_failing.py", st.st_mode | stat.S_IEXEC)
 
         with open("dump_workflow", "w") as f:
             f.write("DUMP dump1 dump_text_1\n")


### PR DESCRIPTION
**Issue**
Continues the work on https://github.com/equinor/ert/issues/194

Does include commits from #520, but I'll rebase and fix everything.. The #520 will probably be merged first anyway.

**Approach**
First off, use `communicate` from `Popen` when using `PIPE` in order to collect and make sure that the program does not deadlock.

A bit unsure how the error should propagate upwards on this one, and who should be responsible for storing the result. I think I made the proper call on where to put it. 

This isn't complete, using `PIPE` also means that the stdout and stderr isn't sent to terminal, I'll fix that before it's merged so this doesn't change current behaviour