### PR TITLE
Added support for activating previously inactive observations

### DIFF
--- a/lib/analysis/modules/ies_enkf_data.h
+++ b/lib/analysis/modules/ies_enkf_data.h
@@ -41,6 +41,7 @@ void ies_enkf_data_fclose_log(ies_enkf_data_type * data);
 
 void ies_enkf_data_allocateW(ies_enkf_data_type * data, int ens_size);
 void ies_enkf_data_store_initialE(ies_enkf_data_type * data, const matrix_type * E0);
+void ies_enkf_data_augment_initialE(ies_enkf_data_type * data, const matrix_type * E0);
 void ies_enkf_data_store_initialA(ies_enkf_data_type * data, const matrix_type * A);
 const matrix_type * ies_enkf_data_getE(const ies_enkf_data_type * data);
 const matrix_type * ies_enkf_data_getA0(const ies_enkf_data_type * data);


### PR DESCRIPTION
**Issue**
Resolves the issue of introducing newly activated observations during the iteration steps in ies_enkf.  Before we did not include any other observations than those that were active in the first iteration.
Now all active observations are used in each iteration. 

I also fixed a bug in the definition of nrobs in ies_enkf_linalg_extract_active which would crash ert if the situation above would occur. This is a rare situation for reservoir applications but it became actual for Camille's wind application.

**Approach**
Instead of storing only the initial measurement perturbations from iteration 0, in data->E I now allocate a full data->E with rows for all the measurements, and measurement perturbations are copied into their respective rows the first time they are input to the analysis computation. Thus, we now always use all active observations input to IES for in each iteration.  This modification significantly simplified the code.

A test is modified to check if the new algorithm runs smoothly.
