### PR TITLE
Removes validation checking that a case has data [Do not merge]

### DIFF
--- a/python/res/enkf/jobs/scaling/scaling_job.py
+++ b/python/res/enkf/jobs/scaling/scaling_job.py
@@ -197,7 +197,6 @@ def valid_job(observations, user_config, ensamble_size, storage):
     error_messages.extend(obs_keys_errors)
 
     if obs_keys_present:
-        error_messages.extend(has_data(observations, calculation_keys, ensamble_size, storage))
         error_messages.extend(same_data_type(observations, calculation_keys))
 
     for error in error_messages:


### PR DESCRIPTION
This is a temporary solution to make the job run through ERT, as
it reports that cases have no data, even when they do.

