### PR TITLE
Add subprocess in res.util to CMakeList

### DIFF
--- a/python/res/util/CMakeLists.txt
+++ b/python/res/util/CMakeLists.txt
@@ -1,15 +1,16 @@
 set(PYTHON_SOURCES
     __init__.py
-    log.py
     arg_pack.py
-    stat.py
-    res_log.py
-    path_format.py
-    ui_return.py
-    res_version.py
-    substitution_list.py
     cthread_pool.py
+    log.py
     matrix.py
+    path_format.py
+    res_log.py
+    res_version.py
+    stat.py
+    subprocess.py
+    substitution_list.py
+    ui_return.py
 )
 
 add_python_package("python.res.util"  ${PYTHON_INSTALL_PREFIX}/res/util "${PYTHON_SOURCES}" True)


### PR DESCRIPTION
To reviewer: Check that the contents of python/res/util matches the list in CMakeList.