### PR TITLE
Run tests in tmpdir

### DIFF
--- a/python/tests/res/analysis/test_rml.py
+++ b/python/tests/res/analysis/test_rml.py
@@ -24,8 +24,7 @@ from res.util import Matrix
 from res.analysis import AnalysisModule, AnalysisModuleLoadStatusEnum, AnalysisModuleOptionsEnum
 from res.enkf import MeasData , ObsData
 
-import res
-
+from tests.utils import tmpdir
 
 def forward_model(params , model_error = False):
     # Y = A*p[0] + B*p[1]
@@ -95,9 +94,9 @@ class RMLTest(ResTest):
         self.assertEnumIsFullyDefined(AnalysisModuleLoadStatusEnum, "analysis_module_load_status_enum", source_file_path)
 
 
-
-
+    @tmpdir()
     def test_analysis_module(self):
+
         rng = RandomNumberGenerator( )
         module = self.createAnalysisModule()
         ens_size = 12

--- a/python/tests/res/enkf/data/test_custom_kw.py
+++ b/python/tests/res/enkf/data/test_custom_kw.py
@@ -1,4 +1,7 @@
 import os
+
+import pytest
+
 from res.enkf.enums import EnkfRunType
 from res.enkf import ErtRunContext
 from res.enkf.config import CustomKWConfig
@@ -11,6 +14,8 @@ from tests import ResTest
 from ecl.util.test.test_area import TestAreaContext
 from ecl.util.util import StringList
 from ecl.util.util import BoolVector
+
+from tests.utils import tmpdir
 
 class CustomKWTest(ResTest):
 
@@ -78,7 +83,7 @@ class CustomKWTest(ResTest):
                 self.assertFalse( "VALUE_3" in custom_kw_config )
 
 
-
+    @tmpdir()
     def test_simulated_custom_kw(self):
         config = self.createTestPath("local/custom_kw/mini_config")
         with ErtTestContext("python/enkf/data/custom_kw_simulated", config) as context:

--- a/python/tests/res/enkf/test_enkf.py
+++ b/python/tests/res/enkf/test_enkf.py
@@ -16,6 +16,7 @@
 
 import sys, os
 import os.path
+import pytest
 from tests import ResTest
 
 from ecl.util.util import BoolVector
@@ -32,6 +33,7 @@ from res.enkf.enums import (EnkfObservationImplementationType, LoadFailTypeEnum,
 from ecl.util.test import TestAreaContext
 from res.enkf.observations.summary_observation import SummaryObservation
 
+from tests.utils import tmpdir
 
 class EnKFTest(ResTest):
     def setUp(self):
@@ -39,6 +41,7 @@ class EnKFTest(ResTest):
         self.case_directory_custom_kw = self.createTestPath("local/snake_oil/")
 
 
+    @tmpdir()
     def test_repr( self ):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
             work_area.copy_directory(self.case_directory)
@@ -48,6 +51,7 @@ class EnKFTest(ResTest):
             self.assertEqual(pfx, repr(main)[:len(pfx)])
 
 
+    @tmpdir()
     def test_bootstrap( self ):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
             work_area.copy_directory(self.case_directory)
@@ -56,6 +60,7 @@ class EnKFTest(ResTest):
             self.assertTrue(main, "Load failed")
 
 
+    @tmpdir()
     def test_site_condif(self):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
             work_area.copy_directory(self.case_directory)
@@ -79,6 +84,7 @@ class EnKFTest(ResTest):
             with  self.assertRaises(ValueError):
                 EnKFMain(None)
 
+    @tmpdir()
     def test_default_res_config(self):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
             work_area.copy_directory(self.case_directory)
@@ -111,6 +117,7 @@ class EnKFTest(ResTest):
         self.assertEnumIsFullyDefined(ActiveMode , "active_mode_type" , "lib/include/ert/enkf/enkf_types.hpp")
 
 
+    @tmpdir()
     def test_observations(self):
         with TestAreaContext("enkf_test") as work_area:
             work_area.copy_directory(self.case_directory)
@@ -181,6 +188,7 @@ class EnKFTest(ResTest):
             self.assertEqual( "simple_config/Ensemble" , main.getMountPoint())
 
 
+    @tmpdir()
     def test_enkf_create_config_file(self):
         config_file      = "test_new_config"
         dbase_type       = "BLOCK_FS"

--- a/python/tests/res/enkf/test_enkf_load_results_manually.py
+++ b/python/tests/res/enkf/test_enkf_load_results_manually.py
@@ -6,6 +6,7 @@ from res.test import ErtTestContext
 from res.enkf.enums.realization_state_enum import RealizationStateEnum
 from ecl.util.util import BoolVector
 
+from tests.utils import tmpdir
 
 @pytest.mark.equinor_test
 class LoadResultsManuallyTest(ResTest):
@@ -40,6 +41,7 @@ class LoadResultsManuallyTest(ResTest):
             self.assertEqual(25, len(expected))
             self.assertEqual(25, len(realisations))
 
+    @tmpdir()
     def test_load_results_from_run_context(self):
         with ErtTestContext("manual_load_test", self.config_file) as test_context:
             ert = test_context.getErt()

--- a/python/tests/utils/__init__.py
+++ b/python/tests/utils/__init__.py
@@ -13,7 +13,7 @@ https://github.com/equinor/everest/blob/master/tests/utils/__init__.py
 """
 
 
-def tmpdir(path, teardown=True):
+def tmpdir(path=None, teardown=True):
     """ Decorator based on the  `tmp` context """
     def real_decorator(function):
         def wrapper(function, *args, **kwargs):


### PR DESCRIPTION
Several tests were running copying files to the source tree, this moves it into tmpdir.
