### PR TITLE
Facilitate extra options res forward models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-
+dist: xenial
 python:
   - 2.7
   - 3.6

--- a/share/ert/forward-models/res/ECLIPSE100
+++ b/share/ert/forward-models/res/ECLIPSE100
@@ -1,4 +1,5 @@
 EXECUTABLE script/ecl100
 DEFAULT <VERSION> version
 DEFAULT <NUM_CPU> 1
-ARGLIST <ECLBASE> "--version=<VERSION>" "--num-cpu=<NUM_CPU>" "--ignore-errors"
+DEFAULT <OPTS> ""
+ARGLIST <ECLBASE> "--version=<VERSION>" "--num-cpu=<NUM_CPU>" <OPTS>

--- a/share/ert/forward-models/res/ECLIPSE300
+++ b/share/ert/forward-models/res/ECLIPSE300
@@ -1,4 +1,5 @@
 EXECUTABLE script/ecl300
 DEFAULT <VERSION> version
 DEFAULT <NUM_CPU> 1
-ARGLIST <ECLBASE> "--version=<VERSION>" "--num-cpu=<NUM_CPU>" "--ignore-errors"
+DEFAULT <OPTS> ""
+ARGLIST <ECLBASE> "--version=<VERSION>" "--num-cpu=<NUM_CPU>" <OPTS>

--- a/share/ert/forward-models/res/FLOW
+++ b/share/ert/forward-models/res/FLOW
@@ -1,4 +1,5 @@
 EXECUTABLE script/flow
 DEFAULT <VERSION> default
 DEFAULT <NUM_CPU> 1
-ARGLIST <ECLBASE> "--version=<VERSION>" "--num-cpu=<NUM_CPU>"
+DEFAULT <OPTS> ""
+ARGLIST <ECLBASE> "--version=<VERSION>" "--num-cpu=<NUM_CPU>" <OPTS>

--- a/share/ert/forward-models/res/script/ecl100
+++ b/share/ert/forward-models/res/script/ecl100
@@ -3,4 +3,4 @@ import sys
 from res.fm.ecl import run, Ecl100Config
 
 config = Ecl100Config()
-run(config, sys.argv[1:])
+run(config, [arg for arg in sys.argv[1:] if len(arg) > 0])

--- a/share/ert/forward-models/res/script/ecl300
+++ b/share/ert/forward-models/res/script/ecl300
@@ -3,4 +3,4 @@ import sys
 from res.fm.ecl import run, Ecl300Config
 
 config = Ecl300Config()
-run(config, sys.argv[1:])
+run(config, [arg for arg in sys.argv[1:] if len(arg) > 0])

--- a/share/ert/forward-models/res/script/flow
+++ b/share/ert/forward-models/res/script/flow
@@ -3,4 +3,4 @@ import sys
 from res.fm.ecl import run, FlowConfig
 
 config = FlowConfig()
-run(config, sys.argv[1:])
+run(config, [arg for arg in sys.argv[1:] if len(arg) > 0])


### PR DESCRIPTION
Make it possible for the user to include additional arguments for the
forward models defined in share/ert/res. This is specifically ment for
the user to include --ignore-errors, the only argument not already
handled.

The empty default argument is further stripped when running each script.
This will be handled differently when the forward model descriptive
files are rewritten.
