### PR TITLE
Fix attribute error in rms_run.py os.stat result

### DIFF
--- a/python/res/fm/rms/rms_run.py
+++ b/python/res/fm/rms/rms_run.py
@@ -47,8 +47,7 @@ class RMSRun(object):
                 self.target_file = os.path.join(os.getcwd(), target_file)
 
             if os.path.isfile(self.target_file):
-                st = os.stat(self.target_file)
-                self.target_file_mtime = st.mtime
+                self.target_file_mtime = os.path.getmtime(self.target_file)
             else:
                 self.target_file_mtime = None
 
@@ -129,8 +128,7 @@ class RMSRun(object):
         if self.target_file_mtime is None:
             return
 
-        st = os.stat(self.target_file)
-        if st.mtime == self.target_file_mtime:
+        if os.path.getmtime(self.target_file) == self.target_file_mtime:
             raise Exception("The target file:{} is unmodified - interpreted as failure".format(self.target_file))
 
 

--- a/python/tests/res/fm/rms
+++ b/python/tests/res/fm/rms
@@ -3,14 +3,37 @@
 import json
 import sys
 import os
+import time
 
 config = {"exit_status" : 0}
 if os.path.isfile("action.json"):
     config = json.load(open("action.json"))
 
+
+def write_target_file(target_file):
+    with open(target_file, "w") as f:
+        f.write("this is the target file {}\n".format(time.time()))
+
+
 if "target_file" in config:
-    with open(config["target_file"], "w") as f:
-        f.write("this is the target file\n")
+    target_file = config["target_file"]
+    if os.path.isfile(target_file):
+        mtime = os.path.getmtime(target_file)
+    else:
+        mtime = None
+
+    write_target_file(target_file)
+
+    # Try to ensure that mtime is updated for target file
+    base_sleep_time = 1
+    for sleep_pow in range(5):
+        if mtime is not None and mtime == os.path.getmtime(target_file):
+            time.sleep(base_sleep_time*2**sleep_pow)
+            write_target_file(target_file)
+            time.sleep(base_sleep_time*2**sleep_pow)
+        else:
+            break
+
 
 with open('env.json', 'w') as f:
     env = {}

--- a/python/tests/res/fm/test_rms_run.py
+++ b/python/tests/res/fm/test_rms_run.py
@@ -252,6 +252,30 @@ class RMSRunTest(ResTest):
                     self.assertNotIn('RMS_TEST_VAR', env)
 
 
+    def test_run_class_with_existing_target_file(self):
+        with TestAreaContext("test_run_existing_target"):
+            with open("rms_config.yml", "w") as f:
+                f.write("executable:  {}/bin/rms".format(os.getcwd()))
+
+            os.mkdir("run_path")
+            os.mkdir("bin")
+            os.mkdir("project")
+            shutil.copy(os.path.join(self.SOURCE_ROOT, "python/tests/res/fm/rms"), "bin")
+            self.monkeypatch.setenv("RMS_SITE_CONFIG", "rms_config.yml")
+
+            target_file = os.path.join(os.getcwd(), "rms_target_file")
+            action = {
+                "exit_status": 0,
+                "target_file": target_file,
+            }
+            with open("run_path/action.json", "w") as f:
+                f.write(json.dumps(action))
+
+            with open(target_file, "w") as f:
+                f.write("This is a dummy target file")
+
+            r = RMSRun(0, "project", "workflow", run_path="run_path", target_file=target_file)
+            r.run()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
There is a minor syntax error when the rms job is checking the stat output of a target file.

The current rms testing is done with a very basic mock script which does not capture this behaviour at all, it was therefor quite nontrivial to make a proper test for this fix. Since the current code accesses attributes from standard module `os.stat()` incorrectly it should be quite trivial though; and I hope this can be merged.