### PR TITLE
Bump libecl dependency to 2.5.b0

### DIFF
--- a/.libecl_version
+++ b/.libecl_version
@@ -1,1 +1,1 @@
-export LIBECL_VERSION=2.5.a2
+export LIBECL_VERSION=2.5.b0


### PR DESCRIPTION
Bump libecl version to newest to facilitate new libres release.
