### PR TITLE
Add testkomodo.sh

### DIFF
--- a/Jenkinsfile-komodo
+++ b/Jenkinsfile-komodo
@@ -1,0 +1,17 @@
+pipeline {
+    agent { label 'si-build' }
+    stages {
+        stage('checkout komodo tag') {
+            steps {
+                sh 'sh checkout_komodo_tag.sh'
+            }
+        }
+	stage('run tests') {
+            steps {
+                sh 'sh testkomodo.sh'
+            }
+        }
+    }
+}
+
+

--- a/checkout_komodo_tag.sh
+++ b/checkout_komodo_tag.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+source /project/res/komodo/$KOMODO_VERSION/enable
+
+GIT=/prog/sdpsoft/bin/git
+
+# find and check out the code that was used to build libres for this komodo relase
+echo "checkout tag from komodo"
+EV=$(cat /project/res/komodo/$KOMODO_VERSION/$KOMODO_RELEASE | grep "libres:" -A2 | grep "version:")
+EV=($EV)    # split the string "version: vX.X.X"
+EV=${EV[1]} # extract the version
+echo "Using libres version $EV"
+$GIT checkout $EV

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -306,7 +306,7 @@ foreach(name ies_enkf_config ies_enkf_data)
 endforeach()
 add_executable( ies_module analysis/modules/tests/ies_enkf_module.cpp)
 target_link_libraries(ies_module res)
-add_test(NAME ies_module COMMAND ies_module $<TARGET_FILE:ies> ${CMAKE_CURRENT_SOURCE_DIR}/analysis/modules/tests/test-data/poly)
+add_test(NAME ies_module COMMAND ies_module $<TARGET_FILE_NAME:ies> ${CMAKE_CURRENT_SOURCE_DIR}/analysis/modules/tests/test-data/poly)
 
 add_executable(ies_linalg analysis/modules/tests/ies_linalg.cpp ${ies_source})
 target_include_directories(ies_linalg PRIVATE analysis/modules)
@@ -428,7 +428,7 @@ target_link_libraries(analysis_external_module res)
 add_test(NAME analysis_module_rml
          COMMAND analysis_external_module
                  "RML_ENKF"
-                 $<TARGET_FILE:rml_enkf> 41
+                 $<TARGET_FILE_NAME:rml_enkf> 41
                  ITER:45
                  USE_PRIOR:False
                  LAMBDA_REDUCE:0.10

--- a/testkomodo.sh
+++ b/testkomodo.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+source /project/res/komodo/$KOMODO_VERSION/enable
+source /opt/rh/devtoolset-7/enable
+GCC_VERSION=7.3.0 CMAKE_VERSION=3.10.2 source /prog/sdpsoft/env.sh
+set -e
+
+echo "building c tests"
+rm -rf build
+mkdir build
+pushd build
+cmake .. -DBUILD_TESTS=ON\
+-DENABLE_PYTHON=OFF\
+-DBUILD_APPLICATIONS=ON\
+-DCMAKE_INSTALL_PREFIX=install\
+-DCMAKE_PREFIX_PATH=/project/res/komodo/$KOMODO_VERSION/root/\
+-DCMAKE_C_FLAGS='-Werror=all'\
+-DCMAKE_CXX_FLAGS='-Wno-unused-result'
+make -j 12
+#removing built libs in order to ensure we are using libs from komodo
+rm -r lib64
+
+echo "running ctest"
+ctest --output-on-failure
+
+popd
+
+echo "create virtualenv"
+ENV=testenv
+rm -rf testenv
+mkdir $ENV
+python -m virtualenv --system-site-packages $ENV
+source $ENV/bin/activate
+python -m pip install mock decorator
+
+echo "running pytest"
+#run in a new folder so that we dont load the other python code from the source, but rather run against komodo
+rm -rf tmptest
+mkdir tmptest
+cp -r python/tests tmptest/tests
+pushd tmptest
+python -m pytest \
+ --ignore="tests/res/enkf/test_analysis_config.py"\
+ --ignore="tests/res/enkf/test_res_config.py"\
+ --ignore="tests/res/enkf/test_site_config.py"\
+ --ignore="tests/res/enkf/test_workflow_list.py"
+
+
+popd
+


### PR DESCRIPTION
Also fix c tests library names to enable running against komodo.

Partial solution to equinor/ert#387

Reviewer:

- The build script in the Jenkins job [libres-komodo-run](https://ci.equinor.com/be/view/SCOUT/job/libres-komodo-run/) first sources komodo, checks out corresponding git tag, and then runs the testkomodo.sh script.
- The Jenkins build is currently running this code on my fork mortalisk/libres on master branch. After merge this must be switched to use equinor/libres in the jenkins build.
- There will still be some python tests failing, but c tests should pass for bleeding at least.
- New issues should be made for each failing test after merge.
