### PR TITLE
Ensure integer division when making cpu list

### DIFF
--- a/python/res/fm/ecl/ecl_run.py
+++ b/python/res/fm/ecl/ecl_run.py
@@ -26,7 +26,7 @@ error_pattern = r"^\s@--  ERROR{}${}".format(date_sub_pattern, body_sub_pattern)
 def make_LSB_MCPU_machine_list( LSB_MCPU_HOSTS ):
     host_numcpu_list = LSB_MCPU_HOSTS.split()
     host_list = []
-    for index in range(len(host_numcpu_list) / 2):
+    for index in range(len(host_numcpu_list) // 2):
         machine = host_numcpu_list[ 2*index ]
         host_numcpu = int(host_numcpu_list[ 2*index  + 1 ])
         for icpu in range(host_numcpu):

--- a/python/tests/res/fm/test_ecl_run.py
+++ b/python/tests/res/fm/test_ecl_run.py
@@ -101,6 +101,12 @@ class EclRunTest(ResTest):
         self.monkeypatch.setenv("FLOW_SITE_CONFIG", "flow_config.yml")
 
 
+    def test_make_LSB_MCPU_machine_list(self):
+        self.assertListEqual(
+            ['host1', 'host1', 'host1', 'host1', 'host2', 'host2', 'host2', 'host2'],
+            ecl_run.make_LSB_MCPU_machine_list("host1 4 host2 4")
+        )
+
     @tmpdir()
     def test_create(self):
         # This test can make do with a mock simulator; - just something executable


### PR DESCRIPTION
**Issue**
Resolves #922 


**Approach**
Use explicit integer division when creating cpu list 
