### PR TITLE
Final report only on job fail/fwd model success.

### DIFF
--- a/python/job_runner/reporting/network.py
+++ b/python/job_runner/reporting/network.py
@@ -12,7 +12,7 @@ from sys import version as sys_version
 import requests
 from ecl import EclVersion
 from job_runner import LOG_URL
-from job_runner.reporting.message import Exited, Init
+from job_runner.reporting.message import Exited, Init, Finish
 from job_runner.util import pad_nonexisting, read_os_release
 from res import ResVersion
 
@@ -22,6 +22,7 @@ class Network(object):
     def __init__(self, log_url=LOG_URL):
         self.simulation_id = None
         self.ert_pid = None
+        self.start_time = None
 
         self.log_url = log_url
         self.node = socket.gethostname()
@@ -37,10 +38,11 @@ class Network(object):
 
             self._post_initial(msg)
         elif isinstance(msg, Exited):
+            if not msg.success():
+                self._post_job_failure(msg)
+        elif isinstance(msg, Finish):
             if msg.success():
                 self._post_success(msg)
-            else:
-                self._post_job_failure(msg)
 
     def _post_initial(self, msg):
         os_info = read_os_release()

--- a/python/tests/job_runner/test_network_reporter.py
+++ b/python/tests/job_runner/test_network_reporter.py
@@ -2,9 +2,9 @@ import sys
 from datetime import datetime as dt
 from unittest import TestCase
 
-
+from job_runner.job import Job
 from job_runner.reporting import Network
-from job_runner.reporting.message import Exited, Init
+from job_runner.reporting.message import Exited, Init, Finish
 
 if sys.version_info >= (3, 3):
     from unittest.mock import patch
@@ -23,19 +23,37 @@ class NetworkReporterTests(TestCase):
         self.assertTrue(post_mock.called)
 
     @patch("job_runner.reporting.network.requests.post")
-    def test_exited_failure_msg(self, post_mock):
+    def test_failed_job_is_reported(self, post_mock):
         self.reporter.start_time = dt.now()
+        job = Job({"name": "failing job",
+                   "executable": "/dev/null", "argList": []}, 0)
 
-        self.reporter.report(Exited(None, 9))
-
-        self.assertTrue(post_mock.called)
-
-    @patch("job_runner.reporting.network.requests.post")
-    def test_exited_success_msg(self, post_mock):
-        self.reporter.start_time = dt.now()
-
-        self.reporter.report(Exited(None, 9))
+        self.reporter.report(
+            Exited(job, 9).with_error("failed"))
         _, data = post_mock.call_args
 
-        self.assertTrue(post_mock.called)
-        self.assertIn('"status": "OK"', data["data"])
+        self.assertTrue(post_mock.called, "post not called for failed Exit")
+        self.assertIn('"status": "exit"', data["data"], "no exit in data")
+        self.assertIn('"error": true', data["data"], "no set err flag in data")
+
+    @patch("job_runner.reporting.network.requests.post")
+    def test_successful_job_not_reported(self, post_mock):
+        self.reporter.report(Exited(None, 9))
+
+        self.assertFalse(post_mock.called, "post called on successful Exit")
+
+    @patch("job_runner.reporting.network.requests.post")
+    def test_successful_forward_model_reported(self, post_mock):
+        self.reporter.start_time = dt.now()
+
+        self.reporter.report(Finish())
+        _, data = post_mock.call_args
+
+        self.assertTrue(post_mock.called, "post not called on OK Finish")
+        self.assertIn('"status": "OK"', data["data"], "no OK in data")
+
+    @patch("job_runner.reporting.network.requests.post")
+    def test_failed_forward_model_not_reported(self, post_mock):
+        self.reporter.report(Finish().with_error("failed"))
+
+        self.assertFalse(post_mock.called, "post called on failed Finish")


### PR DESCRIPTION
**Issue**
Resolves #767


**Approach**
Change networking reporting to the following:

1. On `Init`
1. On failed `Exited`, i.e. a job that was unsuccessful.
1. On successful `Finish`, i.e. a forward model that has all jobs succeeding.
