### PR TITLE
Slurm driver

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -104,6 +104,7 @@ add_library(res res_util/res_log.cpp
                 job_queue/lsf_driver.cpp
                 job_queue/queue_driver.cpp
                 job_queue/rsh_driver.cpp
+                job_queue/slurm_driver.cpp
                 job_queue/torque_driver.cpp
                 job_queue/workflow.cpp
                 job_queue/workflow_job.cpp
@@ -452,6 +453,7 @@ foreach(name job_status_test
              job_lsf_parse_bsub_stdout
              job_lsf_test
              job_queue_driver_test
+             job_slurm_driver
              job_torque_test
              job_queue_manager)
 

--- a/lib/enkf/queue_config.cpp
+++ b/lib/enkf/queue_config.cpp
@@ -27,6 +27,7 @@
 #include <ert/job_queue/lsf_driver.hpp>
 #include <ert/job_queue/rsh_driver.hpp>
 #include <ert/job_queue/local_driver.hpp>
+#include <ert/job_queue/slurm_driver.hpp>
 #include <ert/job_queue/queue_driver.hpp>
 
 #include <ert/config/config_parser.hpp>
@@ -182,6 +183,8 @@ const char * queue_config_get_queue_system(const queue_config_type * queue_confi
             return LOCAL_DRIVER_NAME;
         case TORQUE_DRIVER:
             return TORQUE_DRIVER_NAME;
+        case SLURM_DRIVER:
+            return SLURM_DRIVER_NAME;
         default:
             return NULL;
     }
@@ -255,6 +258,7 @@ void queue_config_create_queue_drivers(queue_config_type * queue_config) {
   queue_config_add_queue_driver(queue_config, TORQUE_DRIVER_NAME, queue_driver_alloc_TORQUE());
   queue_config_add_queue_driver(queue_config, RSH_DRIVER_NAME, queue_driver_alloc_RSH(NULL, NULL));
   queue_config_add_queue_driver(queue_config, LOCAL_DRIVER_NAME, queue_driver_alloc_local());
+  queue_config_add_queue_driver(queue_config, SLURM_DRIVER_NAME, queue_driver_alloc_slurm());
 }
 
 
@@ -281,6 +285,8 @@ static bool queue_config_init(queue_config_type * queue_config, const config_con
       queue_config->driver_type = LOCAL_DRIVER;
     else if (strcmp(queue_system, TORQUE_DRIVER_NAME) == 0)
       queue_config->driver_type = TORQUE_DRIVER;
+    else if (strcmp(queue_system, SLURM_DRIVER_NAME) == 0)
+      queue_config->driver_type = SLURM_DRIVER;
     else {
       util_abort("%s: queue system :%s not recognized \n", __func__, queue_system);
       queue_config->driver_type = NULL_DRIVER;

--- a/lib/include/ert/enkf/queue_config.hpp
+++ b/lib/include/ert/enkf/queue_config.hpp
@@ -34,6 +34,7 @@ extern "C" {
 #define LOCAL_DRIVER_NAME  "LOCAL"
 #define RSH_DRIVER_NAME    "RSH"
 #define TORQUE_DRIVER_NAME "TORQUE"
+#define SLURM_DRIVER_NAME  "SLURM"
 
 
 typedef struct queue_config_struct queue_config_type;

--- a/lib/include/ert/job_queue/queue_driver.hpp
+++ b/lib/include/ert/job_queue/queue_driver.hpp
@@ -59,6 +59,7 @@ extern "C" {
   queue_driver_type * queue_driver_alloc_LSF(const char * queue_name, const char * resource_request, const char * remote_lsf_server);
   queue_driver_type * queue_driver_alloc_TORQUE();
   queue_driver_type * queue_driver_alloc_local();
+  queue_driver_type * queue_driver_alloc_slurm();
   queue_driver_type * queue_driver_alloc(job_driver_type type);
 
   void * queue_driver_submit_job(queue_driver_type * driver, const char * run_cmd, int num_cpu, const char * run_path, const char * job_name, int argc, const char ** argv);

--- a/lib/include/ert/job_queue/queue_driver.hpp
+++ b/lib/include/ert/job_queue/queue_driver.hpp
@@ -30,7 +30,8 @@ extern "C" {
     LSF_DRIVER = 1,
     LOCAL_DRIVER = 2,
     RSH_DRIVER = 3,
-    TORQUE_DRIVER = 4
+    TORQUE_DRIVER = 4,
+    SLURM_DRIVER = 5
   } job_driver_type;
 
 #define JOB_DRIVER_ENUM_SIZE 5

--- a/lib/include/ert/job_queue/slurm_driver.hpp
+++ b/lib/include/ert/job_queue/slurm_driver.hpp
@@ -1,0 +1,62 @@
+/*
+   Copyright (C) 2020  Equinor ASA, Norway.
+
+   The file 'slurm_driver.hpp' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#ifndef ERT_SLURM_DRIVER_H
+#define ERT_SLURM_DRIVER_H
+
+
+#include <ert/util/type_macros.h>
+#include <ert/util/stringlist.hpp>
+
+#include <ert/job_queue/job_status.hpp>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+  The options supported by the Slurm driver; these string constants will be used
+  in the user configuration file - i.e. they are very much part of API and
+  remain stable.
+*/
+
+#define SLURM_SBATCH_OPTION  "SBATCH"
+#define SLURM_SCANCEL_OPTION "SCANCEL"
+#define SLURM_SCONTROL_OPTION   "SCONTROL"
+#define SLURM_SQUEUE_OPTION  "SQUEUE"
+
+
+typedef struct slurm_driver_struct slurm_driver_type;
+typedef struct slurm_job_struct    slurm_job_type;
+
+  void *          slurm_driver_alloc();
+  void            slurm_driver_free(slurm_driver_type * driver);
+  void            slurm_driver_free__(void * __driver );
+  const  void   * slurm_driver_get_option( const void * __driver, const char * option_key);
+  bool            slurm_driver_set_option( void * __driver, const char * option_key, const void * value);
+  void            slurm_driver_init_option_list(stringlist_type * option_list);
+  void          * slurm_driver_submit_job( void * __driver, const char * cmd, int num_cpu, const char * run_path, const char * job_name, int argc, const char ** argv);
+  job_status_type slurm_driver_get_job_status(void * __driver , void * __job);
+  void            slurm_driver_kill_job(void * __driver , void * __job );
+  void            slurm_driver_free_job(void * __job);
+
+  UTIL_SAFE_CAST_HEADER( slurm_driver );
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/lib/job_queue/queue_driver.cpp
+++ b/lib/job_queue/queue_driver.cpp
@@ -365,6 +365,11 @@ queue_driver_type * queue_driver_alloc_local() {
   return driver;
 }
 
+queue_driver_type * queue_driver_alloc_slurm() {
+    queue_driver_type * driver = queue_driver_alloc(SLURM_DRIVER);
+    return driver;
+}
+
 /* These are the functions used by the job_queue layer. */
 
 void * queue_driver_submit_job(queue_driver_type * driver, const char * run_cmd, int num_cpu, const char * run_path, const char * job_name, int argc, const char ** argv) {

--- a/lib/job_queue/queue_driver.cpp
+++ b/lib/job_queue/queue_driver.cpp
@@ -28,6 +28,7 @@
 #include <ert/job_queue/local_driver.hpp>
 #include <ert/job_queue/rsh_driver.hpp>
 #include <ert/job_queue/torque_driver.hpp>
+#include <ert/job_queue/slurm_driver.hpp>
 
 
 /**
@@ -279,6 +280,18 @@ queue_driver_type * queue_driver_alloc(job_driver_type type) {
       driver->name = util_alloc_string_copy("TORQUE");
       driver->init_options = torque_driver_init_option_list;
       driver->data = torque_driver_alloc();
+      break;
+    case SLURM_DRIVER:
+      driver->name = util_alloc_string_copy("SLURM");
+      driver->set_option = slurm_driver_set_option;
+      driver->get_option = slurm_driver_get_option;
+      driver->init_options = slurm_driver_init_option_list;
+      driver->free_driver = slurm_driver_free__;
+      driver->kill_job = slurm_driver_kill_job;
+      driver->free_job = slurm_driver_free_job;
+      driver->submit = slurm_driver_submit_job;
+      driver->get_status = slurm_driver_get_job_status;
+      driver->data = slurm_driver_alloc();
       break;
     default:
       util_abort("%s: unrecognized driver type:%d \n", __func__, type);

--- a/lib/job_queue/slurm_driver.cpp
+++ b/lib/job_queue/slurm_driver.cpp
@@ -1,0 +1,153 @@
+/*
+   Copyright (C) 2020  Equinor ASA, Norway.
+
+   The file 'slurm_driver.cpp' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
+#include <dlfcn.h>
+#include <unistd.h>
+
+#include <string>
+
+#include <ert/util/util.hpp>
+#include <ert/util/stringlist.hpp>
+#include <ert/res_util/log.hpp>
+#include <ert/res_util/res_log.hpp>
+#include <ert/res_util/res_env.hpp>
+
+#include <ert/job_queue/queue_driver.hpp>
+#include <ert/job_queue/slurm_driver.hpp>
+
+
+class SlurmJob {
+};
+
+
+#define SLURM_DRIVER_TYPE_ID  70555081
+#define DEFAULT_SBATCH_CMD    "sbatch"
+#define DEFAULT_SCANCEL_CMD   "scancel"
+#define DEFAULT_SCONTROL_CMD     "scontrol"
+#define DEFAULT_SQUEUE_CMD    "sqeueue"
+
+struct slurm_driver_struct {
+  UTIL_TYPE_ID_DECLARATION;
+
+  std::string sbatch_cmd;
+  std::string scancel_cmd;
+  std::string squeue_cmd;
+  std::string scontrol_cmd;
+};
+
+
+UTIL_SAFE_CAST_FUNCTION( slurm_driver , SLURM_DRIVER_TYPE_ID)
+static UTIL_SAFE_CAST_FUNCTION_CONST( slurm_driver , SLURM_DRIVER_TYPE_ID)
+
+void * slurm_driver_alloc() {
+  slurm_driver_type * driver = new slurm_driver_type();
+  UTIL_TYPE_ID_INIT(driver, SLURM_DRIVER_TYPE_ID);
+  driver->sbatch_cmd = DEFAULT_SBATCH_CMD;
+  driver->scancel_cmd = DEFAULT_SCANCEL_CMD;
+  driver->squeue_cmd = DEFAULT_SQUEUE_CMD;
+  driver->scontrol_cmd = DEFAULT_SCONTROL_CMD;
+  return driver;
+}
+
+void slurm_driver_free(slurm_driver_type * driver) {
+  delete driver;
+}
+
+void slurm_driver_free__(void * __driver ) {
+  slurm_driver_type * driver = slurm_driver_safe_cast( __driver );
+  slurm_driver_free( driver );
+}
+
+
+const void * slurm_driver_get_option( const void * __driver, const char * option_key) {
+  const slurm_driver_type * driver = slurm_driver_safe_cast_const( __driver );
+  if (strcmp(option_key, SLURM_SBATCH_OPTION) == 0)
+    return driver->sbatch_cmd.c_str();
+
+  if (strcmp(option_key, SLURM_SCANCEL_OPTION) == 0)
+    return driver->scancel_cmd.c_str();
+
+  if (strcmp(option_key, SLURM_SCONTROL_OPTION) == 0)
+    return driver->scontrol_cmd.c_str();
+
+  if (strcmp(option_key, SLURM_SQUEUE_OPTION) == 0)
+    return driver->squeue_cmd.c_str();
+
+  return nullptr;
+}
+
+
+bool slurm_driver_set_option( void * __driver, const char * option_key, const void * value) {
+  slurm_driver_type * driver = slurm_driver_safe_cast( __driver );
+  if (strcmp(option_key, SLURM_SBATCH_OPTION) == 0) {
+    driver->sbatch_cmd = static_cast<const char*>(value);
+    return true;
+  }
+
+  if (strcmp(option_key, SLURM_SCANCEL_OPTION) == 0) {
+    driver->scancel_cmd = static_cast<const char*>(value);
+    return true;
+  }
+
+  if (strcmp(option_key, SLURM_SQUEUE_OPTION) == 0) {
+    driver->squeue_cmd = static_cast<const char*>(value);
+    return true;
+  }
+
+  if (strcmp(option_key, SLURM_SCONTROL_OPTION) == 0) {
+    driver->scontrol_cmd = static_cast<const char*>(value);
+    return true;
+  }
+
+  return false;
+}
+
+
+void slurm_driver_init_option_list(stringlist_type * option_list) {
+  stringlist_append_copy(option_list, SLURM_SBATCH_OPTION);
+  stringlist_append_copy(option_list, SLURM_SCONTROL_OPTION);
+  stringlist_append_copy(option_list, SLURM_SQUEUE_OPTION);
+  stringlist_append_copy(option_list, SLURM_SCANCEL_OPTION);
+}
+
+
+void * slurm_driver_submit_job( void * __driver, const char * cmd, int num_cpu, const char * run_path, const char * job_name, int argc, const char ** argv) {
+  slurm_driver_type * driver = slurm_driver_safe_cast( __driver );
+  SlurmJob * job = nullptr;
+  return job;
+}
+
+
+job_status_type slurm_driver_get_job_status(void * __driver , void * __job) {
+  slurm_driver_type * driver = slurm_driver_safe_cast( __driver );
+  return JOB_QUEUE_PENDING;
+}
+
+
+void slurm_driver_kill_job(void * __driver , void * __job ) {
+  slurm_driver_type * driver = slurm_driver_safe_cast( __driver );
+}
+
+void slurm_driver_free_job(void * __job) {
+  SlurmJob * job = static_cast<SlurmJob *>(__job);
+  delete job;
+}

--- a/lib/job_queue/tests/job_queue_driver_test.cpp
+++ b/lib/job_queue/tests/job_queue_driver_test.cpp
@@ -27,6 +27,7 @@
 
 #include <ert/job_queue/torque_driver.hpp>
 #include <ert/job_queue/rsh_driver.hpp>
+#include <ert/job_queue/slurm_driver.hpp>
 
 
 void job_queue_set_driver_(job_driver_type driver_type) {
@@ -151,6 +152,24 @@ void get_driver_option_lists() {
     stringlist_free(option_list);
     queue_driver_free(driver_rsh);
   }
+
+
+  //SLurm driver option list
+  {
+    queue_driver_type * driver_slurm = queue_driver_alloc(SLURM_DRIVER);
+    stringlist_type * option_list = stringlist_alloc_new();
+    queue_driver_init_option_list(driver_slurm, option_list);
+
+    test_assert_true(stringlist_contains(option_list, MAX_RUNNING));
+    test_assert_true(stringlist_contains(option_list, SLURM_SBATCH_OPTION));
+    test_assert_true(stringlist_contains(option_list, SLURM_SCONTROL_OPTION));
+    test_assert_true(stringlist_contains(option_list, SLURM_SQUEUE_OPTION));
+    test_assert_true(stringlist_contains(option_list, SLURM_SCANCEL_OPTION));
+
+    stringlist_free(option_list);
+    queue_driver_free(driver_slurm);
+
+  }
 }
 
 int main(int argc, char ** argv) {
@@ -158,6 +177,7 @@ int main(int argc, char ** argv) {
   job_queue_set_driver_(LOCAL_DRIVER);
   job_queue_set_driver_(RSH_DRIVER);
   job_queue_set_driver_(TORQUE_DRIVER);
+  job_queue_set_driver_(SLURM_DRIVER);
 
   set_option_max_running_max_running_value_set();
   set_option_max_running_max_running_option_set();

--- a/lib/job_queue/tests/job_slurm_driver.cpp
+++ b/lib/job_queue/tests/job_slurm_driver.cpp
@@ -1,0 +1,49 @@
+/*
+   Copyright (C) 2020  Equinor ASA, Norway.
+
+   The file 'slurm_driver.c' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <ert/util/test_util.hpp>
+#include <ert/util/util.hpp>
+
+#include <ert/job_queue/slurm_driver.hpp>
+
+
+void test_option(slurm_driver_type * driver , const char * option , const char * value) {
+  test_assert_true( slurm_driver_set_option( driver , option , value));
+  test_assert_string_equal((const char *) slurm_driver_get_option( driver , option) , value);
+}
+
+
+
+void test_options() {
+  slurm_driver_type * driver = (slurm_driver_type *) slurm_driver_alloc();
+  test_option(driver, SLURM_SBATCH_OPTION, "my_funny_sbatch");
+  test_option(driver, SLURM_SCANCEL_OPTION, "my_funny_scancel");
+  test_option(driver, SLURM_SQUEUE_OPTION, "my_funny_squeue");
+  test_option(driver, SLURM_SCONTROL_OPTION, "my_funny_scontrol");
+  test_assert_false( slurm_driver_set_option(driver, "NO_SUCH_OPTION", "Value"));
+  slurm_driver_free( driver );
+}
+
+
+int main( int argc , char ** argv) {
+  test_options();
+  exit(0);
+}

--- a/python/res/job_queue/driver.py
+++ b/python/res/job_queue/driver.py
@@ -28,18 +28,20 @@ class QueueDriverEnum(BaseCEnum):
     LOCAL_DRIVER = None
     RSH_DRIVER = None
     TORQUE_DRIVER = None
+    SLURM_DRIVER = None
 
 QueueDriverEnum.addEnum( "NULL_DRIVER" , 0 )
 QueueDriverEnum.addEnum( "LSF_DRIVER" , 1 )
 QueueDriverEnum.addEnum( "LOCAL_DRIVER" , 2 )
 QueueDriverEnum.addEnum( "RSH_DRIVER" , 3 )
 QueueDriverEnum.addEnum( "TORQUE_DRIVER" , 4 )
+QueueDriverEnum.addEnum( "SLURM_DRIVER" , 5 )
 
 
 LSF_DRIVER   = QueueDriverEnum.LSF_DRIVER
 RSH_DRIVER   = QueueDriverEnum.RSH_DRIVER
 LOCAL_DRIVER = QueueDriverEnum.LOCAL_DRIVER
-
+SLURM_DRIVER = QueueDriverEnum.SLURM_DRIVER
 
 
 class Driver(BaseCClass):
@@ -143,5 +145,4 @@ class RSHDriver(Driver):
         for (host, host_max) in rsh_host_list:
             options.append(("RSH_HOST", "%s:%d" % (host, host_max)))
         Driver.__init__(self, QueueDriverEnum.RSH_DRIVER, max_running, options=options)
-
 

--- a/python/tests/res/enkf/test_queue_config.py
+++ b/python/tests/res/enkf/test_queue_config.py
@@ -65,3 +65,16 @@ class QueueConfigTest(ResTest):
             queue_config_file = QueueConfig(user_config_file=config_file)
             queue_config_dict = QueueConfig(config_dict=config_dict)
             self.assertEqual(queue_config_dict, queue_config_file)
+
+    def test_get_slurm_queue_config(self):
+        with TestAreaContext("queue_config_slurm_test") as work_area:
+            work_area.copy_directory(self.case_directory)
+
+            config_file = "simple_config/slurm_config"
+            queue_config = QueueConfig(config_file)
+            self.assertEqual(queue_config.queue_system, "SLURM")
+
+            driver = queue_config.driver
+            self.assertEqual(driver.get_option("SBATCH"), "/path/to/sbatch")
+            self.assertEqual(driver.get_option("SCONTROL"), "scontrol")
+            self.assertEqual(driver.name, "SLURM")

--- a/test-data/local/simple_config/slurm_config
+++ b/test-data/local/simple_config/slurm_config
@@ -1,0 +1,14 @@
+JOBNAME  Job%d
+RUNPATH /tmp/simulations/run%d
+NUM_REALIZATIONS 10
+MIN_REALIZATIONS 10
+JOB_SCRIPT script.sh
+QUEUE_SYSTEM SLURM
+QUEUE_OPTION SLURM MAX_RUNNING 50
+QUEUE_OPTION SLURM SBATCH /path/to/sbatch
+QUEUE_OPTION SLURM SQUEUE /path/to/squeue
+
+
+
+-- This is not strictly necessary, a sensible default will be used if not given.
+ENSPATH  Ensemble


### PR DESCRIPTION
**Issue**
Resolves #940 

~~This PR is on top of the micro PR: #939~~ 

With this PR a slurm driver "class" is implemented, the driver is integrated in the main libres/ert queue system, it can be chosen and configured - but it will not work. Every submit attempt will return `nullptr` which implies submit failure.

With this PR the changes "all over the place" should be complete, and the remaining part of the work - actually getting this to do something sensible, should be be fully contained in the new `slurm_driver.cpp`file.


**Question**: The two space indent which is used in C/C++ code of libres is a bit weird (yes I know ....); I could use e.g. four spaces for the new files? Unless explicitly told otherwise I will stick to two spaces.