### PR TITLE
Replace OSError with EnvironmentError

### DIFF
--- a/python/res/job_queue/forward_model_status.py
+++ b/python/res/job_queue/forward_model_status.py
@@ -134,7 +134,7 @@ class ForwardModelStatus(object):
             try:
                 status = cls.try_load(path)
                 return status
-            except (OSError, ValueError):
+            except (EnvironmentError, ValueError):
                 attempt += 1
                 if attempt < num_retry:
                     time.sleep(sleep_time)


### PR DESCRIPTION
OSError is disjoint from IOError, a crucial exception to catch in the
case where the file does not exist.

**Issue**
Resolves https://github.com/equinor/ert/issues/615

This code is largely untested, so I've created https://github.com/equinor/libres/issues/849