### PR TITLE
Part 1: Slurm driver submit and cancel

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -454,6 +454,7 @@ foreach(name job_status_test
              job_lsf_test
              job_queue_driver_test
              job_slurm_driver
+             job_mock_slurm
              job_torque_test
              job_queue_manager)
 
@@ -462,6 +463,17 @@ foreach(name job_status_test
     target_link_libraries(${name} res)
     add_test(NAME ${name} COMMAND ${name})
 endforeach()
+
+find_program(SBATCH "sbatch")
+foreach(name job_slurm_submit)
+  add_executable(${name} job_queue/tests/${name}.cpp)
+  target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/private-include)
+  target_link_libraries(${name} res)
+  if (SBATCH)
+    add_test(NAME ${name} COMMAND ${name})
+  endif()
+endforeach()
+
 
 foreach(name job_loadOK
              ext_joblist_test

--- a/lib/include/ert/job_queue/slurm_driver.hpp
+++ b/lib/include/ert/job_queue/slurm_driver.hpp
@@ -38,7 +38,7 @@ extern "C" {
 #define SLURM_SCANCEL_OPTION "SCANCEL"
 #define SLURM_SCONTROL_OPTION   "SCONTROL"
 #define SLURM_SQUEUE_OPTION  "SQUEUE"
-
+#define SLURM_PARTITION_OPTION "PARTITION"
 
 typedef struct slurm_driver_struct slurm_driver_type;
 typedef struct slurm_job_struct    slurm_job_type;

--- a/lib/job_queue/slurm_driver.cpp
+++ b/lib/job_queue/slurm_driver.cpp
@@ -52,6 +52,7 @@ struct slurm_driver_struct {
   std::string scancel_cmd;
   std::string squeue_cmd;
   std::string scontrol_cmd;
+  std::string partition;
 };
 
 
@@ -92,6 +93,9 @@ const void * slurm_driver_get_option( const void * __driver, const char * option
   if (strcmp(option_key, SLURM_SQUEUE_OPTION) == 0)
     return driver->squeue_cmd.c_str();
 
+  if (strcmp(option_key, SLURM_PARTITION_OPTION) == 0)
+    return driver->partition.c_str();
+
   return nullptr;
 }
 
@@ -118,11 +122,17 @@ bool slurm_driver_set_option( void * __driver, const char * option_key, const vo
     return true;
   }
 
+  if (strcmp(option_key, SLURM_PARTITION_OPTION) == 0) {
+    driver->partition = static_cast<const char*>(value);
+    return true;
+  }
+
   return false;
 }
 
 
 void slurm_driver_init_option_list(stringlist_type * option_list) {
+  stringlist_append_copy(option_list, SLURM_PARTITION_OPTION);
   stringlist_append_copy(option_list, SLURM_SBATCH_OPTION);
   stringlist_append_copy(option_list, SLURM_SCONTROL_OPTION);
   stringlist_append_copy(option_list, SLURM_SQUEUE_OPTION);

--- a/lib/job_queue/tests/job_mock_slurm.cpp
+++ b/lib/job_queue/tests/job_mock_slurm.cpp
@@ -1,0 +1,34 @@
+/*
+   Copyright (C) 2020  Equinor ASA, Norway.
+
+   The file 'job_mock_slurm.cpp' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <ert/util/test_util.hpp>
+#include <ert/util/util.hpp>
+#include <ert/util/test_work_area.hpp>
+
+#include <ert/job_queue/slurm_driver.hpp>
+
+
+
+
+int main( int argc , char ** argv) {
+  ecl::util::TestArea ta("slurm_mock", true);
+  exit(0);
+}

--- a/lib/job_queue/tests/job_queue_driver_test.cpp
+++ b/lib/job_queue/tests/job_queue_driver_test.cpp
@@ -165,6 +165,7 @@ void get_driver_option_lists() {
     test_assert_true(stringlist_contains(option_list, SLURM_SCONTROL_OPTION));
     test_assert_true(stringlist_contains(option_list, SLURM_SQUEUE_OPTION));
     test_assert_true(stringlist_contains(option_list, SLURM_SCANCEL_OPTION));
+    test_assert_true(stringlist_contains(option_list, SLURM_PARTITION_OPTION));
 
     stringlist_free(option_list);
     queue_driver_free(driver_slurm);

--- a/lib/job_queue/tests/job_slurm_driver.cpp
+++ b/lib/job_queue/tests/job_slurm_driver.cpp
@@ -34,6 +34,7 @@ void test_option(slurm_driver_type * driver , const char * option , const char *
 
 void test_options() {
   slurm_driver_type * driver = (slurm_driver_type *) slurm_driver_alloc();
+  test_option(driver, SLURM_PARTITION_OPTION, "my_partition");
   test_option(driver, SLURM_SBATCH_OPTION, "my_funny_sbatch");
   test_option(driver, SLURM_SCANCEL_OPTION, "my_funny_scancel");
   test_option(driver, SLURM_SQUEUE_OPTION, "my_funny_squeue");

--- a/lib/job_queue/tests/job_slurm_submit.cpp
+++ b/lib/job_queue/tests/job_slurm_submit.cpp
@@ -1,0 +1,74 @@
+/*
+   Copyright (C) 2020  Equinor ASA, Norway.
+
+   The file 'job_slurm_runtest.cpp' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#include <vector>
+
+#include <ert/util/test_util.hpp>
+#include <ert/util/util.hpp>
+#include <ert/util/test_work_area.hpp>
+
+#include <ert/job_queue/queue_driver.hpp>
+#include <ert/job_queue/slurm_driver.hpp>
+
+void make_sleep_job(const char * fname, int sleep_time) {
+  FILE * stream = util_fopen(fname, "w");
+  fprintf(stream, "sleep %d \n", sleep_time);
+  fclose(stream);
+
+  mode_t fmode = S_IRWXU;
+  chmod( fname, fmode);
+}
+
+
+
+void submit_job(queue_driver_type * driver, const ecl::util::TestArea& ta, const std::string& job_name, const char* cmd, bool expect_fail) {
+  std::string run_path = ta.test_cwd() + "/" + job_name;
+  util_make_path(run_path.c_str());
+  auto job = queue_driver_submit_job(driver, cmd, 1, run_path.c_str(), job_name.c_str(), 0, nullptr);
+  if (expect_fail)
+    test_assert_NULL( job );
+  else {
+    test_assert_not_NULL( job );
+    queue_driver_kill_job(driver, job);
+    queue_driver_free_job(driver, job);
+  }
+}
+
+
+
+void run() {
+  ecl::util::TestArea ta("slurm_submit", true);
+  queue_driver_type * driver = queue_driver_alloc_slurm();
+  const char * cmd = util_alloc_abs_path("cmd.sh");
+
+  make_sleep_job(cmd, 10);
+  submit_job(driver, ta, "JOB1", cmd, false);
+  queue_driver_set_option(driver, SLURM_PARTITION_OPTION, "invalid_partition");
+  submit_job(driver, ta, "JOB1", cmd, true);
+
+  queue_driver_free(driver);
+}
+
+
+int main( int argc , char ** argv) {
+  run();
+}


### PR DESCRIPTION
**Issue**
Part of #938

This is the next PR in the series of slurm drivers and should be merged before #944 


**Approach**
In this PR slurm_driver function to submit a job and to subsequently cancel it again are added. The functions are based on calling the external programs `sbatch` and `scancel`.

As part of the PR a new block in the `CMakeLists.txt` is created which is condition on finding the `sbatch` executable - i.e. whether the machine we are running on is indeed part of a slurm cluster. If the machine is not part of a slurm cluster the tests are built anyway - but not run.