### PR TITLE
Mark unstable tests and run seperately

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,11 @@ pipeline {
                 sh 'sh testjenkins.sh run_pytest_normal'
             }
         }
+	stage('run pytest_unstable') {
+            steps {
+                sh 'sh testjenkins.sh run_pytest_unstable'
+            }
+        }
     }
 }
 

--- a/python/tests/res/enkf/test_enkf_library.py
+++ b/python/tests/res/enkf/test_enkf_library.py
@@ -13,7 +13,7 @@ from res.enkf import GenDataConfig, FieldConfig, EnkfFs, EnkfObs, EnKFState, Ens
 from res.enkf.util import TimeMap
 
 
-
+@pytest.mark.unstable
 @pytest.mark.equinor_test
 class EnKFLibraryTest(ResTest):
     def setUp(self):

--- a/python/tests/res/enkf/test_enkf_load_results_manually.py
+++ b/python/tests/res/enkf/test_enkf_load_results_manually.py
@@ -8,6 +8,7 @@ from ecl.util.util import BoolVector
 
 from tests.utils import tmpdir
 
+@pytest.mark.unstable
 @pytest.mark.equinor_test
 class LoadResultsManuallyTest(ResTest):
     def setUp(self):

--- a/python/tests/res/enkf/test_enkf_runpath.py
+++ b/python/tests/res/enkf/test_enkf_runpath.py
@@ -14,6 +14,7 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
+import pytest
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
@@ -33,6 +34,7 @@ from res.enkf.observations.summary_observation import SummaryObservation
 
 import os
 
+@pytest.mark.unstable
 class EnKFRunpathTest(ResTest):
     def setUp(self):
         pass

--- a/python/tests/res/enkf/test_enkf_sim_model.py
+++ b/python/tests/res/enkf/test_enkf_sim_model.py
@@ -18,6 +18,7 @@ import os
 import sys
 import json
 import subprocess
+import pytest
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
@@ -39,7 +40,7 @@ from res.enkf.enums import (EnkfObservationImplementationType, LoadFailTypeEnum,
 from res.enkf.observations.summary_observation import SummaryObservation
 from res.test import ErtTestContext
 
-
+@pytest.mark.unstable
 class EnKFTestSimModel(ResTest):
 
   def setUp(self):

--- a/python/tests/res/enkf/test_enkf_transfer_env.py
+++ b/python/tests/res/enkf/test_enkf_transfer_env.py
@@ -18,6 +18,7 @@ import os
 import sys
 import json
 import subprocess
+import pytest
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
@@ -38,6 +39,7 @@ from res.enkf.observations.summary_observation import SummaryObservation
 from res.test import ErtTestContext
 
 
+@pytest.mark.unstable
 class EnKFTestTransferEnv(ResTest):
 
   def setUp(self):

--- a/testjenkins.sh
+++ b/testjenkins.sh
@@ -152,7 +152,15 @@ run_pytest_normal () {
 run_pytest_equinor () {
 	run enable_environment
 	pushd $LIBRES_ROOT/python
-	python -m pytest -s -m "equinor_test"
+	python -m pytest -s -m "equinor_test and not unstable"
+	popd
+}
+
+
+run_pytest_unstable () {
+	run enable_environment
+	pushd $LIBRES_ROOT/python
+	python -m pytest -s -m "unstable"
 	popd
 }
 


### PR DESCRIPTION
Several tests appear to influence each other, this marks them as unstable and runs them separately. Have made an issue in: #737