### PR TITLE
Use JOB_QUEUE_SUCCESS to label success

### DIFF
--- a/python/res/enkf/enkf_state.py
+++ b/python/res/enkf/enkf_state.py
@@ -49,8 +49,8 @@ class EnKFState(BaseCClass):
 
     @classmethod
     def forward_model_exit_callback(cls, args):
-        cls._forward_model_EXIT(args[0])
+        return cls._forward_model_EXIT(args[0])
 
     @classmethod
     def forward_model_ok_callback(cls, args):
-        cls._forward_model_OK(args[1], args[0])
+        return cls._forward_model_OK(args[1], args[0])

--- a/python/res/job_queue/job_queue_manager.py
+++ b/python/res/job_queue/job_queue_manager.py
@@ -105,7 +105,7 @@ class JobQueueManager(BaseCClass):
         return self.queue.job_list[job_index].status == JobStatusType.JOB_QUEUE_FAILED
 
     def didJobSucceed(self, job_index):
-        return self.queue.job_list[job_index].status == JobStatusType.JOB_QUEUE_SUCCEED
+        return self.queue.job_list[job_index].status == JobStatusType.JOB_QUEUE_SUCCESS
 
     def getJobStatus(self, job_index):
         # See comment about return type in the prototype section at

--- a/python/res/job_queue/job_queue_manager.py
+++ b/python/res/job_queue/job_queue_manager.py
@@ -79,14 +79,11 @@ class JobQueueManager(BaseCClass):
     def getNumPending(self):
         return self.queue.count_status(JobStatusType.JOB_QUEUE_PENDING)
 
-
     def getNumSuccess(self):
-        return self.queue.count_status(JobStatusType.JOB_QUEUE_DONE)
-
+        return self.queue.count_status(JobStatusType.JOB_QUEUE_SUCCESS)
 
     def getNumFailed(self):
         return self.queue.count_status(JobStatusType.JOB_QUEUE_FAILED)
-
 
     def isRunning(self):
         return self.queue.is_active()
@@ -108,7 +105,7 @@ class JobQueueManager(BaseCClass):
         return self.queue.job_list[job_index].status == JobStatusType.JOB_QUEUE_FAILED
 
     def didJobSucceed(self, job_index):
-        return self.queue.job_list[job_index].status == JobStatusType.JOB_QUEUE_DONE
+        return self.queue.job_list[job_index].status == JobStatusType.JOB_QUEUE_SUCCEED
 
     def getJobStatus(self, job_index):
         # See comment about return type in the prototype section at

--- a/python/res/job_queue/job_queue_node.py
+++ b/python/res/job_queue/job_queue_node.py
@@ -75,7 +75,14 @@ class JobQueueNode(BaseCClass):
         self._submit(driver)
 
     def run_done_callback(self):
-        return self.done_callback_function(self.callback_arguments)
+        callback_status = self.done_callback_function(self.callback_arguments)
+
+        if callback_status:
+            self._set_status(JobStatusType.JOB_QUEUE_SUCCESS)
+        else:
+            self._set_status(JobStatusType.JOB_QUEUE_EXIT)
+
+        return callback_status
 
     def run_exit_callback(self):
         return self.exit_callback_function(self.callback_arguments)
@@ -119,6 +126,9 @@ class JobQueueNode(BaseCClass):
             if self.status == JobStatusType.JOB_QUEUE_DONE:
                 with pool_sema:
                     self.run_done_callback()
+
+            if self.status == JobStatusType.JOB_QUEUE_SUCCESS:
+                pass
             elif self.status == JobStatusType.JOB_QUEUE_EXIT:
                 if self.submit_attempt < max_submit:
                     self._set_thread_status(ThreadStatus.READY)

--- a/python/tests/res/simulator/test_batch_sim.py
+++ b/python/tests/res/simulator/test_batch_sim.py
@@ -419,6 +419,7 @@ class BatchSimulatorTest(ResTest):
             JobStatusType.JOB_QUEUE_RUNNING,
             JobStatusType.JOB_QUEUE_UNKNOWN,
             JobStatusType.JOB_QUEUE_EXIT,
+            JobStatusType.JOB_QUEUE_DONE,
         ))
 
         for idx in range(len(batch_ctx)):
@@ -426,7 +427,7 @@ class BatchSimulatorTest(ResTest):
             if not final_state_only and status in running_status:
                 continue
             elif idx%2 == 0:
-                self.assertEqual(JobStatusType.JOB_QUEUE_DONE, status)
+                self.assertEqual(JobStatusType.JOB_QUEUE_SUCCESS, status)
             else:
                 self.assertEqual(JobStatusType.JOB_QUEUE_FAILED, status)
 


### PR DESCRIPTION
While working on the queue system the ultimate sign of success moved
from being JOB_QUEUE_SUCCESS to JOB_QUEUE_DONE. This is reverted with this
commit.
