### PR TITLE
Fix potential garbage in model config

### DIFF
--- a/lib/enkf/model_config.cpp
+++ b/lib/enkf/model_config.cpp
@@ -158,7 +158,8 @@ void model_config_add_runpath( model_config_type * model_config , const char * p
 bool model_config_select_runpath( model_config_type * model_config , const char * path_key) {
   if (hash_has_key( model_config->runpath_map , path_key )) {
     model_config->current_runpath = (path_fmt_type * ) hash_get( model_config->runpath_map , path_key );
-    model_config->current_path_key = util_realloc_string_copy( model_config->current_path_key , path_key);
+    if(model_config->current_path_key != path_key) // If ptrs are the same, there is nothing to do
+        model_config->current_path_key = util_realloc_string_copy( model_config->current_path_key , path_key);
     return true;
   } else {
     if (model_config->current_runpath != NULL)  // OK - we already have a valid selection - stick to that and return False.


### PR DESCRIPTION
Realloc can reallocate memory, if the 2 pointers passed to `util_realloc_string_copy are the same`, we can either copy garbage because the source string is deallocated, or break one of the preconditions of `strcpy`, therefore leading to undefined behavior

I have run a few test, and in practice it is unlikely that this issue hit any of our users. I noticed it only because (seemingly) some explicit precondition checks are enabled when compiling libres with clang
