### PR TITLE
WIP: Remove outdated version of Eclipse/Flow jobs

### DIFF
--- a/share/ert/forward-models/res/eclipse100
+++ b/share/ert/forward-models/res/eclipse100
@@ -1,1 +1,0 @@
-EXECUTABLE script/ecl100

--- a/share/ert/forward-models/res/eclipse300
+++ b/share/ert/forward-models/res/eclipse300
@@ -1,1 +1,0 @@
-EXECUTABLE script/ecl300

--- a/share/ert/forward-models/res/flow
+++ b/share/ert/forward-models/res/flow
@@ -1,1 +1,0 @@
-EXECUTABLE script/flow


### PR DESCRIPTION
In `share/ert/forward-models/res` there are 2 versions of the jobs `eclipse100` `eclipse300` and `flow`: a version with the name all lowercase, another version with the name all uppercase
The two versions are similar but not identical, the uppercase version seems to be more up-to-date, so we remove the lowecase version.

@joakim-hove @markusdregi you guys might offer some insight on this. We tried digging in the git log but could not figure out why there are 2 versions of these jobs. If there is actually a good reason to keep them both, please let us know (FYI, they make a pretty bad mess of OSs that do not distinguish between uppercase and lowercase) 