### PR TITLE
tmpdir fix

### DIFF
--- a/python/tests/res/enkf/export/test_custom_kw_collector.py
+++ b/python/tests/res/enkf/export/test_custom_kw_collector.py
@@ -1,4 +1,5 @@
 from tests import ResTest
+from tests.utils import tmpdir
 from res.test import ErtTestContext
 
 from res.enkf.export import CustomKWCollector
@@ -6,6 +7,7 @@ from res.enkf.export import CustomKWCollector
 
 class CustomKwCollectorTest(ResTest):
 
+    @tmpdir()
     def test_custom_kw_collector_non_current_fs(self):
         config = self.createTestPath("local/custom_kw/mini_config")
 
@@ -16,7 +18,7 @@ class CustomKwCollectorTest(ResTest):
 
             self.assertTrue(len(data.columns) == 0)
 
-
+    @tmpdir()
     def test_custom_kw_collector_current_fs(self):
         config = self.createTestPath("local/custom_kw/mini_config")
 

--- a/python/tests/res/enkf/test_enkf.py
+++ b/python/tests/res/enkf/test_enkf.py
@@ -79,6 +79,7 @@ class EnKFTest(ResTest):
                     main.resConfig().user_config_file
                     )
 
+    @tmpdir()
     def test_site_bootstrap( self ):
         with TestAreaContext("enkf_test", store_area=True) as work_area:
             with  self.assertRaises(ValueError):
@@ -95,6 +96,7 @@ class EnKFTest(ResTest):
             self.assertIsNotNone(main.siteConfig)
             self.assertIsNotNone(main.analysisConfig)
 
+    @tmpdir()
     def test_invalid_res_config(self):
         with TestAreaContext("enkf_test") as work_area:
             with self.assertRaises(TypeError):
@@ -102,7 +104,7 @@ class EnKFTest(ResTest):
                 main = EnKFMain(res_config="This is not a ResConfig instance")
 
 
-
+    @tmpdir()
     def test_enum(self):
         self.assertEnumIsFullyDefined(EnkfVarType, "enkf_var_type", "lib/include/ert/enkf/enkf_types.hpp")
         self.assertEnumIsFullyDefined(ErtImplType, "ert_impl_type", "lib/include/ert/enkf/enkf_types.hpp")
@@ -167,6 +169,7 @@ class EnKFTest(ResTest):
 
 
 
+    @tmpdir()
     def test_config( self ):
         with TestAreaContext("enkf_test") as work_area:
             work_area.copy_directory(self.case_directory)
@@ -201,6 +204,7 @@ class EnKFTest(ResTest):
             self.assertEqual(main.getEnsembleSize(), num_realizations)
 
 
+    @tmpdir()
     def test_run_context(self):
         with TestAreaContext("enkf_test") as work_area:
             work_area.copy_directory(self.case_directory)
@@ -226,7 +230,7 @@ class EnKFTest(ResTest):
             self.assertTrue( isinstance( run_arg , RunArg ))
 
 
-
+    @tmpdir()
     def test_run_context_from_external_folder(self):
         with TestAreaContext('enkf_test') as work_area:
             work_area.copy_directory(self.case_directory_custom_kw)

--- a/python/tests/res/enkf/test_enkf_fs.py
+++ b/python/tests/res/enkf/test_enkf_fs.py
@@ -3,6 +3,7 @@ import pytest
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
+from tests.utils import tmpdir
 from res.test import ErtTestContext
 
 from res.enkf import EnkfFs
@@ -43,6 +44,7 @@ class EnKFFSTest(ResTest):
             self.assertTrue( version >= 106 )
 
 
+    @tmpdir()
     def test_create2(self):
         with TestAreaContext("create_fs2") as work_area:
             work_area.copy_parent_content(self.config_file)

--- a/python/tests/res/enkf/test_enkf_fs_manager1.py
+++ b/python/tests/res/enkf/test_enkf_fs_manager1.py
@@ -1,6 +1,7 @@
 import os
 from res.test import ErtTestContext
 from tests import ResTest
+from tests.utils import tmpdir
 
 from res.enkf import EnkfFs
 from res.enkf import EnKFMain
@@ -12,7 +13,7 @@ class EnKFFSManagerTest1(ResTest):
     def setUp(self):
         self.config_file = self.createTestPath("local/snake_oil/snake_oil.ert")
 
-
+    @tmpdir()
     def test_create(self):
         # We are indirectly testing the create through the create
         # already in the enkf_main object. In principle we could

--- a/python/tests/res/enkf/test_enkf_fs_manager2.py
+++ b/python/tests/res/enkf/test_enkf_fs_manager2.py
@@ -2,6 +2,8 @@ import sys
 import os
 from tests import ResTest
 from res.test import ErtTestContext
+from tests.utils import tmpdir
+
 
 from res.enkf import EnkfFs
 from res.enkf import EnKFMain
@@ -12,7 +14,7 @@ class EnKFFSManagerTest2(ResTest):
     def setUp(self):
         self.config_file = self.createTestPath("local/custom_kw/mini_config")
 
-
+    @tmpdir()
     def test_rotate(self):
 
         # We are indirectly testing the create through the create

--- a/python/tests/res/enkf/test_enkf_library.py
+++ b/python/tests/res/enkf/test_enkf_library.py
@@ -3,6 +3,7 @@ import pytest
 
 
 from tests import ResTest
+from tests.utils import tmpdir
 
 from ecl.summary import EclSum
 from ecl.util.test import TestAreaContext
@@ -27,7 +28,7 @@ class EnKFLibraryTest(ResTest):
             with self.assertRaises(NotImplementedError):
                 temp = cls()
 
-
+    @tmpdir()
     def test_ecl_config_creation(self):
         with TestAreaContext("enkf_library_test") as work_area:
             work_area.copy_directory(self.case_directory)

--- a/python/tests/res/enkf/test_enkf_load_results_manually.py
+++ b/python/tests/res/enkf/test_enkf_load_results_manually.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tests import ResTest
+from tests.utils import tmpdir
 from res.test import ErtTestContext
 
 from res.enkf.enums.realization_state_enum import RealizationStateEnum
@@ -14,6 +15,7 @@ class LoadResultsManuallyTest(ResTest):
     def setUp(self):
         self.config_file = self.createTestPath("Equinor/config/with_data/config")
 
+    @tmpdir()
     def test_load_results_manually(self):
         with ErtTestContext("manual_load_test", self.config_file) as test_context:
             ert = test_context.getErt()

--- a/python/tests/res/enkf/test_enkf_obs.py
+++ b/python/tests/res/enkf/test_enkf_obs.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tests import ResTest
+from tests.utils import tmpdir
 from res.test import ErtTestContext
 
 from ecl.grid import EclGrid
@@ -21,7 +22,7 @@ class EnKFObsTest(ResTest):
         self.refcase = self.createTestPath("Equinor/config/obs_testing/EXAMPLE_01_BASE")
         self.grid = self.createTestPath("Equinor/config/obs_testing/EXAMPLE_01_BASE.EGRID")
 
-
+    @tmpdir()
     def test_scale_obs(self):
         with ErtTestContext("obs_test", self.config_file) as test_context:
             ert = test_context.getErt()
@@ -80,11 +81,7 @@ class EnKFObsTest(ResTest):
             self.assertEqual(v1[1], std0*10)
             self.assertEqual(v2[1], std0*20)
 
-
-
-
-
-
+    @tmpdir()
     def testObs(self):
         with ErtTestContext("obs_test", self.config_file) as test_context:
             ert = test_context.getErt()
@@ -118,8 +115,7 @@ class EnKFObsTest(ResTest):
             for t in v1.getStepList():
                 self.assertTrue(local_node.tstepActive(t))
 
-
-
+    @tmpdir()
     def test_obs_block_scale_std(self):
         with ErtTestContext("obs_test_scale", self.config_file) as test_context:
             ert = test_context.getErt()

--- a/python/tests/res/enkf/test_enkf_runpath.py
+++ b/python/tests/res/enkf/test_enkf_runpath.py
@@ -18,6 +18,7 @@ import pytest
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
+from tests.utils import tmpdir
 from ecl.util.util import BoolVector
 
 from res.enkf import (EnsembleConfig, AnalysisConfig, ModelConfig, SiteConfig,
@@ -39,6 +40,7 @@ class EnKFRunpathTest(ResTest):
     def setUp(self):
         pass
 
+    @tmpdir()
     def test_with_gen_kw(self):
         case_directory = self.createTestPath('local/snake_oil_no_data/')
         with TestAreaContext('test_enkf_runpath', store_area=True) as work_area:
@@ -59,6 +61,7 @@ class EnKFRunpathTest(ResTest):
             rp.load()
             self.assertEqual(len(rp), 1)
 
+    @tmpdir()
     def test_without_gen_kw(self):
         case_directory = self.createTestPath('local/snake_oil_no_data/')
         with TestAreaContext('test_enkf_runpath', store_area=False) as work_area:

--- a/python/tests/res/enkf/test_enkf_sim_model.py
+++ b/python/tests/res/enkf/test_enkf_sim_model.py
@@ -22,6 +22,7 @@ import pytest
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
+from tests.utils import tmpdir
 from ecl.util.util import BoolVector
 
 from res.job_queue import ExtJob
@@ -46,6 +47,7 @@ class EnKFTestSimModel(ResTest):
   def setUp(self):
     pass
 
+  @tmpdir()
   def test_simulation_model(self):
 
     with TestAreaContext('enkf_test_sim_model_kw') as work_area:

--- a/python/tests/res/enkf/test_enkf_transfer_env.py
+++ b/python/tests/res/enkf/test_enkf_transfer_env.py
@@ -22,6 +22,7 @@ import pytest
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
+from tests.utils import tmpdir
 from ecl.util.util import BoolVector
 
 from res.enkf import (EnsembleConfig, AnalysisConfig, ModelConfig, SiteConfig,
@@ -45,6 +46,7 @@ class EnKFTestTransferEnv(ResTest):
   def setUp(self):
     pass
 
+  @tmpdir()
   def test_transfer_var(self):
 
     with TestAreaContext('enkf_test_transfer_env') as work_area:

--- a/python/tests/res/enkf/test_es_update.py
+++ b/python/tests/res/enkf/test_es_update.py
@@ -1,4 +1,5 @@
 from tests import ResTest
+from tests.utils import tmpdir
 from res.test import ErtTestContext
 from ecl.util.util import BoolVector
 
@@ -10,6 +11,7 @@ from res.enkf import EnkfNode
 
 class ESUpdateTest(ResTest):
 
+    @tmpdir()
     def test_create(self):
         config = self.createTestPath("local/custom_kw/mini_config")
         with ErtTestContext("python/enkf/data/custom_kw_simulated", config) as context:
@@ -23,6 +25,7 @@ class ESUpdateTest(ResTest):
             module = es_update.getModule( "STD_ENKF" )
 
 
+    @tmpdir()
     def test_update(self):
         config = self.createTestPath("local/snake_oil/snake_oil.ert")
         with ErtTestContext("update_test", config) as context:
@@ -53,6 +56,7 @@ class ESUpdateTest(ResTest):
                 self.assertNotEqual(sim_gen_kw[index], target_gen_kw[index])
 
 
+    @tmpdir()
     def test_localization(self):
         config = self.createTestPath("local/snake_oil/snake_oil.ert")
         with ErtTestContext("localization_test", config) as context:

--- a/python/tests/res/enkf/test_local_dataset.py
+++ b/python/tests/res/enkf/test_local_dataset.py
@@ -17,6 +17,7 @@
 import os.path
 
 from tests import ResTest
+from tests.utils import tmpdir
 from res.test import ErtTestContext
 
 from res.enkf.active_list import ActiveList
@@ -42,6 +43,7 @@ class LocalDatasetTest(ResTest):
         s_args = (None, nx, ny, xinc, yinc, xstart, ystart, angle)
         return Surface(*s_args)
 
+    @tmpdir()
     def test_local_field(self):
         with ErtTestContext('python/enkf/data/local_config', self.field_config) as test_context:
             main = test_context.getErt()
@@ -55,7 +57,7 @@ class LocalDatasetTest(ResTest):
             data_scale.addField('PERMX', ecl_reg)
             self.assertEqual(1, len(data_scale))
 
-
+    @tmpdir()
     def test_local_surface(self):
         with ErtTestContext('python/enkf/data/local_config', self.surf_config) as test_context:
             main = test_context.getErt()
@@ -69,6 +71,7 @@ class LocalDatasetTest(ResTest):
             data_scale.addSurface('TOP', geo_reg)
             self.assertEqual(1, len(data_scale))
 
+    @tmpdir()
     def test_local_dataset(self):
         with ErtTestContext('python/enkf/data/local_config', self.config) as test_context:
             main = test_context.getErt()

--- a/python/tests/res/enkf/test_res_config.py
+++ b/python/tests/res/enkf/test_res_config.py
@@ -20,6 +20,7 @@ from datetime import date
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
+from tests.utils import tmpdir
 from ecl.util.util import CTime
 from ecl.util.enums import RngAlgTypeEnum
 from res.util.enums import MessageLevelEnum
@@ -303,6 +304,7 @@ class ResConfigTest(ResTest):
         self.config_file = "snake_oil_structure/ert/model/user_config.ert"
         expand_config_data()
 
+    @tmpdir()
     def test_invalid_user_config(self):
         self.set_up_simple()
 
@@ -310,6 +312,7 @@ class ResConfigTest(ResTest):
             with self.assertRaises(IOError):
                 ResConfig("this/is/not/a/file")
 
+    @tmpdir()
     def test_init(self):
         self.set_up_simple()
 
@@ -578,7 +581,7 @@ class ResConfigTest(ResTest):
                 log_config.log_level
                 )
 
-
+    @tmpdir()
     def test_extensive_config(self):
         self.set_up_snake_oil_structure()
 
@@ -610,6 +613,7 @@ class ResConfigTest(ResTest):
             # TODO: Not tested
             # - MIN_REALIZATIONS
 
+    @tmpdir()
     def test_missing_directory(self):
         config = {
             "INTERNALS" :
@@ -632,6 +636,7 @@ class ResConfigTest(ResTest):
         with self.assertRaises(IOError):
             ResConfig( config = config )
 
+    @tmpdir()
     def test_res_config_dict_constructor(self):
         self.set_up_snake_oil_structure()
 

--- a/python/tests/res/enkf/test_run_context.py
+++ b/python/tests/res/enkf/test_run_context.py
@@ -2,6 +2,7 @@ from ecl.util.util import BoolVector
 from res.util.substitution_list import SubstitutionList
 from ecl.util.test import TestAreaContext
 from tests import ResTest
+from tests.utils import tmpdir
 from res.enkf import ErtRunContext
 from res.enkf.enums import EnkfRunType
 from res.enkf.enums import EnKFFSType
@@ -10,6 +11,7 @@ from res.util import PathFormat
 
 class ErtRunContextTest(ResTest):
 
+    @tmpdir()
     def test_create(self):
         with TestAreaContext("run_context"):
             arg = None

--- a/python/tests/res/enkf/test_runpath_list_dump.py
+++ b/python/tests/res/enkf/test_runpath_list_dump.py
@@ -3,6 +3,7 @@ import itertools
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
+from tests.utils import tmpdir
 from res.test import ErtTestContext
 
 from ecl.util.util import BoolVector
@@ -79,6 +80,7 @@ class RunpathListDumpTest(ResTest):
             self.assertEqual(list(exp_runpaths), list(dumped_runpaths))
 
 
+    @tmpdir()
     def test_add_all(self):
         test_base = itertools.product([0, 1, 2, 17], [True, False])
         for itr, elementwise_creation in test_base:

--- a/python/tests/res/enkf/test_runpath_list_ert.py
+++ b/python/tests/res/enkf/test_runpath_list_ert.py
@@ -2,6 +2,7 @@ import unittest
 import os
 from res.test import ErtTestContext
 from tests import ResTest
+from tests.utils import tmpdir
 
 from res.enkf import RunpathList, RunpathNode, ErtRunContext
 from res.enkf.enums import EnkfInitModeEnum,EnkfRunType
@@ -13,6 +14,7 @@ from res.util.substitution_list import SubstitutionList
 
 class RunpathListTestErt(ResTest):
 
+    @tmpdir()
     def test_an_enkf_runpath(self):
         # TODO this test is flaky and we need to figure out why.  See #1370
         # enkf_util_assert_buffer_type: wrong target type in file (expected:104 got:0)
@@ -20,7 +22,7 @@ class RunpathListTestErt(ResTest):
         with ErtTestContext("runpathlist_basic", test_path) as tc:
             pass
 
-
+    @tmpdir()
     def test_assert_export(self):
         with ErtTestContext("create_runpath_export" , self.createTestPath("local/snake_oil_no_data/snake_oil.ert")) as tc:
             ert = tc.getErt( )
@@ -44,7 +46,7 @@ class RunpathListTestErt(ResTest):
             self.assertTrue( os.path.isfile( runpath_list.getExportFile( ) ))
             self.assertEqual( "test_runpath_list.txt" , os.path.basename( runpath_list.getExportFile( ) ))
 
-
+    @tmpdir()
     def test_assert_symlink_deleted(self):
         with ErtTestContext("create_runpath_symlink_deleted" , self.createTestPath("local/snake_oil_field/snake_oil.ert")) as tc:
             ert = tc.getErt( )

--- a/python/tests/res/enkf/test_simulation_batch.py
+++ b/python/tests/res/enkf/test_simulation_batch.py
@@ -2,6 +2,7 @@ import os
 import sys
 from ecl.util.test import TestAreaContext
 from tests import ResTest
+from tests.utils import tmpdir
 from ecl.util.util import BoolVector
 
 from res.test import ErtTestContext
@@ -16,6 +17,7 @@ class SimulationBatchTest(ResTest):
         pass
 
 
+    @tmpdir()
     def test_run(self):
         ens_size = 2
         config_file = self.createTestPath("local/config/simulation_batch/config.ert")

--- a/python/tests/res/fm/test_templating.py
+++ b/python/tests/res/fm/test_templating.py
@@ -1,6 +1,7 @@
 
 from ecl.util.test import TestAreaContext
 from tests import ResTest
+from tests.utils import tmpdir
 from res.fm.templating import *
 
 import jinja2
@@ -37,7 +38,7 @@ class TemplatingTest(ResTest):
         }
     }
 
-
+    @tmpdir()
     def test_render_invalid(self):
         with TestAreaContext("templating") as tac:
 
@@ -72,7 +73,7 @@ class TemplatingTest(ResTest):
             with self.assertRaises(TypeError):
                 render_template(prod_in, 'template_file', None)
 
-
+    @tmpdir()
     def test_render(self):
 
         wells = { 'PROD%d' % idx: 0.2*idx for idx in range(1, 5) }
@@ -105,7 +106,7 @@ class TemplatingTest(ResTest):
 
         self.assertEqual(expected_template_out, output)
 
-
+    @tmpdir()
     def test_template_multiple_input(self):
         with open("template", 'w') as template_file:
             template_file.write(self.mulitple_input_template)
@@ -138,7 +139,7 @@ class TemplatingTest(ResTest):
 
             self.assertEqual(parameter_file.read(), expected_output)
 
-
+    @tmpdir()
     def test_template_executable(self):
         with TestAreaContext("templating") as tac:
             with open("template", 'w') as template_file:
@@ -168,7 +169,7 @@ class TemplatingTest(ResTest):
                                   "F2 200"
                 self.assertEqual(parameter_file.read(), expected_output)
 
-
+    @tmpdir()
     def test_load_parameters(self):
 
         with TestAreaContext("templating") as tac:

--- a/python/tests/res/simulator/test_batch_sim.py
+++ b/python/tests/res/simulator/test_batch_sim.py
@@ -12,6 +12,8 @@ from res.job_queue import JobStatusType
 from res.enkf import ResConfig
 from tests.utils import wait_until, tmpdir
 from tests import ResTest
+from tests.utils import tmpdir
+
 from threading import Thread
 
 class TestMonitor(object):
@@ -39,6 +41,7 @@ def _wait_for_completion(ctx):
 class BatchSimulatorTest(ResTest):
 
 
+    @tmpdir()
     def test_invalid_simulator_creation(self):
         config_file = self.createTestPath("local/batch_sim/batch_sim.ert")
 
@@ -163,6 +166,7 @@ class BatchSimulatorTest(ResTest):
                            ])
 
 
+    @tmpdir()
     def test_batch_simulation(self):
         config_file = self.createTestPath("local/batch_sim/batch_sim.ert")
 
@@ -233,8 +237,7 @@ class BatchSimulatorTest(ResTest):
 
             self.assertTrue(isinstance(monitor.sim_context, BatchContext))
 
-
-
+    @tmpdir()
     def test_batch_simulation_invalid_suffixes(self):
         config_file = self.createTestPath("local/batch_sim/batch_sim.ert")
         with TestAreaContext("batch_sim") as test_area:
@@ -310,6 +313,7 @@ class BatchSimulatorTest(ResTest):
                     }})])
 
 
+    @tmpdir()
     def test_batch_simulation_suffixes(self):
         config_file = self.createTestPath("local/batch_sim/batch_sim.ert")
         with TestAreaContext("batch_sim") as test_area:
@@ -372,6 +376,7 @@ class BatchSimulatorTest(ResTest):
                     self.assertAlmostEqual(exp, act)
 
 
+    @tmpdir()
     def test_stop_sim(self):
         config_file = self.createTestPath("local/batch_sim/batch_sim.ert")
         with TestAreaContext("batch_sim_stop") as test_area:

--- a/python/tests/res/simulator/test_simulation_context.py
+++ b/python/tests/res/simulator/test_simulation_context.py
@@ -1,5 +1,6 @@
 import time
 from tests import ResTest
+from tests.utils import tmpdir
 from ecl.util.util import BoolVector
 
 from res.test import ErtTestContext
@@ -10,7 +11,7 @@ from res.simulator import SimulationContext
 
 class SimulationContextTest(ResTest):
 
-
+    @tmpdir()
     def test_simulation_context(self):
         config_file = self.createTestPath("local/snake_oil_no_data/snake_oil.ert")
         with ErtTestContext("ert/server/rpc/simulation_context", config_file) as test_context:

--- a/python/tests/res/testcase/test_mini_config.py
+++ b/python/tests/res/testcase/test_mini_config.py
@@ -1,10 +1,12 @@
 from res.enkf.enums.realization_state_enum import RealizationStateEnum
 from res.test import ErtTestContext
 from tests import ResTest
+from tests.utils import tmpdir
 
 
 class MiniConfigTest(ResTest):
 
+    @tmpdir()
     def test_failed_realizations(self):
 
         # mini_fail_config has the following realization success/failures:


### PR DESCRIPTION
**Issue**
Resolves #813 


**Approach**
The cause is described in details in #813. Using decorator `@tmpdir` provides currently the most convenient solution as the test is wrapped inside a function, which automatically collects all variables when exiting the function.
