### PR TITLE
Fix crash in test ert_util_matrix_lapack and remove memory leaks

### DIFF
--- a/lib/res_util/matrix_lapack.cpp
+++ b/lib/res_util/matrix_lapack.cpp
@@ -236,6 +236,7 @@ void matrix_dgesvx(matrix_type * A , matrix_type * B, double * rcond) {
     free(ferr);
     free(berr);
     free(ipivot);
+    free(iwork);
   }
 }
 

--- a/lib/res_util/tests/ert_util_matrix_lapack.cpp
+++ b/lib/res_util/tests/ert_util_matrix_lapack.cpp
@@ -117,7 +117,7 @@ void test_dgesvx() {
 
 
      matrix_sub(b3,b2,b1);
-     matrix_pretty_fprint_submat(b3,"b3","%.*f ",stdout,0,2,0,4) ;
+     matrix_pretty_fprint_submat(b3,"b3","%.6f ",stdout,0,2,0,4) ;
 
      test_assert_true( matrix_similar( b1 , b2 , epsilon ) );
 
@@ -127,6 +127,7 @@ void test_dgesvx() {
   matrix_free( m2 );
   matrix_free( b1 );
   matrix_free( b2 );
+  matrix_free( b3 );
   rng_free( rng );
 }
 
@@ -147,6 +148,9 @@ void test_matrix_similar() {
   matrix_iadd(m2,2,2,epsilon);
   test_assert_true( !matrix_similar( m1 , m2, epsilon));
 
+  matrix_free(m2);
+  matrix_free(m1);
+  rng_free(rng);
 }
 
 


### PR DESCRIPTION
An invalid use of fprintf caused fprintf to sometimes use up all memory
on the system, then crash, and sometimes flood stdout with characters.

The large memory usage happened 80 percent of the time when running a
Debug build. The flooding of characters happened consistently when
running through valgrind. When actually debugging no errors would occur,
making the bug hard to track down.

Fixed by editing format string. The formatting string used a * to
specify that the number of decimal points should be given in a separate
argument, which was not given. It seemed to work most of the time,
except for certain double values (e.g. 0.0).  Fixed it by specifying a
fixed number of decimal points.

Also fixes some memory leaks in both the test and library code.
