### PR TITLE
Use c++ TestArea implementation

### DIFF
--- a/lib/config/tests/config_path_elm.cpp
+++ b/lib/config/tests/config_path_elm.cpp
@@ -33,13 +33,13 @@ int main(int argc , char ** argv) {
   const char * rel_true = "rel/path/XXX";
   const char * path_true1 = "rel/path/XXX";
 
-  test_work_area_type * work_area = test_work_area_alloc( "config_path_elm" );
-  const char * root = test_work_area_get_cwd( work_area );
+  ecl::util::TestArea ta("config_path");
+  const char * root = ta.test_cwd().c_str();
   char * abs_path = util_alloc_filename( root , "rel/path" , NULL);
   char * abs_true = util_alloc_filename( root , "rel/path/XXX" , NULL);
   char * path_true2 = util_alloc_filename( root , "rel/path/XXX" , NULL);
 
-  util_chdir( test_work_area_get_original_cwd( work_area ));
+  util_chdir( ta.original_cwd().c_str() );
   config_root_path_type * root_path = config_root_path_alloc( root );
   {
     config_path_elm_type * path_elm = config_path_elm_alloc( root_path , rel_path );

--- a/lib/enkf/tests/enkf_analysis_config.cpp
+++ b/lib/enkf/tests/enkf_analysis_config.cpp
@@ -21,7 +21,7 @@
 #include <unistd.h>
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/util.h>
 #include <ert/util/rng.h>
 
@@ -46,8 +46,7 @@ void test_create() {
 
 
 void test_min_realizations(const char * num_realizations_str, const char * min_realizations_str, int min_realizations_expected_needed) {
-  test_work_area_type * work_area = test_work_area_alloc("test_min_realizations_string");
-
+  ecl::util::TestArea ta("min_realizations");
   {
     FILE * config_file_stream = util_mkdir_fopen("config_file", "w");
     test_assert_not_NULL(config_file_stream);
@@ -79,8 +78,6 @@ void test_min_realizations(const char * num_realizations_str, const char * min_r
       config_free( c );
     }
   }
-
-  test_work_area_free(work_area);
 }
 
 

--- a/lib/enkf/tests/enkf_config_node_ext_param.cpp
+++ b/lib/enkf/tests/enkf_config_node_ext_param.cpp
@@ -17,7 +17,7 @@
    for more details.
 */
 
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/test_util.h>
 
 #include <ert/enkf/enkf_fs.hpp>
@@ -96,7 +96,7 @@ void test_create_data() {
 }
 
 void test_forward_write() {
-  test_work_area_type * work_area = test_work_area_alloc( "test_json");
+  ecl::util::TestArea ta("test_json");
   enkf_config_node_type * config_node1 = create_config_node( );
   enkf_config_node_type * config_node2 = create_config_node__( "output/file.json");
   enkf_node_type * node1 = enkf_node_alloc( config_node1 );
@@ -111,7 +111,6 @@ void test_forward_write() {
   enkf_node_free( node2 );
   enkf_config_node_free( config_node1 );
   enkf_config_node_free( config_node2 );
-  test_work_area_free( work_area );
 }
 
 
@@ -133,7 +132,7 @@ void test_read_node( enkf_node_type * node ) {
 
 
 void test_fs() {
-  test_work_area_type * work_area = test_work_area_alloc( "test_json");
+  ecl::util::TestArea ta("test_fs");
   enkf_config_node_type * config_node = create_config_node( );
   enkf_node_type * node = enkf_node_alloc( config_node );
   ext_param_type * ext_param = (ext_param_type *) enkf_node_value_ptr( node );
@@ -152,7 +151,6 @@ void test_fs() {
 
   enkf_node_free( node );
   enkf_config_node_free( config_node );
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/enkf/tests/enkf_ert_workflow_list.cpp
+++ b/lib/enkf/tests/enkf_ert_workflow_list.cpp
@@ -21,7 +21,7 @@
 #include <unistd.h>
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/util.h>
 
 #include <ert/enkf/ert_workflow_list.hpp>
@@ -37,7 +37,7 @@ void test_create_workflow_list() {
 
 
 void test_add_alias( const char * job) {
-  test_work_area_type * work_area = test_work_area_alloc( "workflow_list/alias" );
+  ecl::util::TestArea ta("alias");
   ert_workflow_list_type * wf_list = ert_workflow_list_alloc_empty(NULL);
   ert_workflow_list_add_job( wf_list , "JOB" , job );
 
@@ -72,8 +72,6 @@ void test_add_alias( const char * job) {
   test_assert_true( ert_workflow_list_has_workflow( wf_list , "alias"));
   test_assert_true( workflow_is_instance( ert_workflow_list_get_workflow( wf_list , "WF")));
   test_assert_true( workflow_is_instance( ert_workflow_list_get_workflow( wf_list , "alias")));
-
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/enkf/tests/enkf_executable_path.cpp
+++ b/lib/enkf/tests/enkf_executable_path.cpp
@@ -1,14 +1,13 @@
 #include <ert/util/util.h>
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 
 #include <ert/enkf/config_keys.hpp>
 #include <ert/enkf/queue_config.hpp>
 
 int main() {
     util_install_signals();
-
-    test_work_area_type * work_area = test_work_area_alloc("enkf_executable_path");
+    ecl::util::TestArea ta("executable");
     const char * user_config_file = "path.txt";
 
     config_parser_type * parser = config_alloc( );
@@ -21,8 +20,5 @@ int main() {
     fclose(stream);
 
     queue_config_alloc_load( user_config_file );
-
-    test_work_area_free( work_area );
-
     return 0;
 }

--- a/lib/enkf/tests/enkf_forward_init_GEN_KW.cpp
+++ b/lib/enkf/tests/enkf_forward_init_GEN_KW.cpp
@@ -23,7 +23,7 @@
 #include <ert/util/rng.h>
 #include <ert/util/mzran.h>
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/util.h>
 #include <ert/res_util/arg_pack.hpp>
 
@@ -52,8 +52,8 @@ int main(int argc , char ** argv) {
   const char * root_path = argv[1];
   const char * config_file = argv[2];
   const char * forward_init_string = argv[3];
-  test_work_area_type * work_area = test_work_area_alloc(config_file );
-  test_work_area_copy_directory_content( work_area , root_path );
+  ecl::util::TestArea ta("GEN_KW");
+  ta.copy_directory_content(root_path);
   {
     bool forward_init;
     bool strict = true;
@@ -171,6 +171,5 @@ int main(int argc , char ** argv) {
     enkf_main_free( enkf_main );
     res_config_free(res_config);
   }
-  test_work_area_free( work_area );
   rng_free( rng );
 }

--- a/lib/enkf/tests/enkf_forward_init_GEN_PARAM.cpp
+++ b/lib/enkf/tests/enkf_forward_init_GEN_PARAM.cpp
@@ -23,7 +23,7 @@
 #include <ert/util/rng.h>
 #include <ert/util/mzran.h>
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/util.h>
 #include <ert/res_util/arg_pack.hpp>
 #include <ert/res_util/subst_list.hpp>
@@ -53,8 +53,8 @@ int main(int argc , char ** argv) {
   const char * root_path = argv[1];
   const char * config_file = argv[2];
   const char * forward_init_string = argv[3];
-  test_work_area_type * work_area = test_work_area_alloc(config_file );
-  test_work_area_copy_directory_content( work_area , root_path );
+  ecl::util::TestArea ta("main");
+  ta.copy_directory_content(root_path);
   {
     bool forward_init;
     bool strict = true;
@@ -164,7 +164,6 @@ int main(int argc , char ** argv) {
     enkf_main_free( enkf_main );
     res_config_free(res_config);
   }
-  test_work_area_free( work_area );
   rng_free( rng );
 }
 

--- a/lib/enkf/tests/enkf_forward_init_SURFACE.cpp
+++ b/lib/enkf/tests/enkf_forward_init_SURFACE.cpp
@@ -21,7 +21,7 @@
 #include <unistd.h>
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/util.h>
 #include <ert/res_util/arg_pack.hpp>
 #include <ert/util/rng.h>
@@ -44,6 +44,29 @@ void create_runpath(enkf_main_type * enkf_main, int iter  ) {
   ert_run_context_free( run_context );
 }
 
+void install_file( const ecl::util::TestArea& ta, const char * input_src_file ) {
+  if (util_is_abs_path( input_src_file))
+    return;
+  else {
+    std::string src_file = ta.original_path(input_src_file);
+    char * src_path;
+
+    util_alloc_file_components(input_src_file, &src_path, NULL, NULL);
+
+    if (!util_entry_exists( src_path ))
+      util_make_path( src_path );
+
+    if (util_file_exists( src_file.c_str() )) {
+      char * target_file   = util_alloc_filename( ta.test_cwd().c_str(), input_src_file, NULL );
+      util_copy_file( src_file.c_str() , target_file );
+      free( target_file );
+    }
+
+    free(src_path);
+  }
+}
+
+
 
 
 int main(int argc , char ** argv) {
@@ -52,10 +75,10 @@ int main(int argc , char ** argv) {
   const char * config_file = argv[2];
   const char * init_file = argv[3];
   const char * forward_init_string = argv[4];
-  test_work_area_type * work_area = test_work_area_alloc(config_file );
 
-  test_work_area_copy_directory_content( work_area , root_path );
-  test_work_area_install_file( work_area , init_file );
+  ecl::util::TestArea ta("surface");
+  ta.copy_directory_content(root_path);
+  install_file(ta, init_file);
   {
 
     bool forward_init;

--- a/lib/enkf/tests/enkf_forward_init_transform.cpp
+++ b/lib/enkf/tests/enkf_forward_init_transform.cpp
@@ -21,7 +21,7 @@
 #include <unistd.h>
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/util.h>
 #include <ert/res_util/subst_list.hpp>
 
@@ -69,6 +69,31 @@ bool check_original_exported_data_equal(const enkf_node_type * field_node) {
 }
 
 
+void install_file( const ecl::util::TestArea& ta, const char * input_src_file ) {
+  if (util_is_abs_path( input_src_file))
+    return;
+  else {
+    std::string src_file = ta.original_path(input_src_file);
+    char * src_path;
+
+    util_alloc_file_components(input_src_file, &src_path, NULL, NULL);
+
+    if (!util_entry_exists( src_path ))
+      util_make_path( src_path );
+
+    if (util_file_exists( src_file.c_str() )) {
+      char * target_file   = util_alloc_filename( ta.test_cwd().c_str(), input_src_file, NULL );
+      util_copy_file( src_file.c_str() , target_file );
+      free( target_file );
+    }
+
+    free(src_path);
+  }
+}
+
+
+
+
 int main(int argc , char ** argv) {
   enkf_main_install_SIGNALS();
   const char * root_path   = argv[1];
@@ -76,9 +101,9 @@ int main(int argc , char ** argv) {
   const char * init_file   = argv[3];
   const char * forward_init_string = argv[4];
 
-  test_work_area_type * work_area = test_work_area_alloc__(config_file, true);
-  test_work_area_copy_directory_content( work_area , root_path );
-  test_work_area_install_file( work_area , init_file );
+  ecl::util::TestArea ta("init_transform");
+  ta.copy_directory_content(root_path);
+  install_file(ta, init_file);
 
   bool strict = true;
   res_config_type * res_config = res_config_alloc_load(config_file);
@@ -118,6 +143,5 @@ int main(int argc , char ** argv) {
   run_arg_free( run_arg );
   enkf_main_free(enkf_main);
   res_config_free(res_config);
-  test_work_area_free(work_area);
 }
 

--- a/lib/enkf/tests/enkf_forward_load_context.cpp
+++ b/lib/enkf/tests/enkf_forward_load_context.cpp
@@ -17,7 +17,7 @@
 */
 #include <stdlib.h>
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 
 #include <ert/enkf/forward_load_context.hpp>
 #include <ert/enkf/run_arg.hpp>
@@ -74,7 +74,7 @@ void make_restart_mock( const char * path , const char * eclbase , int report_st
 }
 
 void test_load_restart2() {
-  test_work_area_type * work_area = test_work_area_alloc("forward_load");
+  ecl::util::TestArea ta("load_restart");
   {
     subst_list_type * subst_list = subst_list_alloc(NULL);
     run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", NULL , 0 , 0 , "run", "BASE", subst_list);
@@ -94,7 +94,6 @@ void test_load_restart2() {
     run_arg_free( run_arg );
     subst_list_free(subst_list);
   }
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/enkf/tests/enkf_gen_data_config.cpp
+++ b/lib/enkf/tests/enkf_gen_data_config.cpp
@@ -23,7 +23,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/test_util.h>
 #include <ert/enkf/gen_data.hpp>
 #include <ert/enkf/gen_data_config.hpp>
@@ -82,11 +82,11 @@ void test_report_steps_dynamic() {
 
 
 void test_gendata_fload(const char * filename) {
-  test_work_area_type * work_area = test_work_area_alloc( "test_gendata_fload");
+  ecl::util::TestArea ta("gendata_fload");
   gen_data_config_type * config = gen_data_config_alloc_GEN_DATA_result("KEY" , ASCII);
   gen_data_type * gen_data = gen_data_alloc(config);
 
-  const char * cwd = test_work_area_get_cwd(work_area);
+  const char * cwd = ta.original_cwd().c_str();
   enkf_fs_type * write_fs = enkf_fs_create_fs(cwd, BLOCK_FS_DRIVER_ID, NULL , true);
   subst_list_type * subst_list = subst_list_alloc(NULL);
   run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", write_fs, 0,0,"path", "base", subst_list);
@@ -99,7 +99,6 @@ void test_gendata_fload(const char * filename) {
 
   gen_data_free(gen_data);
   gen_data_config_free( config );
-  test_work_area_free(work_area);
   run_arg_free( run_arg );
   subst_list_free(subst_list);
   forward_load_context_free( load_context );
@@ -107,10 +106,10 @@ void test_gendata_fload(const char * filename) {
 
 
 void test_gendata_fload_empty_file(const char * filename) {
-  test_work_area_type * work_area = test_work_area_alloc( "test_gendata_fload_empty_file" );
+  ecl::util::TestArea ta("fload_empty");
   gen_data_config_type * config = gen_data_config_alloc_GEN_DATA_result("KEY" , ASCII);
   gen_data_type * gen_data = gen_data_alloc(config);
-  const char * cwd = test_work_area_get_cwd(work_area);
+  const char * cwd = ta.original_cwd().c_str();
   enkf_fs_type * write_fs = enkf_fs_create_fs(cwd, BLOCK_FS_DRIVER_ID, NULL , true);
   subst_list_type * subst_list = subst_list_alloc(NULL);
   run_arg_type * run_arg = run_arg_alloc_ENSEMBLE_EXPERIMENT("run_id", write_fs, 0,0,"path", "base", subst_list);
@@ -124,7 +123,6 @@ void test_gendata_fload_empty_file(const char * filename) {
 
   gen_data_free(gen_data);
   gen_data_config_free( config );
-  test_work_area_free(work_area);
   run_arg_free( run_arg );
   subst_list_free(subst_list);
   forward_load_context_free( load_context );
@@ -181,7 +179,7 @@ void test_format_check() {
 
 
 void test_set_template_invalid() {
-  test_work_area_type * work_area = test_work_area_alloc("GEN_DATA_SET_TEMPLATE_INVALID");
+  ecl::util::TestArea ta("invalid");
   gen_data_config_type * config = gen_data_config_alloc_GEN_PARAM("KEY" , ASCII , ASCII);
 
   test_assert_false( gen_data_config_set_template( config , "does/not/exist" , NULL ) );
@@ -231,13 +229,12 @@ void test_set_template_invalid() {
   }
 
   gen_data_config_free( config );
-  test_work_area_free( work_area );
 }
 
 
 
 void test_set_template() {
-  test_work_area_type * work_area = test_work_area_alloc("GEN_DATA_SET_TEMPLATE");
+  ecl::util::TestArea ta("set_template");
   {
     gen_data_config_type * config = gen_data_config_alloc_GEN_PARAM("KEY" , ASCII , ASCII);
 
@@ -336,7 +333,6 @@ void test_set_template() {
 
     gen_data_config_free( config );
   }
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/enkf/tests/enkf_gen_data_config_parse.cpp
+++ b/lib/enkf/tests/enkf_gen_data_config_parse.cpp
@@ -23,7 +23,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/test_util.h>
 
 #include <ert/config/config_parser.hpp>
@@ -66,8 +66,7 @@ enkf_config_node_type * parse_alloc_GEN_PARAM( const char * config_string , bool
 
 
 void test_parse_gen_param() {
-  test_work_area_type * work_area = test_work_area_alloc("GEN_PARAM_parse");
-
+  ecl::util::TestArea ta("parse");
   // Parse error: missing eclfile
   {
     enkf_config_node_type * config_node = parse_alloc_GEN_PARAM( "GEN_PARAM KEY\n" , false);
@@ -117,8 +116,6 @@ void test_parse_gen_param() {
 
     enkf_config_node_free( config_node );
   }
-
-  test_work_area_free( work_area );
 }
 
 
@@ -152,7 +149,7 @@ enkf_config_node_type * parse_alloc_GEN_DATA_result( const char * config_string 
 
 
 void test_parse_gen_data_result() {
-  test_work_area_type * work_area = test_work_area_alloc("GEN_DATA_RESULT_parse");
+  ecl::util::TestArea ta("GEN_DATA_RESULT_parse");
   // Parse error: missing KEY
   {
     enkf_config_node_type * config_node = parse_alloc_GEN_DATA_result( "GEN_DATA\n" , false);
@@ -238,8 +235,6 @@ void test_parse_gen_data_result() {
 
     enkf_config_node_free( config_node );
   }
-
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/enkf/tests/enkf_main.cpp
+++ b/lib/enkf/tests/enkf_main.cpp
@@ -21,7 +21,7 @@
 #include <unistd.h>
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/util.h>
 
 #include <ert/enkf/enkf_main.hpp>
@@ -31,8 +31,8 @@
 
 
 void test_case_initialized(const char * config_path, const char * config_file) {
-  test_work_area_type * work_area = test_work_area_alloc("enkf_main_case_initialized");
-  test_work_area_copy_directory_content(work_area, config_path);
+  ecl::util::TestArea ta("case_initialized");
+  ta.copy_directory_content(config_path);
   {
     res_config_type * res_config = res_config_alloc_load(config_file);
     enkf_main_type * enkf_main = enkf_main_alloc(res_config, true, true);
@@ -47,14 +47,13 @@ void test_case_initialized(const char * config_path, const char * config_file) {
     enkf_main_free(enkf_main);
     res_config_free(res_config);
   }
-  test_work_area_free(work_area);
 }
 
 
 
 void test_create(const char * config_path, const char * config_file) {
-  test_work_area_type * work_area = test_work_area_alloc("enkf_main_create");
-  test_work_area_copy_directory_content(work_area, config_path);
+  ecl::util::TestArea ta("create");
+  ta.copy_directory_content(config_path);
 
   res_config_type * res_config = res_config_alloc_load(config_file);
   enkf_main_type * enkf_main = enkf_main_alloc(res_config, true, true);
@@ -62,7 +61,6 @@ void test_create(const char * config_path, const char * config_file) {
 
   enkf_main_free( enkf_main );
   res_config_free(res_config);
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/enkf/tests/enkf_main_fs.cpp
+++ b/lib/enkf/tests/enkf_main_fs.cpp
@@ -35,10 +35,10 @@
 
 int main(int argc, char ** argv) {
   const char * config_file = argv[1];
-  test_work_area_type * work_area = test_work_area_alloc( "enkf_main_fs" );
+  ecl::util::TestArea ta("main");
   char * model_config;
   util_alloc_file_components( config_file , NULL , &model_config , NULL);
-  test_work_area_copy_parent_content( work_area , config_file );
+  ta.copy_parent_content(config_file);
   {
     res_config_type * res_config = res_config_alloc_load(model_config);
     enkf_main_type * enkf_main = enkf_main_alloc(res_config, false, false);
@@ -121,6 +121,5 @@ int main(int argc, char ** argv) {
     enkf_main_free( enkf_main );
     res_config_free(res_config);
   }
-  test_work_area_free( work_area );
   exit(0);
 }

--- a/lib/enkf/tests/enkf_main_fs_current_file_test.cpp
+++ b/lib/enkf/tests/enkf_main_fs_current_file_test.cpp
@@ -22,7 +22,7 @@
 #include <stdbool.h>
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/enkf/enkf_fs.hpp>
 #include <ert/enkf/enkf_main.hpp>
 
@@ -86,16 +86,15 @@ void test_change_case(const char * model_config) {
 
 int main(int argc, char ** argv) {
   const char * config_file = argv[1];
-  test_work_area_type * work_area = test_work_area_alloc__( "enkf_main_fs_current_file_test", true);
+  ecl::util::TestArea ta("current_file");
   char * model_config;
   util_alloc_file_components( config_file , NULL , &model_config , NULL);
-  test_work_area_copy_parent_content( work_area , config_file );
+  ta.copy_parent_content(config_file);
 
   test_current_file_not_present_symlink_present(model_config);
   test_current_file_present(model_config);
   test_change_case(model_config);
 
   free(model_config);
-  test_work_area_free( work_area );
   exit(0);
 }

--- a/lib/enkf/tests/enkf_obs_invalid_path.cpp
+++ b/lib/enkf/tests/enkf_obs_invalid_path.cpp
@@ -18,14 +18,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/test_util.h>
 
 #include <ert/enkf/enkf_obs.hpp>
 
 
 void test_invalid_path() {
-  test_work_area_type * work_area = test_work_area_alloc__("conf", true);
+  ecl::util::TestArea ta("conf");
   util_make_path("obs_path");
   {
     FILE * stream = util_fopen("obs_path/conf.txt","w");
@@ -51,13 +51,11 @@ void test_invalid_path() {
   test_assert_false(conf_instance_validate(enkf_conf));
 
   conf_instance_free(enkf_conf);
-
-  test_work_area_free(work_area);
 }
 
 
 void test_valid_path() {
-  test_work_area_type * work_area = test_work_area_alloc("conf");
+  ecl::util::TestArea ta("valid");
   util_make_path("obs_path");
   {
     FILE * stream = util_fopen("obs_path/conf.txt","w");
@@ -84,7 +82,6 @@ void test_valid_path() {
   test_assert_true(conf_instance_validate(enkf_conf));
 
   conf_instance_free(enkf_conf);
-  test_work_area_free(work_area);
 }
 
 

--- a/lib/enkf/tests/enkf_plot_data_fs.cpp
+++ b/lib/enkf/tests/enkf_plot_data_fs.cpp
@@ -22,7 +22,7 @@
 #include <stdbool.h>
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 
 #include <ert/enkf/enkf_fs.hpp>
 #include <ert/enkf/enkf_main.hpp>
@@ -107,10 +107,10 @@ int main(int argc, char ** argv) {
   util_install_signals();
   {
     const char * config_file = argv[1];
-    test_work_area_type * work_area = test_work_area_alloc__( "enkf_main_fs", true);
+    ecl::util::TestArea ta("plot_fs");
     char * model_config;
     util_alloc_file_components( config_file , NULL , &model_config , NULL);
-    test_work_area_copy_parent_content( work_area , config_file );
+    ta.copy_parent_content(config_file);
     {
       res_config_type * res_config = res_config_alloc_load(model_config);
       enkf_main_type * enkf_main = enkf_main_alloc(res_config, false, false);
@@ -120,7 +120,6 @@ int main(int argc, char ** argv) {
       enkf_main_free( enkf_main );
       res_config_free(res_config);
     }
-    test_work_area_free( work_area );
     exit(0);
   }
 }

--- a/lib/enkf/tests/enkf_queue_config.cpp
+++ b/lib/enkf/tests/enkf_queue_config.cpp
@@ -1,6 +1,6 @@
 #include <ert/util/util.h>
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 
 #include <ert/job_queue/job_queue.hpp>
 #include <ert/job_queue/ext_job.hpp>
@@ -25,7 +25,7 @@ void test_empty() {
 
 
 void test_parse() {
-   test_work_area_type * work_area = test_work_area_alloc("queue_config");
+   ecl::util::TestArea ta("parse");
    const char * user_config_file = "queue_config.txt";
    config_parser_type * parser = config_alloc( );
 
@@ -94,7 +94,6 @@ void test_parse() {
    job_queue_free(job_queue);
    config_content_free(config_content);
    config_free( parser );
-   test_work_area_free( work_area );
 }
 
 

--- a/lib/enkf/tests/enkf_run_arg.cpp
+++ b/lib/enkf/tests/enkf_run_arg.cpp
@@ -39,7 +39,7 @@ void call_set_queue_index( void * arg ) {
 
 
 void test_queue_index() {
-  test_work_area_type * test_area = test_work_area_alloc("run_arg/ENS");
+  ecl::util::TestArea ta("queue_index");
   {
     enkf_fs_type * fs   = enkf_fs_create_fs("sim" , BLOCK_FS_DRIVER_ID , NULL , true);
     subst_list_type * subst_list = subst_list_alloc(NULL);
@@ -60,7 +60,6 @@ void test_queue_index() {
     subst_list_free(subst_list);
     enkf_fs_decref( fs );
   }
-  test_work_area_free( test_area );
 }
 
 void call_get_sim_fs( void * arg ) {
@@ -77,7 +76,7 @@ void call_get_update_target_fs( void * arg ) {
 
 
 void test_SMOOTHER_RUN( ) {
-  test_work_area_type * test_area = test_work_area_alloc("run_arg/SMOOTHER");
+  ecl::util::TestArea ta("smoother");
   {
     enkf_fs_type * sim_fs    = enkf_fs_create_fs("sim" , BLOCK_FS_DRIVER_ID , NULL , true);
     enkf_fs_type * target_fs = enkf_fs_create_fs("target" , BLOCK_FS_DRIVER_ID , NULL , true);
@@ -92,12 +91,11 @@ void test_SMOOTHER_RUN( ) {
     enkf_fs_decref( sim_fs );
     enkf_fs_decref( target_fs );
   }
-  test_work_area_free( test_area );
 }
 
 
 void alloc_invalid_run_arg(void *arg) {
-  test_work_area_type * test_area = test_work_area_alloc("run_arg/invalid");
+  ecl::util::TestArea ta("invalid_run");
   {
     enkf_fs_type * fs    = enkf_fs_create_fs("fs" , BLOCK_FS_DRIVER_ID , NULL , true);
     subst_list_type * subst_list = subst_list_alloc(NULL);
@@ -106,7 +104,6 @@ void alloc_invalid_run_arg(void *arg) {
     subst_list_free(subst_list);
     enkf_fs_decref( fs );
   }
-  test_work_area_free( test_area );
 }
 
 
@@ -116,7 +113,7 @@ void test_invalid_update_on_self( ) {
 
 
 void test_INIT_ONLY( ) {
-  test_work_area_type * test_area = test_work_area_alloc("run_arg/INIT");
+  ecl::util::TestArea ta("INIT");
   {
     enkf_fs_type * init_fs   = enkf_fs_create_fs("sim" , BLOCK_FS_DRIVER_ID , NULL , true);
 
@@ -131,12 +128,11 @@ void test_INIT_ONLY( ) {
 
     enkf_fs_decref( init_fs );
   }
-  test_work_area_free( test_area );
 }
 
 
 void test_ENSEMBLE_EXPERIMENT( ) {
-  test_work_area_type * test_area = test_work_area_alloc("run_arg/ENS");
+  ecl::util::TestArea ta("ens");
   {
     enkf_fs_type * fs   = enkf_fs_create_fs("sim" , BLOCK_FS_DRIVER_ID , NULL , true);
 
@@ -152,7 +148,6 @@ void test_ENSEMBLE_EXPERIMENT( ) {
     subst_list_free(subst_list);
     enkf_fs_decref( fs );
   }
-  test_work_area_free( test_area );
 }
 
 // TODO: Write tests for the new functionality

--- a/lib/enkf/tests/enkf_runpath_list.cpp
+++ b/lib/enkf/tests/enkf_runpath_list.cpp
@@ -23,7 +23,7 @@
 #include <ert/util/test_util.h>
 #include <ert/util/util.h>
 #include <ert/res_util/arg_pack.hpp>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 
 #include <ert/res_util/thread_pool.hpp>
 
@@ -93,7 +93,7 @@ void test_runpath_list() {
     test_assert_int_equal( runpath_list_size( list ) , block_size * threads );
 
     {
-      test_work_area_type * work_area = test_work_area_alloc("enkf_runpath_list" );
+      ecl::util::TestArea ta("runpath_list");
       runpath_list_fprintf( list );
       {
         int file_iens;
@@ -110,7 +110,6 @@ void test_runpath_list() {
         }
         fclose( stream );
       }
-      test_work_area_free( work_area );
     }
   }
   runpath_list_free( list );

--- a/lib/enkf/tests/enkf_site_config.cpp
+++ b/lib/enkf/tests/enkf_site_config.cpp
@@ -25,7 +25,7 @@
 #include <ert/util/test_util.h>
 #include <ert/util/util.h>
 #include <ert/res_util/arg_pack.hpp>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 
 #include <ert/config/config_parser.hpp>
 #include <ert/config/config_content.hpp>
@@ -51,7 +51,7 @@ void test_init(const char * config_file) {
 
 
 void test_job_script() {
-  test_work_area_type * test_area = test_work_area_alloc("site-config");
+  ecl::util::TestArea ta("script");
   {
     site_config_type * site_config = site_config_alloc_load_user_config(NULL);
 
@@ -79,7 +79,6 @@ void test_job_script() {
     }
     site_config_free( site_config );
   }
-  test_work_area_free( test_area );
 }
 
 

--- a/lib/enkf/tests/enkf_state_manual_load_test.cpp
+++ b/lib/enkf/tests/enkf_state_manual_load_test.cpp
@@ -22,7 +22,7 @@
 #include <unistd.h>
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/util.h>
 
 #include <ert/enkf/enkf_main.hpp>
@@ -71,8 +71,8 @@ int main(int argc , char ** argv) {
   const char * root_path   = argv[1];
   const char * config_file = argv[2];
 
-  test_work_area_type * work_area = test_work_area_alloc(config_file);
-  test_work_area_copy_directory_content( work_area , root_path );
+  ecl::util::TestArea ta(config_file);
+  ta.copy_directory_content(root_path);
   {
     bool strict = true;
     res_config_type * res_config = res_config_alloc_load(config_file);
@@ -83,8 +83,6 @@ int main(int argc , char ** argv) {
     enkf_main_free( enkf_main );
     res_config_free(res_config);
   }
-  test_work_area_free(work_area);
-
   exit(0);
 }
 

--- a/lib/enkf/tests/enkf_state_map.cpp
+++ b/lib/enkf/tests/enkf_state_map.cpp
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/test_util.h>
 #include <ert/util/util.h>
 #include <ert/util/bool_vector.h>
@@ -107,7 +107,7 @@ void test_copy() {
 
 
 void test_io( ) {
-  test_work_area_type * work_area = test_work_area_alloc( "enkf-state-map" );
+  ecl::util::TestArea ta("state_map_io");
   {
     state_map_type * state_map = state_map_alloc();
     state_map_type * copy1 , *copy2;
@@ -131,7 +131,6 @@ void test_io( ) {
     test_assert_false(state_map_fread( copy2 , "DoesNotExist"));
     test_assert_int_equal( 0 , state_map_get_size( copy2 ));
   }
-  test_work_area_free( work_area );
 }
 
 
@@ -330,7 +329,7 @@ void test_readonly() {
     state_map_free(map1);
   }
   {
-    test_work_area_type * work_area = test_work_area_alloc("state-map");
+    ecl::util::TestArea ta("ro");
     state_map_type * map1 = state_map_alloc();
 
     state_map_iset(map1 , 5 , STATE_INITIALIZED);
@@ -343,7 +342,6 @@ void test_readonly() {
       test_assert_true(state_map_equal(map1 , map2));
       state_map_free(map2);
     }
-    test_work_area_free( work_area );
     state_map_free(map1);
   }
 }

--- a/lib/enkf/tests/enkf_state_report_step_compatible.cpp
+++ b/lib/enkf/tests/enkf_state_report_step_compatible.cpp
@@ -21,7 +21,7 @@
 #include <unistd.h>
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/util.h>
 
 #include <ert/enkf/enkf_main.hpp>
@@ -66,8 +66,8 @@ int main(int argc , char ** argv) {
 
   test_assert_true( util_sscanf_bool( compatible_str , &check_compatible));
 
-  test_work_area_type * work_area = test_work_area_alloc(config_file );
-  test_work_area_copy_directory_content( work_area , root_path );
+  ecl::util::TestArea ta("compatible");
+  ta.copy_directory_content(root_path);
 
   bool strict = true;
   res_config_type * res_config = res_config_alloc_load(config_file);
@@ -77,5 +77,4 @@ int main(int argc , char ** argv) {
 
   enkf_main_free( enkf_main );
   res_config_free(res_config);
-  test_work_area_free(work_area);
 }

--- a/lib/enkf/tests/enkf_state_skip_summary_load_test.cpp
+++ b/lib/enkf/tests/enkf_state_skip_summary_load_test.cpp
@@ -21,7 +21,7 @@
 #include <unistd.h>
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/util/util.h>
 
 #include <ert/enkf/enkf_main.hpp>
@@ -61,8 +61,8 @@ int main(int argc , char ** argv) {
   const char * root_path      = argv[1];
   const char * config_file    = argv[2];
 
-  test_work_area_type * work_area = test_work_area_alloc(config_file );
-  test_work_area_copy_directory_content( work_area , root_path );
+  ecl::util::TestArea ta("summary_load");
+  ta.copy_directory_content( root_path );
 
   bool strict = true;
   res_config_type * res_config = res_config_alloc_load(config_file);
@@ -72,5 +72,4 @@ int main(int argc , char ** argv) {
 
   enkf_main_free( enkf_main );
   res_config_free(res_config);
-  test_work_area_free(work_area);
 }

--- a/lib/enkf/tests/enkf_time_map.cpp
+++ b/lib/enkf/tests/enkf_time_map.cpp
@@ -140,7 +140,7 @@ void test_refcase( const char * refcase_name , const char * case1, const char * 
 
 
   {
-    test_work_area_type * work_area = test_work_area_alloc( "time_map/attach_short_refcase");
+    ecl::util::TestArea ta("x");
     {
       time_map_type * ecl_map = time_map_alloc(  );
       test_assert_true( time_map_summary_update( ecl_map , refcase ) );
@@ -156,7 +156,6 @@ void test_refcase( const char * refcase_name , const char * case1, const char * 
       test_assert_true( time_map_attach_refcase( ecl_map , refcase ) );
       time_map_free( ecl_map );
     }
-    test_work_area_free( work_area );
   }
 
 
@@ -238,7 +237,7 @@ void test_index_map( const char * case1, const char * case2 , const char * case3
 
 void simple_test() {
   time_map_type * time_map = time_map_alloc(  );
-  test_work_area_type * work_area = test_work_area_alloc("enkf_time_map" );
+  ecl::util::TestArea ta("simple");
   const char * mapfile = "map";
 
   time_map_set_strict( time_map , false );
@@ -267,7 +266,6 @@ void simple_test() {
     time_map_fwrite( time_map , mapfile);
     test_assert_time_t_not_equal( mtime1 , util_file_mtime( mapfile ) );
   }
-  test_work_area_free( work_area );
 }
 
 
@@ -330,7 +328,7 @@ void thread_test() {
 
 
 void test_read_only() {
-  test_work_area_type * work_area = test_work_area_alloc("time-map");
+  ecl::util::TestArea ta("read_only");
   {
     time_map_type * tm = time_map_alloc(  );
 
@@ -368,7 +366,6 @@ void test_read_only() {
     test_assert_int_equal(0 , time_map_get_size( tm ));
     time_map_free( tm );
   }
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/enkf/tests/rng_config.cpp
+++ b/lib/enkf/tests/rng_config.cpp
@@ -17,7 +17,7 @@
 */
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 
 #include <ert/enkf/rng_config.hpp>
 #include <ert/res_util/res_log.hpp>
@@ -53,7 +53,7 @@ static char * alloc_read_random_seed(const char * log_file)
 
 void test_init()
 {
-  test_work_area_type * work_area = test_work_area_alloc("rng_config");
+  ecl::util::TestArea ta("rng_init");
   res_log_init_log(LOG_DEBUG, "log", true);
 
   const char * config_file = "my_rng_config";
@@ -73,7 +73,6 @@ void test_init()
 
   free(logged_random_seed);
   free(rng_config);
-  free(work_area);
 }
 
 static void alloc_reproduced_rng_config(
@@ -83,7 +82,7 @@ static void alloc_reproduced_rng_config(
         rng_manager_type ** orig_rng_man,
         rng_manager_type ** rep_rng_man)
 {
-  test_work_area_type * work_area = test_work_area_alloc("rng_config");
+  ecl::util::TestArea ta("rng_conifg");
   res_log_init_log(LOG_DEBUG, "log", true);
 
   const char * config_file = "my_rng_config";
@@ -105,7 +104,6 @@ static void alloc_reproduced_rng_config(
     *rep_rng_man = rng_config_alloc_rng_manager(*rep_rng_config);
 
   free(logged_random_seed);
-  free(work_area);
 }
 
 void test_reproducibility(const char * random_seed)

--- a/lib/enkf/tests/rng_manager.cpp
+++ b/lib/enkf/tests/rng_manager.cpp
@@ -77,7 +77,7 @@ void test_default( ) {
 
 void test_state( ) {
   rng_manager_type * rng_manager = rng_manager_alloc_default( );
-  test_work_area_type * work_area = test_work_area_alloc( "rng_manager" );
+  ecl::util::TestArea ta("test_rng");
   rng_manager_iget(rng_manager , 100 );
   rng_manager_save_state( rng_manager , "seed.txt");
   test_assert_true( util_file_exists( "seed.txt" ));
@@ -97,12 +97,11 @@ void test_state( ) {
     rng_manager_free( rng_manager2 );
     rng_manager_free( rng_manager1 );
   }
-  test_work_area_free( work_area );
   rng_manager_free( rng_manager );
 }
 
 void test_state_restore( ) {
-  test_work_area_type * work_area = test_work_area_alloc( "rng_manager" );
+  ecl::util::TestArea ta("restore");
   rng_manager_type * rng_manager1 = rng_manager_alloc_default( );
   rng_manager_save_state( rng_manager1 , "seed.txt");
   rng_type * rng1 = rng_manager_alloc_rng( rng_manager1 );
@@ -124,7 +123,6 @@ void test_state_restore( ) {
     rng_free( rng2 );
     rng_manager_free( rng_manager2 );
   }
-  test_work_area_free( work_area );
   rng_manager_free( rng_manager1 );
 }
 

--- a/lib/enkf/tests/value_export.cpp
+++ b/lib/enkf/tests/value_export.cpp
@@ -25,12 +25,12 @@
 #include <ext/json/cJSON.h>
 
 #include <ert/util/test_util.h>
-#include <ert/util/test_work_area.h>
+#include <ert/util/test_work_area.hpp>
 #include <ert/enkf/value_export.hpp>
 
 
 void test_create() {
-  test_work_area_type * work_area = test_work_area_alloc("value_export");
+  ecl::util::TestArea ta("value_export");
   value_export_type * export_value = value_export_alloc( "", "parameters");
 
   test_assert_int_equal( 0 , value_export_size( export_value ));
@@ -45,14 +45,12 @@ void test_create() {
   test_assert_false( util_file_exists( "parameters.json" ));
 
   value_export_free( export_value );
-
-  test_work_area_free( work_area );
 }
 
 
 
 void test_export_json() {
-test_work_area_type * work_area = test_work_area_alloc("value_export");
+  ecl::util::TestArea ta("value_export_json");
   value_export_type * export_value = value_export_alloc( "path", "parameters");
   util_make_path( "path" );
 
@@ -83,13 +81,11 @@ test_work_area_type * work_area = test_work_area_alloc("value_export");
   test_assert_double_equal(compkey1->valuedouble, 100);
 
   value_export_free( export_value );
-  test_work_area_free( work_area );
-
 }
 
 
 void test_export_txt__() {
-  test_work_area_type * work_area = test_work_area_alloc("value_export");
+  ecl::util::TestArea ta("export_txt");
   value_export_type * export_value = value_export_alloc( "", "parameters");
   value_export_append(export_value, "KEY100", "SUBKEY1", 100);
   value_export_append(export_value, "KEY200", "SUBKEY2", 200);
@@ -100,12 +96,11 @@ void test_export_txt__() {
   test_assert_true( util_file_exists( "path/parameters__.txt" ));
   test_assert_true( util_files_equal( "path/parameters__.txt", "path/parameters.txt"));
   value_export_free( export_value );
-  test_work_area_free( work_area );
 }
 
 
 void test_export_txt() {
-  test_work_area_type * work_area = test_work_area_alloc("value_export");
+  ecl::util::TestArea ta("export_txt");
   value_export_type * export_value = value_export_alloc( "path", "parameters");
   util_make_path( "path" );
 
@@ -138,7 +133,6 @@ void test_export_txt() {
   }
 
   value_export_free( export_value );
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/job_queue/tests/ext_job_test.cpp
+++ b/lib/job_queue/tests/ext_job_test.cpp
@@ -94,8 +94,7 @@ void test_angular() {
 
 
 int main( int argc , char ** argv) {
-  test_work_area_type * test_area = test_work_area_alloc("ext_job");
-
+  ecl::util::TestArea ta("joblist");
   {
     FILE * stream = util_fopen("script", "w");
     fprintf(stream, "Dummy script");
@@ -103,6 +102,4 @@ int main( int argc , char ** argv) {
     chmod("script", 0777);
   }
   test_angular();
-
-  test_work_area_free(test_area);
 }

--- a/lib/job_queue/tests/job_lsf_parse_bsub_stdout.cpp
+++ b/lib/job_queue/tests/job_lsf_parse_bsub_stdout.cpp
@@ -71,14 +71,13 @@ void test_parse_fail_abort() {
 
 
 int main(int argc, char ** argv) {
-  test_work_area_type * work_area = test_work_area_alloc( "bsub_parse_stdout");
+  ecl::util::TestArea ta("lsf_parse");
   {
     test_empty_file();
     test_file_does_not_exist( );
     test_OK();
     test_parse_fail_abort();
   }
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/job_queue/tests/job_queue_stress_test.cpp
+++ b/lib/job_queue/tests/job_queue_stress_test.cpp
@@ -278,7 +278,7 @@ int main(int argc , char ** argv) {
   const char * job = util_alloc_abs_path(argv[1]);
   rng_type * rng = rng_alloc( MZRAN , INIT_CLOCK );
   bool user_exit;
-  test_work_area_type * work_area = test_work_area_alloc("job_queue");
+  ecl::util::TestArea ta("stress_test");
   job_type **jobs = alloc_jobs( rng , number_of_jobs , job);
 
   job_queue_type * queue = job_queue_alloc(number_of_jobs, "OK", "STATUS", "ERROR");
@@ -315,6 +315,5 @@ int main(int argc , char ** argv) {
     check_jobs( number_of_jobs , jobs );
 
   queue_driver_free(driver);
-  test_work_area_free(work_area);
   rng_free( rng );
 }

--- a/lib/job_queue/tests/job_queue_timeout_test.cpp
+++ b/lib/job_queue/tests/job_queue_timeout_test.cpp
@@ -139,8 +139,7 @@ int main(int argc, char ** argv) {
   const int running_timeout = 0; // Pretend that the node running the job is dead
   const int sec = 1000*1000;
 
-  test_work_area_type * work_area = test_work_area_alloc__("job_timeout", true);
-
+  ecl::util::TestArea ta("timeout");
   job_type **jobs = alloc_jobs(number_of_jobs, argv[1]);
 
   // By setting max_submit to 0, failing jobs won't be restarted unless the retry callback says so
@@ -177,5 +176,4 @@ int main(int argc, char ** argv) {
   job_queue_free(queue);
   queue_driver_free(driver);
   free_jobs(jobs, number_of_jobs);
-  test_work_area_free(work_area);
 }

--- a/lib/job_queue/tests/job_torque_submit_test.cpp
+++ b/lib/job_queue/tests/job_torque_submit_test.cpp
@@ -74,8 +74,8 @@ void test_submit_failed_qstat(torque_driver_type * driver, const char * cmd) {
   torque_job_type * job = (torque_job_type *) torque_driver_submit_job(driver, cmd, 1, run_path, "TEST-TORQUE-SUBMIT", 0, NULL);
 
   {
-    test_work_area_type * work_area = test_work_area_alloc("torque-failed-qstat");
-    test_work_area_copy_file( work_area , (const char *) torque_driver_get_option( driver , TORQUE_QSTAT_CMD ));
+    ecl::util::TestArea ta("torque");
+    ta.copy_file( (const char *) torque_driver_get_option( driver , TORQUE_QSTAT_CMD ));
     assert_status( driver , job , JOB_QUEUE_RUNNING + JOB_QUEUE_PENDING);
 
     {
@@ -90,7 +90,6 @@ void test_submit_failed_qstat(torque_driver_type * driver, const char * cmd) {
     }
 
     assert_status( driver , job , JOB_QUEUE_STATUS_FAILURE );
-    test_work_area_free( work_area );
   }
 
   torque_driver_free_job(job);

--- a/lib/job_queue/tests/job_torque_test.cpp
+++ b/lib/job_queue/tests/job_torque_test.cpp
@@ -67,7 +67,6 @@ void setoption_setalloptions_optionsset() {
   test_assert_string_equal( (const char *) torque_driver_get_option( driver, TORQUE_NUM_NODES         ), "36");
   test_assert_string_equal( (const char *) torque_driver_get_option( driver, TORQUE_KEEP_QSUB_OUTPUT  ), "0");
 
-  printf("Options OK\n");
   torque_driver_free(driver);
 }
 
@@ -101,7 +100,7 @@ void getoption_nooptionsset_defaultoptionsreturned() {
 }
 
 void create_submit_script_script_according_to_input() {
-  test_work_area_type * work_area = (test_work_area_type *) test_work_area_alloc("job_torque_test" );
+  ecl::util::TestArea ta("submit_script");
   const char * script_filename = "qsub_script.sh";
 
   {
@@ -130,7 +129,6 @@ void create_submit_script_script_according_to_input() {
 
     fclose(file_stream);
   }
-  test_work_area_free( work_area );
 }
 
 
@@ -138,15 +136,12 @@ void create_submit_script_script_according_to_input() {
 void test_parse_invalid( ) {
   test_assert_int_equal( torque_driver_parse_status( "/file/does/not/exist" , NULL) , JOB_QUEUE_STATUS_FAILURE);
   {
-    test_work_area_type * work_area = (test_work_area_type *) test_work_area_alloc("job_torque_test");
+    ecl::util::TestArea ta("submit");
     {
       FILE * stream = util_fopen("qstat.stdout", "w");
       fclose( stream );
     }
     test_assert_int_equal( torque_driver_parse_status( "qstat.stdout" , "a2345") , JOB_QUEUE_STATUS_FAILURE);
-
-
-    test_work_area_free( work_area );
   }
 }
 

--- a/lib/job_queue/tests/job_workflow_test.cpp
+++ b/lib/job_queue/tests/job_workflow_test.cpp
@@ -98,7 +98,7 @@ int main( int argc , char ** argv) {
   const char * exjob_file = "job";
   const char * bin_path = argv[1];
   const char * internal_workflow = argv[2];
-  test_work_area_type * work_area = (test_work_area_type *) test_work_area_alloc( "job_workflow_test" );
+  ecl::util::TestArea ta("workflo_test");
 
   signal(SIGSEGV , util_abort_signal);
   create_exjob( exjob_file , bin_path );
@@ -182,6 +182,5 @@ int main( int argc , char ** argv) {
     test_assert_false( workflow_run( workflow , &read_value , false , NULL) );
     test_assert_int_equal( workflow_get_stack_size( workflow ) , 0 );
   }
-  test_work_area_free( work_area );
   exit(0);
 }

--- a/lib/res_util/tests/ert_util_block_fs.cpp
+++ b/lib/res_util/tests/ert_util_block_fs.cpp
@@ -35,12 +35,11 @@ void violating_fwrite( void * arg ) {
 
 
 void test_readonly( ) {
-  test_work_area_type * work_area = test_work_area_alloc("block_fs/read_only");
+  ecl::util::TestArea ta("readonly");
   block_fs_type * bfs = block_fs_mount( "test.mnt" , 1000 , 10000 , 0.67 , 10 , true , true , false );
   test_assert_true( block_fs_is_readonly( bfs ));
   test_assert_util_abort("block_fs_aquire_wlock" , violating_fwrite , bfs );
   block_fs_close(bfs , true);
-  test_work_area_free( work_area );
 }
 
 
@@ -76,7 +75,7 @@ void createFS1() {
 
 
 void test_lock_conflict() {
-  test_work_area_type * work_area = test_work_area_alloc("block_fs/lock_conflict");
+  ecl::util::TestArea ta("lockfile");
   createFS1();
   while (true) {
     if (util_file_exists("test.lock_0"))
@@ -95,8 +94,6 @@ void test_lock_conflict() {
   while (util_file_exists( "stop")) {
     usleep( 1000 );
   }
-
-  test_work_area_free( work_area );
 }
 
 

--- a/lib/res_util/tests/ert_util_logh.cpp
+++ b/lib/res_util/tests/ert_util_logh.cpp
@@ -28,7 +28,7 @@
 
 
 void test_open() {
-  test_work_area_type * work_area = test_work_area_alloc("util/logh");
+  ecl::util::TestArea ta("test_open");
   {
     log_type * logh = log_open_file( LOG_FILE , LOG_DEBUG);
     test_assert_not_NULL(logh);
@@ -41,13 +41,11 @@ void test_open() {
     test_assert_int_equal( 1 , log_get_msg_count( logh ));
     log_close( logh );
   }
-
-  test_work_area_free( work_area );
 }
 
 
 void test_delete_empty() {
-  test_work_area_type * work_area = test_work_area_alloc("logh_delete_empty");
+  ecl::util::TestArea ta("delete");
   {
     log_type * logh = log_open_file( LOG_FILE , LOG_DEBUG );
     test_assert_not_NULL(logh);
@@ -73,8 +71,6 @@ void test_delete_empty() {
     log_close( logh );
     test_assert_true( util_file_exists( LOG_FILE ));
   }
-
-  test_work_area_free( work_area );
 }
 
 
@@ -82,14 +78,12 @@ void test_delete_empty() {
   Invalid input - return NULL.
 */
 void test_invalid_input() {
-  test_work_area_type * work_area = test_work_area_alloc("logh_invalid_input");
+  ecl::util::TestArea ta("invalic_iinput");
   test_assert_NULL( log_open_file( NULL, LOG_DEBUG));
 
   util_mkdir_p("read_only");
   chmod("read_only", 0500);
   test_assert_NULL( log_open_file( "read_only/log.txt", LOG_DEBUG));
-
-  test_work_area_free(work_area);
 }
 
 
@@ -108,7 +102,7 @@ void test_file_deleted() {
 
 
 void test_stream_open() {
-  test_work_area_type * work_area = test_work_area_alloc("logh_stream_open");
+  ecl::util::TestArea ta("stream_open");
   FILE * stream = util_fopen("log_file.txt", "w");
   {
     log_type * logh = log_open_stream( stream , LOG_DEBUG);
@@ -117,7 +111,6 @@ void test_stream_open() {
   }
   fputs("Can still write to stream \n", stream);
   fclose(stream);
-  test_work_area_free(work_area);
 }
 
 

--- a/lib/res_util/tests/ert_util_subst_list.cpp
+++ b/lib/res_util/tests/ert_util_subst_list.cpp
@@ -33,7 +33,7 @@ void test_create() {
 
 void test_filter_file1() {
   subst_list_type * subst_list = subst_list_alloc( NULL );
-  test_work_area_type * work_area = test_work_area_alloc("subst_list/filter1");
+  ecl::util::TestArea ta("filter_:file");
   {
     FILE * stream = util_fopen("template" , "w");
     fprintf(stream , "<KEY1>\n<KEY2>\n<KEY3>\n<KEY4>\n");
@@ -58,14 +58,13 @@ void test_filter_file1() {
     test_assert_string_equal( s3 , "Value3");
     test_assert_string_equal( s4 , "Value4");
   }
-  test_work_area_free( work_area );
   subst_list_free( subst_list );
 }
 
 
 void test_filter_file2() {
   subst_list_type * subst_list = subst_list_alloc( NULL );
-  test_work_area_type * work_area = test_work_area_alloc("subst_list/filter2");
+  ecl::util::TestArea ta("filetr2");
   {
     FILE * stream = util_fopen("template" , "w");
     fprintf(stream , "MAGIC_PRINT  magic-list.txt  <ERTCASE>  __MAGIC__");
@@ -83,7 +82,6 @@ void test_filter_file2() {
     test_assert_string_equal( target_string , "MAGIC_PRINT  magic-list.txt  default  MagicAllTheWayToWorkFlow");
     free( target_string );
   }
-  test_work_area_free( work_area );
   subst_list_free( subst_list );
 }
 


### PR DESCRIPTION
Similar to:  https://github.com/equinor/libecl/pull/583

Two issues:

1. When creating an `ErtTestContext` from Python the underlying test_area is created independently from Python - this implies that the `ert_test_context`implementation is still based on the C api.
2. The utility function `install_file()` was previously removed from the  `TestArea` implementation; the tests where that was used a copy of the function is inlined.
