### PR TITLE
Create config content in resconfig python constructor

### DIFF
--- a/lib/enkf/res_config.cpp
+++ b/lib/enkf/res_config.cpp
@@ -120,7 +120,7 @@ static void res_config_install_config_key(
 }
 
 
-static config_content_type * res_config_alloc_user_content(
+config_content_type * res_config_alloc_user_content(
                                 const char * user_config_file,
                                 config_parser_type * config_parser) {
 

--- a/lib/include/ert/enkf/res_config.hpp
+++ b/lib/include/ert/enkf/res_config.hpp
@@ -62,6 +62,8 @@ typedef struct res_config_struct res_config_type;
   void              res_config_free(res_config_type *);
   void              res_config_add_config_items(config_parser_type * config_parser);
 
+config_content_type * res_config_alloc_user_content(const char * user_config_file,
+                                                    config_parser_type * config_parser);
 const site_config_type       * res_config_get_site_config(const res_config_type *);
 rng_config_type              * res_config_get_rng_config(const res_config_type *);
 const analysis_config_type   * res_config_get_analysis_config(const res_config_type *);

--- a/python/res/enkf/res_config.py
+++ b/python/res/enkf/res_config.py
@@ -82,6 +82,8 @@ class ResConfig(BaseCClass):
         else:
             raise ValueError("No config provided")
 
+        if self.errors and throw_on_error:
+            raise ValueError("Error loading configuration")
 
 
         config_dir = config_content.getValue(ConfigKeys.CONFIG_DIRECTORY)
@@ -131,10 +133,10 @@ class ResConfig(BaseCClass):
 
         c_ptr = None
 
-        if not self.errors or not throw_on_error:
-            for conf in configs:
-                conf.convertToCReference(None)
-            c_ptr = self._alloc_full(config_dir, user_config_file, *configs)
+
+        for conf in configs:
+            conf.convertToCReference(None)
+        c_ptr = self._alloc_full(config_dir, user_config_file, *configs)
 
 
         if c_ptr:

--- a/python/tests/res/enkf/test_enkf.py
+++ b/python/tests/res/enkf/test_enkf.py
@@ -76,7 +76,8 @@ class EnKFTest(ResTest):
 
     def test_site_bootstrap( self ):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
-            EnKFMain(None)
+            with  self.assertRaises(ValueError):
+                EnKFMain(None)
 
     def test_default_res_config(self):
         with TestAreaContext("enkf_test", store_area=True) as work_area:


### PR DESCRIPTION
Initially fetch out ConfigContent into python in order to pass them to the child-configs of ResConfig

resolves #531 