### PR TITLE
Updated the documentation in the eclxxx_config.yml files

### DIFF
--- a/python/res/fm/ecl/ecl100_config.yml
+++ b/python/res/fm/ecl/ecl100_config.yml
@@ -2,31 +2,22 @@
 #     class which essentially internalizes this file and the EclRun class
 #     which uses the EclConfig class.
 #
-# The information about an eclipse installation at a particular site is
-# stored in one such configuration file. The file has only one required
-# top level element: 'simulators' which describe the various simulators
-# which are installed. In additon you can optionally have a top level
-# element 'env' which is a dictionary representing environment variables
-# which should be set before the simulator starts.
-
-# The 'simulators' setting is a dictionary where the keys are the available
-# simulators. In the example below we have the simulators 'ecl100' and 'flow'.
-# Observe that the names 'flow' and 'ecl100' will be used as keys in the EclRun
-# class, i.e. these are *not* arbitrary strings.
+# The information about eclipse versions installed at a particular site is
+# assembled in configuration files like this one, there are separate files for
+# ecl100, ecl300 and opm/flow. The file has only one required top level element:
+# 'versions' - which describe the versions which are installed. In
+# additon you can optionally have a top level element 'env' which is a
+# dictionary representing environment variables which should be set before the
+# simulator starts.
 #
-# Each simulator can be installed in multiple versions, in the example below the
-# ecl100 simulator is installed in versions '2015.2' and '2017.2' whereas flow
-# is only installed in version '2018.04'. These version strings will be passed
-# as argv[1] when instantiating a EclRun instance.
-#
-# Finally each version of the programs can exist as a scalar single process
+# In the example below the ecl100 simulator is installed in versions '2015.2'
+# and '2017.2'. Each version of the program can exist as a scalar single process
 # application and a parallell MPI application. When we have drilled all the way
-# down through simulators['ecl100']['2105.2']['scalar'] the only required
+# down through versions['2105.2']['scalar'] the only required
 # attribute is 'executable' which is the full path to the executable program. In
 # addition you can add an env: setting which will be a dictionary of environment
 # variables which will be set before the simulator is invoked. The 2015.2 mpi
-# version of ecl100 and the 2018.04 scalar version of flow have examples of
-# shuch env settings.
+# version has an example of such a settings.
 #
 # If it is an MPI simulation you must in addition to the executable attribute
 # also set an 'mpirun' attribute.

--- a/python/res/fm/ecl/ecl300_config.yml
+++ b/python/res/fm/ecl/ecl300_config.yml
@@ -1,35 +1,5 @@
-# NB: There are inter related dependencies between this file, the EclConfig
-#     class which essentially internalizes this file and the EclRun class
-#     which uses the EclConfig class.
-#
-# The information about an eclipse installation at a particular site is
-# stored in one such configuration file. The file has only one required
-# top level element: 'simulators' which describe the various simulators
-# which are installed. In additon you can optionally have a top level
-# element 'env' which is a dictionary representing environment variables
-# which should be set before the simulator starts.
-
-# The 'simulators' setting is a dictionary where the keys are the available
-# simulators. In the example below we have the simulators 'ecl100' and 'flow'.
-# Observe that the names 'flow' and 'ecl100' will be used as keys in the EclRun
-# class, i.e. these are *not* arbitrary strings.
-#
-# Each simulator can be installed in multiple versions, in the example below the
-# ecl100 simulator is installed in versions '2015.2' and '2017.2' whereas flow
-# is only installed in version '2018.04'. These version strings will be passed
-# as argv[1] when instantiating a EclRun instance.
-#
-# Finally each version of the programs can exist as a scalar single process
-# application and a parallell MPI application. When we have drilled all the way
-# down through simulators['ecl100']['2105.2']['scalar'] the only required
-# attribute is 'executable' which is the full path to the executable program. In
-# addition you can add an env: setting which will be a dictionary of environment
-# variables which will be set before the simulator is invoked. The 2015.2 mpi
-# version of ecl100 and the 2018.04 scalar version of flow have examples of
-# shuch env settings.
-#
-# If it is an MPI simulation you must in addition to the executable attribute
-# also set an 'mpirun' attribute.
+# This is an example configuration file for the local ecl300 installation, see
+# the ecl100_config.yml file for more extensive dcoujmentation.
 
 versions:
   '2015.2':  # without quotes this will be interpreted as a number
@@ -50,11 +20,6 @@ versions:
       executable: /path/ecl/2017.2/linux/x86_64/bin/eclipse300_mpi
       mpirun: /path/ecl/2017.2/intel/bin/mpirun
 
-
-# You can have a shared 'env' attribute which is an environment variable map
-# which will be set before the simulator starts. If there are env settings in
-# the simulator as well they will be merged with these common settings, the
-# simulator specific take presedence.
 
 env:
   LM_LICENSE_FILE: license@company.com

--- a/python/res/fm/ecl/flow_config.yml.in
+++ b/python/res/fm/ecl/flow_config.yml.in
@@ -1,4 +1,4 @@
-# See the ecl_config.yml for more documentation of this file.
+# See the ecl100_config.yml for more documentation of this file.
 
 default_version: '@FLOW_VERSION@'
 

--- a/python/res/fm/ecl/flow_config_mpi.yml.in
+++ b/python/res/fm/ecl/flow_config_mpi.yml.in
@@ -1,4 +1,4 @@
-# See the ecl_config.yml for more documentation of this file.
+# See the ecl100_config.yml for more documentation of this file.
 
 default_version: '@FLOW_VERSION@'
 


### PR DESCRIPTION
Initially all three simulators ecl100, ecl300 and flow were configured in the same configuration file `ecl_config.yml` - but as part of https://github.com/equinor/libres/pull/477 the configuration was split across three files. The documentation has not been updated to reflect this.