### PR TITLE
Imp deprication

### DIFF
--- a/python/res/job_queue/job_manager.py
+++ b/python/res/job_queue/job_manager.py
@@ -26,7 +26,6 @@ import socket
 import pwd
 import requests
 import json
-import imp
 from ecl import EclVersion
 from res import ResVersion
 from res.job_queue import ForwardModelStatus, ForwardModelJobStatus


### PR DESCRIPTION
**Issue**
Resolves #640


**Approach**
Dynamically import the relevant module based on the current python version. I am normally not very happy about imports that does not happen at the top of the file, however; in this case I think it is an ok solution. 
