### PR TITLE
Create rng_config from python dict

### DIFF
--- a/lib/enkf/rng_config.cpp
+++ b/lib/enkf/rng_config.cpp
@@ -125,6 +125,16 @@ rng_config_type * rng_config_alloc(const config_content_type * config_content) {
 
   return rng_config;
 }
+rng_config_type * rng_config_alloc_full(const char * random_seed, const char * store_seed, const char * load_seed) {
+  rng_config_type * rng_config = rng_config_alloc_default();
+
+  rng_config->random_seed = util_realloc_string_copy(rng_config->random_seed, random_seed);
+  rng_config->seed_store_file = util_realloc_string_copy(rng_config->seed_store_file, store_seed);
+  rng_config->seed_load_file = util_realloc_string_copy(rng_config->seed_load_file, load_seed);
+
+  return rng_config;
+}
+
 
 void rng_config_free( rng_config_type * rng) {
   free( rng->seed_load_file );

--- a/lib/include/ert/enkf/rng_config.hpp
+++ b/lib/include/ert/enkf/rng_config.hpp
@@ -41,6 +41,7 @@ typedef struct rng_config_struct rng_config_type;
   void               rng_config_set_seed_store_file( rng_config_type * rng_config , const char * seed_store_file);
   rng_config_type  * rng_config_alloc_load_user_config(const char * user_config_file);
   rng_config_type  * rng_config_alloc(const config_content_type * config_content);
+  rng_config_type  * rng_config_alloc_full(const char * random_seed, const char * store_seed, const char * load_seed);
   void               rng_config_free( rng_config_type * rng);
   void               rng_config_add_config_items( config_parser_type * config );
   rng_manager_type * rng_config_alloc_rng_manager( const rng_config_type * rng_config );

--- a/python/res/enkf/rng_config.py
+++ b/python/res/enkf/rng_config.py
@@ -20,19 +20,39 @@ from cwrap import BaseCClass
 from ecl.util.enums import RngAlgTypeEnum
 
 from res import ResPrototype
+from res.enkf import ConfigKeys
 
 class RNGConfig(BaseCClass):
 
     TYPE_NAME = "rng_config"
     _alloc        = ResPrototype("void* rng_config_alloc(config_content)", bind=False)
+    _alloc_full   = ResPrototype("void* rng_config_alloc_full(char*, char*, char*)", bind=False)
     _free         = ResPrototype("void rng_config_free(rng_config)")
     _rng_alg_type = ResPrototype("rng_alg_type_enum rng_config_get_type(rng_config)")
     _load_file    = ResPrototype("char* rng_config_get_seed_load_file(rng_config)")
     _store_file   = ResPrototype("char* rng_config_get_seed_store_file(rng_config)")
     _random_seed  = ResPrototype("char* rng_config_get_random_seed(rng_config)")
 
-    def __init__(self, config_content):
-        c_ptr = self._alloc(config_content)
+    def __init__(self, config_content=None, config_dict=None):
+        if config_content and config_dict:
+            raise ValueError('RNGConfig can not be instantiated with both config types')
+
+        if not (config_content or config_dict):
+            raise ValueError('RNGConfig can not be instantiated without any config objects')
+
+        if config_content:
+            c_ptr = self._alloc(config_content)
+
+        elif config_dict:
+
+            random_seed = config_dict.get(ConfigKeys.RANDOM_SEED)
+            store_seed = config_dict.get(ConfigKeys.STORE_SEED) if random_seed is None else None
+            load_seed = config_dict.get(ConfigKeys.LOAD_SEED) if random_seed is None else None
+
+            if store_seed or load_seed:
+                print("STORE_SEED/LOAD_SEED has been deprecated. Please use RANDOM_SEED instead!")
+
+            c_ptr = self._alloc_full(random_seed, store_seed, load_seed)
 
         if c_ptr is None:
             raise ValueError('Failed to construct RNGConfig instance')
@@ -57,3 +77,19 @@ class RNGConfig(BaseCClass):
 
     def free(self):
         self._free()
+
+    def __eq__(self, other):
+
+        if self.random_seed != other.random_seed:
+            return False
+
+        if self.load_filename != other.load_filename:
+            return False
+
+        if self.store_filename != other.store_filename:
+            return False
+
+        if self.alg_type != other.alg_type:
+            return False
+
+        return True

--- a/python/tests/res/enkf/test_rng_config.py
+++ b/python/tests/res/enkf/test_rng_config.py
@@ -67,6 +67,36 @@ class RNGConfigTest(ResTest):
 
             self.assertIsNone(res_config.rng_config.random_seed)
 
+    def test_dict_constructor(self):
+        config = self.create_base_config()
+
+        seed_store = "../input/rng/SEED_STORE"
+        seed_load = "../input/rng/SEED"
+        config["SIMULATION"]["SEED"] = {ConfigKeys.STORE_SEED: seed_store,
+                                        ConfigKeys.LOAD_SEED: seed_load}
+        case_directory = self.createTestPath("local/simple_config")
+        with TestAreaContext("rng_config") as work_area:
+            work_area.copy_directory(case_directory)
+            rng_config = RNGConfig(config_dict=config["SIMULATION"]["SEED"])
+            res_config = ResConfig(config=config)
+            self.assertEqual(rng_config, res_config.rng_config)
+
+            random_seed = "abcdefghijklmnop"
+            config["SIMULATION"]["SEED"] = {ConfigKeys.RANDOM_SEED: random_seed}
+
+            rng_config = RNGConfig(config_dict=config["SIMULATION"]["SEED"])
+            res_config = ResConfig(config=config)
+            self.assertEqual(rng_config, res_config.rng_config)
+
+            #seed store and seed load should be ignored by both constructors
+            config["SIMULATION"]["SEED"] = {ConfigKeys.RANDOM_SEED: random_seed,
+                                        ConfigKeys.STORE_SEED: seed_store,
+                                        ConfigKeys.LOAD_SEED: seed_load
+                                        }
+
+            rng_config = RNGConfig(config_dict=config["SIMULATION"]["SEED"])
+            res_config = ResConfig(config=config)
+            self.assertEqual(rng_config, res_config.rng_config)
 
     def test_random_seed(self):
         config = self.create_base_config()


### PR DESCRIPTION
Creates an rng_config from a python object and feeds the config values directly to the C object

Resolves #535 
Resolves #533 
