### PR TITLE
Fix for collections ABC import DeprecationWarning

### DIFF
--- a/python/res/util/stat.py
+++ b/python/res/util/stat.py
@@ -13,7 +13,10 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from collections.abc import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from cwrap import PrototypeError
 from res import ResPrototype

--- a/python/res/util/stat.py
+++ b/python/res/util/stat.py
@@ -13,7 +13,7 @@
 #
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
-from collections import Sequence
+from collections.abc import Sequence
 
 from cwrap import PrototypeError
 from res import ResPrototype


### PR DESCRIPTION
**Issue**
Resolves the DeprecationWarning that `collections` throws in stat.py

`DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working`

**Approach**
Did as suggested by the warning, changed `from collections import Sequence` to `from collections.abc import Sequence`.
