### PR TITLE
Match delete with new

### DIFF
--- a/lib/enkf/value_export.cpp
+++ b/lib/enkf/value_export.cpp
@@ -94,7 +94,7 @@ value_export_type * value_export_alloc(std::string directory, std::string base_n
 
 
 void value_export_free(value_export_type * value) {
-  free( value );
+  delete value;
 }
 
 int value_export_size( const value_export_type * value) {


### PR DESCRIPTION
In the "class" `value_export` the new instance was created with C++`new`- and then it was subsequently discarded with `free( pointer )`. With this PR that is changed to `delete pointer`.  
