### PR TITLE
Add new status for layer to monitor threads and not job process

### DIFF
--- a/python/res/job_queue/CMakeLists.txt
+++ b/python/res/job_queue/CMakeLists.txt
@@ -12,6 +12,7 @@ set(PYTHON_SOURCES
     job.py
     job_status_type_enum.py
     run_status_type_enum.py
+    thread_status_type_enum.py
     queue.py
     job_queue_manager.py
     workflow.py

--- a/python/res/job_queue/__init__.py
+++ b/python/res/job_queue/__init__.py
@@ -72,7 +72,7 @@ if LSF_HOME:
 
 from .job_status_type_enum import JobStatusType
 from .run_status_type_enum import RunStatusType
-from .thread_status_type_enum import ThreadStatusType
+from .thread_status_type_enum import ThreadStatus
 from .job import Job
 from .driver import Driver, QueueDriverEnum
 from .job_queue_node import JobQueueNode

--- a/python/res/job_queue/__init__.py
+++ b/python/res/job_queue/__init__.py
@@ -72,6 +72,7 @@ if LSF_HOME:
 
 from .job_status_type_enum import JobStatusType
 from .run_status_type_enum import RunStatusType
+from .thread_status_type_enum import ThreadStatusType
 from .job import Job
 from .driver import Driver, QueueDriverEnum
 from .job_queue_node import JobQueueNode

--- a/python/res/job_queue/queue.py
+++ b/python/res/job_queue/queue.py
@@ -27,7 +27,7 @@ import ctypes
 from cwrap import BaseCClass
 
 from res import ResPrototype
-from res.job_queue import Job, JobStatusType
+from res.job_queue import Job, JobStatusType, ThreadStatusType
 
 
 class JobQueue(BaseCClass):
@@ -260,20 +260,17 @@ class JobQueue(BaseCClass):
         int_status = self._get_job_status(job_number)
         return JobStatusType( int_status )
 
-    def is_running(self):
+    def is_active(self):
         for job in self.job_list:
-            job_status = job.status
-            if (job_status ==  JobStatusType.JOB_QUEUE_PENDING or
-                job_status == JobStatusType.JOB_QUEUE_SUBMITTED or
-                job_status == JobStatusType.JOB_QUEUE_WAITING or
-                job_status == JobStatusType.JOB_QUEUE_UNKNOWN or
-                job_status == JobStatusType.JOB_QUEUE_RUNNING):
+            if (job.thread_status == ThreadStatusType.THREAD_READY or
+                job.thread_status == ThreadStatusType.THREAD_RUNNING or
+                job.thread_status == ThreadStatusType.THREAD_STOPPING):
                 return True
         return False
 
     def fetch_next_waiting(self):
         for job in self.job_list:
-            if job.status == JobStatusType.JOB_QUEUE_WAITING and not job.started:
+            if job.thread_status == ThreadStatusType.THREAD_READY:
                 return job
         return None
 
@@ -310,4 +307,4 @@ class JobQueue(BaseCClass):
         return queue_index
 
     def count_running(self):
-        return sum(job.is_running() for job in self.job_list)
+        return sum(job.thread_status == ThreadStatusType.THREAD_RUNNING for job in self.job_list)

--- a/python/res/job_queue/queue.py
+++ b/python/res/job_queue/queue.py
@@ -27,7 +27,7 @@ import ctypes
 from cwrap import BaseCClass
 
 from res import ResPrototype
-from res.job_queue import Job, JobStatusType, ThreadStatusType
+from res.job_queue import Job, JobStatusType, ThreadStatus
 
 
 class JobQueue(BaseCClass):
@@ -262,15 +262,15 @@ class JobQueue(BaseCClass):
 
     def is_active(self):
         for job in self.job_list:
-            if (job.thread_status == ThreadStatusType.THREAD_READY or
-                job.thread_status == ThreadStatusType.THREAD_RUNNING or
-                job.thread_status == ThreadStatusType.THREAD_STOPPING):
+            if (job.thread_status == ThreadStatus.READY or
+                job.thread_status == ThreadStatus.RUNNING or
+                job.thread_status == ThreadStatus.STOPPING):
                 return True
         return False
 
     def fetch_next_waiting(self):
         for job in self.job_list:
-            if job.thread_status == ThreadStatusType.THREAD_READY:
+            if job.thread_status == ThreadStatus.READY:
                 return job
         return None
 
@@ -307,4 +307,4 @@ class JobQueue(BaseCClass):
         return queue_index
 
     def count_running(self):
-        return sum(job.thread_status == ThreadStatusType.THREAD_RUNNING for job in self.job_list)
+        return sum(job.thread_status == ThreadStatus.RUNNING for job in self.job_list)

--- a/python/res/job_queue/thread_status_type_enum.py
+++ b/python/res/job_queue/thread_status_type_enum.py
@@ -15,9 +15,9 @@
 #  for more details.
 
 
-class ThreadStatusType:
-    THREAD_READY = 1
-    THREAD_RUNNING = 2
-    THREAD_FAILED = 3
-    THREAD_DONE = 4
-    THREAD_STOPPING = 5
+class ThreadStatus:
+    READY = 1
+    RUNNING = 2
+    FAILED = 3
+    DONE = 4
+    STOPPING = 5

--- a/python/res/job_queue/thread_status_type_enum.py
+++ b/python/res/job_queue/thread_status_type_enum.py
@@ -1,0 +1,23 @@
+#  Copyright (C) 2013  Equinor ASA, Norway.
+#
+#  The file 'thread_status_type_enum.py' is part of ERT - Ensemble based Reservoir Tool.
+#
+#  ERT is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+#  for more details.
+
+
+class ThreadStatusType:
+    THREAD_READY = 1
+    THREAD_RUNNING = 2
+    THREAD_FAILED = 3
+    THREAD_DONE = 4
+    THREAD_STOPPING = 5

--- a/python/tests/res/job_queue/test_job_queue_manager.py
+++ b/python/tests/res/job_queue/test_job_queue_manager.py
@@ -3,7 +3,6 @@ from res.enkf import ResConfig
 from tests import ResTest
 from tests.utils import wait_until
 from ecl.util.test import TestAreaContext
-from threading import Thread
 import os, stat
 
 

--- a/python/tests/res/simulator/test_batch_sim.py
+++ b/python/tests/res/simulator/test_batch_sim.py
@@ -400,7 +400,6 @@ class BatchSimulatorTest(ResTest):
                                   })
                              ])
 
-            time.sleep(2.0)
             ctx.stop()
             status = ctx.status
 


### PR DESCRIPTION
**Issue**
Resolves #787 

Adds a new status layer, as the job_manager should keep track for the monitor threads 

Each job now keeps track of its own monitor thread in order or not having two threads looking at the a same job

