### PR TITLE
ecl_run: "Tee" Eclipse output into .LOG and stdout

### DIFF
--- a/python/res/fm/ecl/ecl_run.py
+++ b/python/res/fm/ecl/ecl_run.py
@@ -18,10 +18,10 @@ from .ecl_config import EclConfig
 from res.util.subprocess import await_process_tee
 
 
-EclipseResult = namedtuple("EclipseResult" , "errors bugs")
-body_sub_pattern = "(\s^\s@.+$)*"
-date_sub_pattern = "\s+AT TIME\s+(?P<Days>\d+\.\d+)\s+DAYS\s+\((?P<Date>(.+)):\s*$"
-error_pattern    = "^\s@--  ERROR%s$%s"   % (date_sub_pattern, body_sub_pattern)
+EclipseResult = namedtuple("EclipseResult", "errors bugs")
+body_sub_pattern = r"(\s^\s@.+$)*"
+date_sub_pattern = r"\s+AT TIME\s+(?P<Days>\d+\.\d+)\s+DAYS\s+\((?P<Date>(.+)):\s*$"
+error_pattern = r"^\s@--  ERROR{}${}".format(date_sub_pattern, body_sub_pattern)
 
 def make_LSB_MCPU_machine_list( LSB_MCPU_HOSTS ):
     host_numcpu_list = LSB_MCPU_HOSTS.split()
@@ -268,8 +268,8 @@ class EclRun(object):
 
 
     def readECLEND(self):
-        error_regexp = re.compile("^\s*Errors\s+(\d+)\s*$")
-        bug_regexp = re.compile("^\s*Bugs\s+(\d+)\s*$")
+        error_regexp = re.compile(r"^\s*Errors\s+(\d+)\s*$")
+        bug_regexp = re.compile(r"^\s*Bugs\s+(\d+)\s*$")
 
         report_file = os.path.join( self.run_path , "{}.ECLEND".format(self.base_name))
         if not os.path.isfile(report_file):

--- a/python/res/util/subprocess.py
+++ b/python/res/util/subprocess.py
@@ -1,0 +1,38 @@
+#  Copyright (C) 2019  Equinor ASA, Norway.
+#
+#  The file 'subprocess.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+
+import os
+
+
+def await_process_tee(process, *out_files):
+    """Wait for process to finish, "tee"-ing the subprocess' stdout into all the
+    given file objects.
+
+    """
+    out_fds = [f.fileno() for f in out_files]
+    process_fd = process.stdout.fileno()
+
+    while process.poll() is None:
+        while True:
+            bytes_ = os.read(process_fd, 4096)
+            if bytes_ == b"":  # check EOF
+                break
+            for fd in out_fds:
+                os.write(fd, bytes_)
+    process.stdout.close()
+
+    return process.returncode

--- a/python/tests/res/fm/test_ecl_run.py
+++ b/python/tests/res/fm/test_ecl_run.py
@@ -188,7 +188,12 @@ class EclRunTest(ResTest):
         ecl_run = EclRun("SPE1.DATA", sim)
         ecl_run.runEclipse( )
 
-        self.assertTrue( os.path.isfile( os.path.join( ecl_run.runPath() , "%s.OK" % ecl_run.baseName())))
+        ok_path = os.path.join(ecl_run.runPath(), "{}.OK".format(ecl_run.baseName()))
+        log_path = os.path.join(ecl_run.runPath(), "{}.LOG".format(ecl_run.baseName()))
+
+        self.assertTrue(os.path.isfile(ok_path))
+        self.assertTrue(os.path.isfile(log_path))
+        self.assertTrue(os.path.getsize(log_path) > 0)
 
         errors = ecl_run.parseErrors( )
         self.assertEqual( 0 , len(errors ))
@@ -251,7 +256,9 @@ class EclRunTest(ResTest):
         shutil.copy(os.path.join(self.SOURCE_ROOT, "test-data/local/eclipse/SPE1_PARALLELL.DATA"), "SPE1_PARALLELL.DATA")
         ecl_config = Ecl100Config()
         run(ecl_config, ["SPE1_PARALLELL.DATA", "--version=2014.2", "--num-cpu=2"])
-        self.assertTrue( os.path.isfile( "SPE1_PARALLELL.OK"))
+        self.assertTrue(os.path.isfile("SPE1_PARALLELL.LOG"))
+        self.assertTrue(os.path.getsize("SPE1_PARALLELL.LOG") > 0)
+
 
     @pytest.mark.equinor_test
     @tmpdir()
@@ -325,4 +332,3 @@ class EclRunTest(ResTest):
 
         self.assertEqual( error_list[0], error0)
         self.assertEqual( error_list[1], error1)
-

--- a/python/tests/res/util/test_subprocess.py
+++ b/python/tests/res/util/test_subprocess.py
@@ -1,0 +1,42 @@
+#  Copyright (C) 2019  Equinor ASA, Norway.
+#
+#  The file 'test_subprocess.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+
+import unittest
+import os
+from tests.utils import tmpdir
+from subprocess import Popen, PIPE
+
+from res.util.subprocess import await_process_tee
+
+
+class TestSubprocess(unittest.TestCase):
+    @tmpdir()
+    def test_await_process_tee(self):
+        with open("a", "wb") as a_fh, open("b", "wb") as b_fh:
+            process = Popen(["/bin/cat", "/bin/cat"], stdout=PIPE)
+            await_process_tee(process, a_fh, b_fh)
+
+        with open("a", "rb") as f:
+            a_content = f.read()
+        with open("b", "rb") as f:
+            b_content = f.read()
+        with open("/bin/cat", "rb") as f:
+            cat_content = f.read()
+
+        self.assertTrue(process.stdout.closed)
+        self.assertEqual(cat_content, a_content)
+        self.assertEqual(cat_content, b_content)


### PR DESCRIPTION
**Issue**
Resolves the second half of equinor/ert#532


**Approach**
Use POSIX IO functions to read from the subprocess' stdout and write it into stdout and file as a bytestream.

The `os.read` function blocks if there isn't any data to read but the pipe hasn't been closed, which is the behaviour we want so we don't 100% the CPU. [`man 3 read`]

There is a function in `io.BufferedReader` (ie. superclass of `sys.stdout` and `open(...)`) called `read1` that is the blessed way to do this (and also supports Windows I think), but it doesn't exist in `2.7`, so I have chosen to use `os` directly.