### PR TITLE
Remove bare except, always set memory_ job status

### DIFF
--- a/python/job_runner/reporting/file.py
+++ b/python/job_runner/reporting/file.py
@@ -110,6 +110,8 @@ class File(object):
             "end_time": None,
             "stdout": job.std_out,
             "stderr": job.std_err,
+            "current_memory_usage": None,
+            "max_memory_usage": None,
         }
 
     def _start_status_file(self, msg):

--- a/python/res/job_queue/forward_model_status.py
+++ b/python/res/job_queue/forward_model_status.py
@@ -134,7 +134,7 @@ class ForwardModelStatus(object):
             try:
                 status = cls.try_load(path)
                 return status
-            except:
+            except (OSError, ValueError):
                 attempt += 1
                 if attempt < num_retry:
                     time.sleep(sleep_time)


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/615


**Approach**
Since there was a bare except, we did not catch that `max_memory_usage` and `current_memory_usage` caused `KeyExceptions`. This in turn prevented reading of status, which caused a blank window.
