### PR TITLE
ExternalErtScript: Explicit bytes -> str conversion

### DIFF
--- a/python/res/job_queue/external_ert_script.py
+++ b/python/res/job_queue/external_ert_script.py
@@ -1,3 +1,4 @@
+import codecs
 import sys
 from subprocess import Popen, PIPE
 from res.job_queue import ErtScript
@@ -21,6 +22,9 @@ class ExternalErtScript(ErtScript):
 
         # The job will complete before stdout and stderr is returned
         self._stdoutdata, self._stderrdata = self.__job.communicate()
+
+        self._stdoutdata = codecs.decode(self._stdoutdata, "utf8", "replace")
+        self._stderrdata = codecs.decode(self._stderrdata, "utf8", "replace")
 
         sys.stdout.write(self._stdoutdata)
 


### PR DESCRIPTION
We use the [`codecs`](https://docs.python.org/3/library/codecs.html) library instead of `str(self._stdoutdata, 'UTF-8')` because the latter will throw a UnicodeDecodeError if the output is not UTF-8. Instead, we try our best with the given output and replace all invalid codepoints with � (U+FFFD Replacement Character). This is controlled by the 'replace' argument, with another reasonable option being 'ignore'.