### PR TITLE
Exit signal condition

### DIFF
--- a/etc-example/ERT/Scripts/job_dispatch.py
+++ b/etc-example/ERT/Scripts/job_dispatch.py
@@ -255,6 +255,8 @@ if len(sys.argv) == 2:
         fileH.write("%-32s: %02d:%02d:%02d .... " % (job["name"] , now.tm_hour , now.tm_min , now.tm_sec))
         fileH.close()
         (OK , exit_status, error_msg) = run_one(job)
+        if os.WIFEXITED(exit_status):
+            exit_status = os.WEXITSTATUS(exit_status)
         now = time.localtime()
         if OK:
             fileH = open(STATUS_file , "a")

--- a/python/res/fm/ecl/ecl_run.py
+++ b/python/res/fm/ecl/ecl_run.py
@@ -218,7 +218,8 @@ class EclRun(object):
                 if return_pid == 0:
                     time.sleep( 1 )
                 else:
-                    exit_status = os.WEXITSTATUS( exit_status )
+                    if os.WIFEXITED(exit_status):
+                        exit_status = os.WEXITSTATUS( exit_status )
                     break
 
             OK_file = os.path.join(self.run_path , "%s.OK" % self.base_name)

--- a/python/res/fm/rms/rms_run.py
+++ b/python/res/fm/rms/rms_run.py
@@ -115,10 +115,12 @@ class RMSRun(object):
 
     def wait(self, child_pid):
         _, wait_status = os.waitpid(child_pid, 0)
-        exit_status = os.WEXITSTATUS(wait_status)
 
-        if exit_status != 0:
-            raise Exception("The RMS run failed with exit status: {}".format(exit_status))
+        if os.WIFEXITED(wait_status):
+            wait_status = os.WEXITSTATUS(wait_status)
+
+        if wait_status != 0:
+            raise Exception("The RMS run failed with exit status: {}".format(wait_status))
 
         if self.target_file is None:
             return

--- a/python/res/job_queue/job_manager.py
+++ b/python/res/job_queue/job_manager.py
@@ -522,7 +522,8 @@ class JobManager(object):
             # both the exit status of the external application,
             # and in case the job was killed by a signal - the
             # number of that signal.
-            exit_status = os.WEXITSTATUS(exit_status)
+            if os.WIFEXITED(exit_status):
+                exit_status = os.WEXITSTATUS(exit_status)
 
         status.end_time = dt.now()
 

--- a/python/tests/res/job_queue/test_jobmanager.py
+++ b/python/tests/res/job_queue/test_jobmanager.py
@@ -355,7 +355,7 @@ class JobManagerTest(TestCase):
 
             for (index,job) in enumerate(jobm):
                 exit_status, msg = jobm.runJob(job)
-                self.assertEqual(exit_status, 1)
+                self.assertEqual(1, exit_status)
                 self.assertTrue(os.path.getsize("mkdir_err.%d" % index) > 0)
 
 

--- a/python/tests/res/job_queue/test_jobmanager.py
+++ b/python/tests/res/job_queue/test_jobmanager.py
@@ -527,9 +527,9 @@ assert exec_env["NOT_SET"] is None
                         'jobm = JobManager()',
                         'for job in jobm:',
                         '    exit_status, msg = jobm.runJob(job)',
-                        'if exit_status != {}:'.format(exit_signal),
-                        '   msg = "Expected exit code {}, received {{}}".format(exit_status)'.format(exit_signal),
-                        '   raise AssertionError(msg)',
+                        '    if exit_status != {}:'.format(exit_signal),
+                        '       msg = "Expected exit code {}, received {{}}".format(exit_status)'.format(exit_signal),
+                        '       raise AssertionError(msg)',
                     )))
                 st = os.stat(run_script_name)
                 os.chmod(run_script_name, st.st_mode | stat.S_IEXEC)


### PR DESCRIPTION
**Issue**
Misusage of `WEXITSTATUS`. From documentation:
```
If WIFEXITED(status) is true, return the integer parameter to the exit(2) system call. Otherwise, the return value is meaningless.
```

**Approach**
Use `WIFEXITED` as a condition to apply `WEXITSTATUS`
