### PR TITLE
Update template render job description

### DIFF
--- a/share/ert/forward-models/old_style/TEMPLATE_RENDER
+++ b/share/ert/forward-models/old_style/TEMPLATE_RENDER
@@ -1,1 +1,2 @@
 EXECUTABLE  ../templating/script/template_render
+ARGLIST -i <INPUT_FILES> -o <OUTPUT_FILE> -t <TEMPLATE_FILE>

--- a/share/ert/forward-models/templating/script/template_render
+++ b/share/ert/forward-models/templating/script/template_render
@@ -5,24 +5,43 @@ from res.fm.templating import render_template
 
 
 def _build_argument_parser():
-    description = (
-        'Loads the data from each file ("some/path/filename.xxx") in INPUT_FILES '
-        'and exposes it as the variable "filename". It then loads the Jinja2 '
-        'template TEMPLATE_FILE and dumps the rendered resoult to OUTPUT.'
-    )
+    description = ("""
+Loads the data from each file ("some/path/filename.xxx") in INPUT_FILES
+and exposes it as the variable "filename". It then loads the Jinja2
+template TEMPLATE_FILE and dumps the rendered result to OUTPUT.
+
+Example:
+Given an input file my_input.json:
+
+{
+    my_variable: my_value
+}
+
+And a template file tmpl.jinja:
+
+This is written in my file together with {{my_input.my_variable}}
+
+This job will produce an output file:
+
+This is written in my file together with my_value
+""")
+
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         '--output_file',
+        '-o',
         required=True,
         help='the output file',
     )
     parser.add_argument(
         '--template_file',
+        '-t',
         required=True,
         help='the jinja2 template file',
     )
     parser.add_argument(
         '--input_files',
+        '-i',
         nargs='+',
         help='list of json and yaml input files',
     )


### PR DESCRIPTION
**Issue**
While working on https://github.com/equinor/ert/issues/426, I found that the job description file should be updated to include an `ARGLIST` in order for the `FORWARD_MODEL` keyword to function. It is possible to run the job as is with the following command:

`SIMULATION_JOB TEMPLATE_RENDER -o outpath -i my_input.json -t tmpl.jinja`, but it isn't possible to forward the arguments for the `FORWARD_MODEL` command.

Update the description slightly as well, and added explicit shortkey arguments.

I have one more question though. There is an explicit check for `parameters.json` (or `enkf.EnkfDefaults.DEFAULT_GEN_KW_EXPORT_NAME` to be exact) for this job to run. So in practice you _can_ add another input file, but it is required with a `parameters.json` as well. Should we have the requirement be optional?