### PR TITLE
Move the nan filtering to after index filtering

### DIFF
--- a/python/res/enkf/jobs/scaling/job_config.py
+++ b/python/res/enkf/jobs/scaling/job_config.py
@@ -112,6 +112,9 @@ def build_schema():
                         "index": {
                             MK.Required: False,
                             MK.LayerTransformation: _to_int_list,
+                            MK.Description: (
+                                "Index list where scaling factor is calculatied, must match the simulated data"
+                            ),
                             MK.Type: types.List,
                             MK.ElementValidators: (_min_length,),
                             MK.Content: {

--- a/python/res/enkf/jobs/scaling/measured_data.py
+++ b/python/res/enkf/jobs/scaling/measured_data.py
@@ -8,9 +8,10 @@ class MeasuredData(object):
 
     def __init__(self, ert, events):
         self.data = self._get_data(ert, events.keys)
-        self.remove_nan()
         self.filter_on_column_index(events.index)
+        self.remove_nan()
         self.filter_out_outliers(events)
+
 
     def remove_nan(self):
         self.data = self.data.dropna(axis=1)

--- a/python/tests/res/enkf/jobs/scaling/test_enkf_scaling_job.py
+++ b/python/tests/res/enkf/jobs/scaling/test_enkf_scaling_job.py
@@ -635,6 +635,10 @@ def test_main_entry_point_summary_data_calc():
 
     arguments["CALCULATE_KEYS"].update({"index":[1, 2, 3]})
 
+    with pytest.raises(ValueError):  # Will give an empty data set
+        scaling_job.scaling_job(ert, arguments)
+
+    arguments["CALCULATE_KEYS"].update({"index": [8, 35, 71]})
     scaling_job.scaling_job(ert, arguments)
 
     for index, node in enumerate(obs_vector):


### PR DESCRIPTION
When nans were filtered out before the index list was applied the index would not match the input data.
