### PR TITLE
Depend on libecl 2.5.0

### DIFF
--- a/.libecl_version
+++ b/.libecl_version
@@ -1,1 +1,1 @@
-export LIBECL_VERSION=2.5.rc1
+export LIBECL_VERSION=2.5.0


### PR DESCRIPTION
**Issue**
Resolves requirement for 2019.12 release


**Approach**
Bumped `.libecl_version` to `2.5.0`.
