### PR TITLE
Use standard C++ library for generating random distribution

### DIFF
--- a/lib/enkf/enkf_util.cpp
+++ b/lib/enkf/enkf_util.cpp
@@ -21,7 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>
-
+#include <random>
 #include <ert/util/util.h>
 #include <ert/util/rng.h>
 #include <ert/ecl/ecl_util.h>
@@ -30,23 +30,25 @@
 #include <ert/enkf/enkf_util.hpp>
 #include <ert/enkf/enkf_defaults.hpp>
 
+class generator {
+  rng_type *rng;
 
+  public:
+    generator(rng_type *rng): rng(rng) {}
+
+    using value_type = unsigned int;
+    static constexpr value_type min() {return 0;}
+    static constexpr value_type max() {return UINT32_MAX;}
+
+    value_type operator()() {return rng_forward(rng); }
+};
 
 
 double enkf_util_rand_normal(double mean , double std , rng_type * rng) {
-  const double pi = 3.141592653589;
-  double R1 = rng_get_double( rng );
-  double R2 = rng_get_double( rng );
-
-  return mean + std * sqrt(-2.0 * log(R1)) * cos(2.0 * pi * R2);
+  generator gen(rng);
+  std::normal_distribution<double> normdist{mean, std};
+  return normdist(gen);
 }
-
-void enkf_util_rand_stdnormal_vector(int size , double *R, rng_type * rng) {
-  int i;
-  for (i = 0; i < size; i++)
-    R[i] = enkf_util_rand_normal(0.0 , 1.0 , rng);
-}
-
 
 /*****************************************************************/
 

--- a/lib/enkf/obs_data.cpp
+++ b/lib/enkf/obs_data.cpp
@@ -406,18 +406,12 @@ matrix_type * obs_data_allocE(const obs_data_type * obs_data , rng_type * rng , 
   pert_mean = (double *) util_calloc(active_obs_size , sizeof * pert_mean );
   pert_var  = (double *) util_calloc(active_obs_size , sizeof * pert_var  );
   {
-    double * tmp = (double *)util_calloc( active_obs_size * active_ens_size , sizeof * tmp );
-    int i,j;
-    int k = 0;
 
-    enkf_util_rand_stdnormal_vector(active_obs_size * active_ens_size , tmp , rng);
-    for (j=0; j < active_ens_size; j++) {
-      for (i=0; i < active_obs_size; i++) {
-        matrix_iset( E , i , j , tmp[k]);
-        k++;
+    for (int j=0; j < active_ens_size; j++) {
+      for (int i=0; i < active_obs_size; i++) {
+        matrix_iset( E , i , j , enkf_util_rand_normal(0, 1, rng));
       }
     }
-    free(tmp);
   }
 
   for (iobs_active = 0; iobs_active < active_obs_size; iobs_active++) {

--- a/python/tests/res/job_queue/test_workflow_runner.py
+++ b/python/tests/res/job_queue/test_workflow_runner.py
@@ -2,6 +2,7 @@ import os
 import time
 from res.job_queue import WorkflowJoblist, Workflow, WorkflowRunner
 from tests import ResTest
+from tests.utils import wait_until
 from ecl.util.test import TestAreaContext
 from res.util.substitution_list import SubstitutionList
 from .workflow_common import WorkflowCommon
@@ -33,28 +34,33 @@ class WorkflowRunnerTest(ResTest):
             with workflow_runner:
                 self.assertIsNone(workflow_runner.workflowResult())
 
-                time.sleep(1) # wait for workflow to start
-                self.assertTrue(workflow_runner.isRunning())
-                self.assertFileExists("wait_started_0")
+                wait_until(
+                    lambda: self.assertTrue(workflow_runner.isRunning())
+                )
+                wait_until(
+                    lambda: self.assertFileExists("wait_started_0")
+                )
 
-                time.sleep(1) # wait for first job to finish
+                wait_until(
+                    lambda: self.assertFileExists("wait_finished_0")
+                )
+
+                wait_until(
+                    lambda: self.assertFileExists("wait_started_1")
+                )
 
                 workflow_runner.cancel()
-                time.sleep(1) # wait for cancel to take effect
-                self.assertFileExists("wait_finished_0")
-
-
-                self.assertFileExists("wait_started_1")
-                self.assertFileExists("wait_cancelled_1")
-                self.assertFileDoesNotExist("wait_finished_1")
-
+                
+                wait_until(
+                    lambda: self.assertFileExists("wait_cancelled_1")
+                )
+                
                 self.assertTrue(workflow_runner.isCancelled())
 
-                workflow_runner.wait() # wait for runner to complete
-
-                self.assertFileDoesNotExist("wait_started_2")
-                self.assertFileDoesNotExist("wait_cancelled_2")
-                self.assertFileDoesNotExist("wait_finished_2")
+            self.assertFileDoesNotExist("wait_finished_1")
+            self.assertFileDoesNotExist("wait_started_2")
+            self.assertFileDoesNotExist("wait_cancelled_2")
+            self.assertFileDoesNotExist("wait_finished_2")
 
 
 
@@ -77,26 +83,25 @@ class WorkflowRunnerTest(ResTest):
             self.assertFalse(workflow_runner.isRunning())
 
             with workflow_runner:
-                time.sleep(1) # wait for workflow to start
-                self.assertTrue(workflow_runner.isRunning())
-                self.assertFileExists("wait_started_0")
-
-                time.sleep(1) # wait for first job to finish
-
+                wait_until(
+                    lambda: self.assertTrue(workflow_runner.isRunning())
+                )
+                wait_until(
+                    lambda: self.assertFileExists("wait_started_0")
+                )
+                wait_until(
+                    lambda: self.assertFileExists("wait_finished_0")
+                )
+                wait_until(
+                    lambda: self.assertFileExists("wait_started_1")
+                )
                 workflow_runner.cancel()
-                time.sleep(1) # wait for cancel to take effect
-                self.assertFileExists("wait_finished_0")
-
-                self.assertFileExists("wait_started_1")
-                self.assertFileDoesNotExist("wait_finished_1")
-
                 self.assertTrue(workflow_runner.isCancelled())
 
-                workflow_runner.wait() # wait for runner to complete
-
-                self.assertFileDoesNotExist("wait_started_2")
-                self.assertFileDoesNotExist("wait_cancelled_2")
-                self.assertFileDoesNotExist("wait_finished_2")
+            self.assertFileDoesNotExist("wait_finished_1")
+            self.assertFileDoesNotExist("wait_started_2")
+            self.assertFileDoesNotExist("wait_cancelled_2")
+            self.assertFileDoesNotExist("wait_finished_2")
 
 
     def test_workflow_failed_job(self):
@@ -133,15 +138,13 @@ class WorkflowRunnerTest(ResTest):
 
             self.assertFalse(workflow_runner.isRunning())
             with workflow_runner:
-                time.sleep(1) # wait for workflow to start
                 workflow_runner.wait()
+            self.assertFileExists("wait_started_0")
+            self.assertFileDoesNotExist("wait_cancelled_0")
+            self.assertFileExists("wait_finished_0")
 
-                self.assertFileExists("wait_started_0")
-                self.assertFileDoesNotExist("wait_cancelled_0")
-                self.assertFileExists("wait_finished_0")
+            self.assertFileExists("wait_started_1")
+            self.assertFileDoesNotExist("wait_cancelled_1")
+            self.assertFileExists("wait_finished_1")
 
-                self.assertFileExists("wait_started_1")
-                self.assertFileDoesNotExist("wait_cancelled_1")
-                self.assertFileExists("wait_finished_1")
-
-                self.assertTrue(workflow_runner.workflowResult())
+            self.assertTrue(workflow_runner.workflowResult())


### PR DESCRIPTION
__bug__:
When sampling a normal distribution, the following function was called: 

`return mean + std * sqrt(-2.0 * log(R1)) * cos(2.0 * pi * R2);`

where `R1` and `R2` where random numbers generated from our RNG. 

On the very rare case that that `R1` was zero, `log(R1)` would return `-infinite`, resulting in  `matrix_assert_finite` failing.

__fix__:
Use c++ standard version for sampling a normal distribution.

resolves #894 