### PR TITLE
Add Jenkinsfile-komodo and testkomodo.sh

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -306,7 +306,7 @@ foreach(name ies_enkf_config ies_enkf_data)
 endforeach()
 add_executable( ies_module analysis/modules/tests/ies_enkf_module.cpp)
 target_link_libraries(ies_module res)
-add_test(NAME ies_module COMMAND ies_module $<TARGET_FILE:ies> ${CMAKE_CURRENT_SOURCE_DIR}/analysis/modules/tests/test-data/poly)
+add_test(NAME ies_module COMMAND ies_module $<TARGET_FILE_NAME:ies> ${CMAKE_CURRENT_SOURCE_DIR}/analysis/modules/tests/test-data/poly)
 
 add_executable(ies_linalg analysis/modules/tests/ies_linalg.cpp ${ies_source})
 target_include_directories(ies_linalg PRIVATE analysis/modules)
@@ -428,7 +428,7 @@ target_link_libraries(analysis_external_module res)
 add_test(NAME analysis_module_rml
          COMMAND analysis_external_module
                  "RML_ENKF"
-                 $<TARGET_FILE:rml_enkf> 41
+                 $<TARGET_FILE_NAME:rml_enkf> 41
                  ITER:45
                  USE_PRIOR:False
                  LAMBDA_REDUCE:0.10

--- a/testkomodo.sh
+++ b/testkomodo.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+GIT=/prog/sdpsoft/bin/git
+
+source /opt/rh/devtoolset-8/enable
+GCC_VERSION=7.3.0 CMAKE_VERSION=3.10.2 source /prog/sdpsoft/env.sh
+set -e
+
+echo "building c tests"
+rm -rf build
+mkdir build
+pushd build
+cmake .. -DBUILD_TESTS=ON\
+-DENABLE_PYTHON=OFF\
+-DBUILD_APPLICATIONS=ON\
+-DCMAKE_INSTALL_PREFIX=install\
+-DCMAKE_PREFIX_PATH=/project/res/komodo/bleeding/root/\
+-DCMAKE_C_FLAGS='-Werror=all'\
+-DCMAKE_CXX_FLAGS='-Wno-unused-result'
+make -j 12
+#removing built libs in order to ensure we are using libs from komodo
+rm -r lib64
+
+echo "running ctest"
+ctest --output-on-failure
+
+popd
+
+echo "running pytest"
+#run in a new folder so that we dont load the other python code from the source, but rather run against komodo
+rm -rf tmptest
+mkdir tmptest
+cp -r python/tests tmptest/tests
+pushd tmptest
+python -m pytest
+
+popd
+


### PR DESCRIPTION
Also fix c tests library names to enable running against komodo.

Partial solution to #387

Reviewer:
Can't really know if this works until after it is merged, so look and see if makes a little sense.
After merge, there will still be some python tests failing, but c tests should pass for bleeding at least.
New issues should be made for each failing test.
Only bleeding will work at first, and then as we deploy other releases, they will also start working.
After merge can be tested with jenkins job libres-komodo
