### PR TITLE
Part3: Slurm driver mpi

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -465,7 +465,8 @@ foreach(name job_status_test
 endforeach()
 
 find_program(SBATCH "sbatch")
-foreach(name job_slurm_submit)
+foreach(name job_slurm_submit
+             job_slurm_runtest)
   add_executable(${name} job_queue/tests/${name}.cpp)
   target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/private-include)
   target_link_libraries(${name} res)
@@ -539,16 +540,33 @@ add_test(NAME job_queue_test
 set_tests_properties(job_queue_test PROPERTIES LABELS "SLOW_1")
 
 
-add_test(NAME job_queue_stress_test
+add_test(NAME job_queue_stress_test_LOCAL
          COMMAND job_queue_stress_test
                  $<TARGET_FILE:job_queue_stress_task>
+                 LOCAL
                  False)
-set_tests_properties(job_queue_stress_test PROPERTIES LABELS "SLOW_1")
+set_tests_properties(job_queue_stress_test_LOCAL PROPERTIES LABELS "SLOW_1")
 
-add_test(NAME job_queue_user_exit
+add_test(NAME job_queue_user_exit_LOCAL
          COMMAND job_queue_stress_test
                  $<TARGET_FILE:job_queue_stress_task>
+                 LOCAL
                  True)
+
+if (SBATCH)
+  add_test(NAME job_queue_stress_test_SLURM
+    COMMAND job_queue_stress_test
+    $<TARGET_FILE:job_queue_stress_task>
+    SLURM
+    False)
+  set_tests_properties(job_queue_stress_test_SLURM PROPERTIES LABELS "SLOW_1")
+
+  add_test(NAME job_queue_user_exit_SLURM
+    COMMAND job_queue_stress_test
+    $<TARGET_FILE:job_queue_stress_task>
+    SLURM
+    True)
+endif()
 
 add_test(NAME job_queue_timeout_test
          COMMAND job_queue_timeout_test $<TARGET_FILE:job_queue_stress_task>)

--- a/lib/include/ert/job_queue/slurm_driver.hpp
+++ b/lib/include/ert/job_queue/slurm_driver.hpp
@@ -39,6 +39,7 @@ extern "C" {
 #define SLURM_SCONTROL_OPTION   "SCONTROL"
 #define SLURM_SQUEUE_OPTION  "SQUEUE"
 #define SLURM_PARTITION_OPTION "PARTITION"
+#define SLURM_SQUEUE_TIMEOUT_OPTION "SQUEUE_TIMEOUT"
 
 typedef struct slurm_driver_struct slurm_driver_type;
 typedef struct slurm_job_struct    slurm_job_type;

--- a/lib/job_queue/slurm_driver.cpp
+++ b/lib/job_queue/slurm_driver.cpp
@@ -305,12 +305,18 @@ void slurm_driver_init_option_list(stringlist_type * option_list) {
   stringlist_append_copy(option_list, SLURM_SQUEUE_TIMEOUT_OPTION);
 }
 
-
+/*
+  Slurm allows very fine control over how a parallel job should be distributed
+  over available nodes and CPUs, the current approach is an absolutely simplest
+  way - where we just say how many processors we will need in total with the
+  --ntasks=$num_cpu setting.
+*/
 static std::string make_submit_script(const char * cmd, int num_cpu, int argc, const char ** argv) {
   char * submit        = (char*) util_alloc_tmp_file("/tmp" , "slurm-submit" , true);
 
   FILE * submit_stream = util_fopen(submit, "w");
   fprintf(submit_stream, "#!/bin/sh\n");
+  fprintf(submit_stream, "#SBATCH --ntasks=%d\n", num_cpu);
 
   fprintf(submit_stream, "%s", cmd);  // Without srun?
   for (int iarg=0; iarg < argc; iarg++)

--- a/lib/job_queue/tests/job_mock_slurm.cpp
+++ b/lib/job_queue/tests/job_mock_slurm.cpp
@@ -16,6 +16,8 @@
    for more details.
 */
 
+#include <vector>
+
 #include <stdlib.h>
 #include <stdbool.h>
 
@@ -24,11 +26,250 @@
 #include <ert/util/test_work_area.hpp>
 
 #include <ert/job_queue/slurm_driver.hpp>
+#include <ert/job_queue/queue_driver.hpp>
+
+
+/*
+  This test tests the interaction between slurm and libres by using mock scripts
+  for slurm functionality. The scripts are very simple, and just return suitable
+  "results" on stdout which the slurm driver in libres interprets. Observe that
+  this testing is 100% stateless and does not invoke running external "jobs" in
+  any kind.
+
+  The different jobs have different behaviour based on the the job name; the
+  names are just the strings "0", "1", "2", "3" and "4". The behaviour of the
+  different job is as follows:
+
+  0: The sbatch command fails with exit != 0 when this job is started. The test
+     verifies that the queue_driver_submit_job() returns nullptr, and after that
+     we do not hear naything more from this job.
+
+  1: This job is submitted as it should, but then subsequently cancelled. The
+     cancel script actually does not do anything, but afterwards we test that
+     the status is correctly returned. Before the CANCELLED status is reached we
+     go through two steps:
+
+     a) We run the squeue command, that does not report on cancelled jobs and
+        will not report status for job 1.
+
+     b) We run the scontrol command which through a detailed request finds the
+        cancelled status of the job.
+
+  2: / 3: These jobs are PENDING and RUNNING respoectively, that status is
+     reported by the squeue command.
+
+  4: This job has been completed. As with the canceled job 1 we need to go
+     through both squeue and scontrol before we get the status of the job.
+
+*/
+
+
+void make_sleep_job(const char * fname, int sleep_time) {
+  FILE * stream = util_fopen(fname, "w");
+  fprintf(stream, "sleep %d \n", sleep_time);
+  fclose(stream);
+
+  mode_t fmode = S_IRWXU;
+  chmod( fname, fmode);
+}
+
+void make_script(const char* fname, const std::string& content) {
+  FILE * stream = util_fopen(fname, "w");
+  fprintf(stream, "%s" , content.c_str());
+  fclose(stream);
+
+  mode_t fmode = S_IRWXU;
+  chmod( fname, fmode);
+}
+
+
+void install_script(queue_driver_type * driver, const char * option, const std::string& content) {
+  char * fname = util_alloc_abs_path( option );
+  make_script(fname, content);
+  queue_driver_set_option(driver, option, fname);
+  free( fname );
+}
+
+
+void make_slurm_commands(queue_driver_type * driver) {
+  std::string sbatch = R"(#!/bin/bash
+
+if [ $2 = "--job-name=0" ]; then
+   exit 1
+fi
+
+if [ $2 = "--job-name=1" ]; then
+   echo 1
+fi
+
+if [ $2 = "--job-name=2" ]; then
+   echo 2
+fi
+
+if [ $2 = "--job-name=3" ]; then
+   echo 3
+fi
+
+if [ $2 = "--job-name=4" ]; then
+   echo 4
+fi
+)";
+
+
+  std::string scancel = R"(#!/bin/bash
+
+exit 0
+)";
+
+
+  std::string scontrol = R"(#!/bin/bash
+if [ $3 = "1" ]; then
+cat <<EOF
+   UserId=user(777) GroupId=group(888) MCS_label=N/A
+   Priority=4294901494 Nice=0 Account=(null) QOS=(null)
+   JobState=CANCELLED Reason=None Dependency=(null)
+   Requeue=1 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0
+   RunTime=00:00:22 TimeLimit=UNLIMITED TimeMin=N/A
+   SubmitTime=2020-06-08T19:43:54 EligibleTime=2020-06-08T19:43:54
+   AccrueTime=Unknown
+   StartTime=2020-06-08T19:43:55 EndTime=Unknown Deadline=N/A
+   PreemptTime=None SuspendTime=None SecsPreSuspend=0
+   LastSchedEval=2020-06-08T19:43:55
+   Partition=debug AllocNode:Sid=ws:13314
+   ReqNodeList=(null) ExcNodeList=(null)
+   NodeList=ws
+   BatchHost=ws
+   NumNodes=1 NumCPUs=1 NumTasks=1 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
+   TRES=cpu=1,node=1,billing=1
+   Socks/Node=* NtasksPerN:B:S:C=0:0:*:* CoreSpec=*
+   MinCPUsNode=1 MinMemoryNode=0 MinTmpDiskNode=0
+   Features=(null) DelayBoot=00:00:00
+   OverSubscribe=OK Contiguous=0 Licenses=(null) Network=(null)
+   Command=/tmp/flow.sh
+   WorkDir=/home/user/work/ERT/libres/build
+   StdErr=/home/user/work/ERT/libres/build/slurm-7625.out
+   StdIn=/dev/null
+   StdOut=/home/user/work/ERT/libres/build/slurm-7625.out
+   Power=
+
+EOF
+fi
+
+if [ $3 = "4" ]; then
+cat <<EOF
+   UserId=user(777) GroupId=group(888) MCS_label=N/A
+   Priority=4294901494 Nice=0 Account=(null) QOS=(null)
+   JobState=COMPLETED Reason=None Dependency=(null)
+   Requeue=1 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0
+   RunTime=00:00:22 TimeLimit=UNLIMITED TimeMin=N/A
+   SubmitTime=2020-06-08T19:43:54 EligibleTime=2020-06-08T19:43:54
+   AccrueTime=Unknown
+   StartTime=2020-06-08T19:43:55 EndTime=Unknown Deadline=N/A
+   PreemptTime=None SuspendTime=None SecsPreSuspend=0
+   LastSchedEval=2020-06-08T19:43:55
+   Partition=debug AllocNode:Sid=ws:13314
+   ReqNodeList=(null) ExcNodeList=(null)
+   NodeList=ws
+   BatchHost=ws
+   NumNodes=1 NumCPUs=1 NumTasks=1 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
+   TRES=cpu=1,node=1,billing=1
+   Socks/Node=* NtasksPerN:B:S:C=0:0:*:* CoreSpec=*
+   MinCPUsNode=1 MinMemoryNode=0 MinTmpDiskNode=0
+   Features=(null) DelayBoot=00:00:00
+   OverSubscribe=OK Contiguous=0 Licenses=(null) Network=(null)
+   Command=/tmp/flow.sh
+   WorkDir=/home/user/work/ERT/libres/build
+   StdErr=/home/user/work/ERT/libres/build/slurm-7625.out
+   StdIn=/dev/null
+   StdOut=/home/user/work/ERT/libres/build/slurm-7625.out
+   Power=
+
+EOF
+fi
+
+)";
+
+
+  std::string squeue = R"(#!/bin/bash
+echo "2 PENDING"
+echo "3 RUNNING"
+)";
+
+  install_script( driver, SLURM_SBATCH_OPTION, sbatch );
+  install_script( driver, SLURM_SCANCEL_OPTION, scancel );
+  install_script( driver, SLURM_SCONTROL_OPTION, scontrol);
+  install_script( driver, SLURM_SQUEUE_OPTION, squeue);
+}
+
+
+
+void * submit_job(queue_driver_type * driver, const ecl::util::TestArea& ta, const std::string& job_name, const char* cmd) {
+  std::string run_path = ta.test_cwd() + "/" + job_name;
+  util_make_path(run_path.c_str());
+  return queue_driver_submit_job(driver, cmd, 1, run_path.c_str(), job_name.c_str(), 0, nullptr);
+}
+
+
+
+void run() {
+  ecl::util::TestArea ta("slurm_submit", true);
+  queue_driver_type * driver = queue_driver_alloc_slurm();
+  char * cmd = util_alloc_abs_path("cmd.sh");
+  std::vector<void *> jobs;
+
+
+  make_sleep_job(cmd, 10);
+  make_slurm_commands(driver);
+
+  test_assert_NULL( submit_job(driver, ta, "0", cmd));
+
+  {
+    auto job = submit_job(driver, ta, "1", cmd);
+    test_assert_not_NULL(job);
+    jobs.push_back(job);
+  }
+
+  {
+    auto job = submit_job(driver, ta, "2", cmd);
+    test_assert_not_NULL(job);
+    jobs.push_back(job);
+  }
+
+  {
+    auto job = submit_job(driver, ta, "3", cmd);
+    test_assert_not_NULL(job);
+    jobs.push_back(job);
+  }
+
+  {
+    auto job = submit_job(driver, ta, "4", cmd);
+    test_assert_not_NULL(job);
+    jobs.push_back(job);
+  }
+
+  queue_driver_kill_job(driver, jobs[0]);
+  auto job1_status = queue_driver_get_status(driver, jobs[0]);
+  test_assert_int_equal(job1_status, JOB_QUEUE_IS_KILLED);
+
+  auto job2_status = queue_driver_get_status(driver, jobs[1]);
+  test_assert_int_equal(job2_status, JOB_QUEUE_PENDING);
+
+  auto job3_status = queue_driver_get_status(driver, jobs[2]);
+  test_assert_int_equal(job3_status, JOB_QUEUE_RUNNING);
+
+  auto job4_status = queue_driver_get_status(driver, jobs[3]);
+  test_assert_int_equal(job4_status, JOB_QUEUE_DONE);
+
+  for (auto job : jobs)
+    queue_driver_free_job(driver, job);
+
+  free(cmd);
+  queue_driver_free(driver);
+}
 
 
 
 
 int main( int argc , char ** argv) {
-  ecl::util::TestArea ta("slurm_mock", true);
-  exit(0);
+  run();
 }

--- a/lib/job_queue/tests/job_queue_driver_test.cpp
+++ b/lib/job_queue/tests/job_queue_driver_test.cpp
@@ -160,12 +160,14 @@ void get_driver_option_lists() {
     stringlist_type * option_list = stringlist_alloc_new();
     queue_driver_init_option_list(driver_slurm, option_list);
 
+    stringlist_fprintf(option_list, ", ", stdout);
     test_assert_true(stringlist_contains(option_list, MAX_RUNNING));
     test_assert_true(stringlist_contains(option_list, SLURM_SBATCH_OPTION));
     test_assert_true(stringlist_contains(option_list, SLURM_SCONTROL_OPTION));
     test_assert_true(stringlist_contains(option_list, SLURM_SQUEUE_OPTION));
     test_assert_true(stringlist_contains(option_list, SLURM_SCANCEL_OPTION));
     test_assert_true(stringlist_contains(option_list, SLURM_PARTITION_OPTION));
+    test_assert_true(stringlist_contains(option_list, SLURM_SQUEUE_TIMEOUT_OPTION));
 
     stringlist_free(option_list);
     queue_driver_free(driver_slurm);

--- a/lib/job_queue/tests/job_slurm_driver.cpp
+++ b/lib/job_queue/tests/job_slurm_driver.cpp
@@ -39,6 +39,8 @@ void test_options() {
   test_option(driver, SLURM_SCANCEL_OPTION, "my_funny_scancel");
   test_option(driver, SLURM_SQUEUE_OPTION, "my_funny_squeue");
   test_option(driver, SLURM_SCONTROL_OPTION, "my_funny_scontrol");
+  test_option(driver, SLURM_SQUEUE_TIMEOUT_OPTION, "11");
+  test_assert_false( slurm_driver_set_option(driver, "SLURM_SQUEUE_TIMEOUT_OPTION", "NOT_INTEGER"));
   test_assert_false( slurm_driver_set_option(driver, "NO_SUCH_OPTION", "Value"));
   slurm_driver_free( driver );
 }

--- a/lib/job_queue/tests/job_slurm_runtest.cpp
+++ b/lib/job_queue/tests/job_slurm_runtest.cpp
@@ -1,0 +1,123 @@
+/*
+   Copyright (C) 2020  Equinor ASA, Norway.
+
+   The file 'job_slurm_runtest.cpp' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#include <vector>
+
+#include <ert/util/test_util.hpp>
+#include <ert/util/util.hpp>
+#include <ert/util/test_work_area.hpp>
+
+#include <ert/job_queue/queue_driver.hpp>
+#include <ert/job_queue/slurm_driver.hpp>
+
+void make_sleep_job(const char * fname, int sleep_time) {
+  FILE * stream = util_fopen(fname, "w");
+  fprintf(stream, "sleep %d \n", sleep_time);
+  fclose(stream);
+
+  mode_t fmode = S_IRWXU;
+  chmod( fname, fmode);
+}
+
+
+void make_failed_job(const char * fname, int sleep_time) {
+  FILE * stream = util_fopen(fname, "w");
+  fprintf(stream, "sleep %d \n", sleep_time);
+  fprintf(stream, "exit 1\n");
+  fclose(stream);
+
+  mode_t fmode = S_IRWXU;
+  chmod( fname, fmode);
+}
+
+
+
+void run(double squeue_timeout) {
+  ecl::util::TestArea ta("slurm_submit", true);
+  queue_driver_type * driver = queue_driver_alloc_slurm();
+  std::vector<void *> jobs;
+  const char * long_cmd = util_alloc_abs_path("long_run.sh");
+  const char * ok_cmd = util_alloc_abs_path("ok_run.sh");
+  const char * fail_cmd = util_alloc_abs_path("failed_run.sh");
+  int num_jobs = 6;
+
+  make_sleep_job(long_cmd, 10);
+  make_sleep_job(ok_cmd, 1);
+  make_failed_job(fail_cmd, 1);
+  auto squeue_timeout_string = std::to_string( squeue_timeout );
+  queue_driver_set_option(driver, SLURM_SQUEUE_TIMEOUT_OPTION, squeue_timeout_string.c_str());
+
+  for (int i = 0; i < num_jobs; i++) {
+    std::string run_path = ta.test_cwd() + "/" + std::to_string(i);
+    std::string job_name = "job" + std::to_string(i);
+    util_make_path(run_path.c_str());
+    if (i == 0)
+      jobs.push_back( queue_driver_submit_job(driver, long_cmd, 1, run_path.c_str(), job_name.c_str(), 0, nullptr));
+    else if (i == num_jobs - 1)
+      jobs.push_back( queue_driver_submit_job(driver, fail_cmd, 1, run_path.c_str(), job_name.c_str(), 0, nullptr));
+    else
+      jobs.push_back( queue_driver_submit_job(driver, ok_cmd, 1, run_path.c_str(), job_name.c_str(), 0, nullptr));
+  }
+
+
+  while (true) {
+    int active_count = 0;
+    for (auto * job_ptr : jobs) {
+      auto status = queue_driver_get_status(driver, job_ptr);
+      if (status == JOB_QUEUE_RUNNING || status == JOB_QUEUE_PENDING || status == JOB_QUEUE_WAITING)
+        active_count += 1;
+    }
+
+    if (active_count == 0)
+      break;
+
+    auto * long_job = jobs[0];
+    auto long_status = queue_driver_get_status(driver, long_job);
+    if (long_status != JOB_QUEUE_IS_KILLED)
+      queue_driver_kill_job( driver, long_job );
+
+    usleep(100000);
+  }
+
+
+  for (int i = 0; i < num_jobs; i++) {
+    auto * job_ptr = jobs[i];
+    if (i == 0)
+      test_assert_int_equal( queue_driver_get_status(driver, job_ptr), JOB_QUEUE_IS_KILLED );
+    else if (i == num_jobs - 1)
+      test_assert_int_equal( queue_driver_get_status(driver, job_ptr), JOB_QUEUE_EXIT );
+    else
+      test_assert_int_equal( queue_driver_get_status(driver, job_ptr), JOB_QUEUE_DONE );
+  }
+
+  for (auto * job_ptr : jobs)
+    queue_driver_free_job(driver, job_ptr);
+
+  queue_driver_free(driver);
+}
+
+
+int main( int argc , char ** argv) {
+  run(0);
+  run(2);
+  exit(0);
+}


### PR DESCRIPTION
**Issue**
This is the final(?) part of #938. This is on top of #944 

**Approach**
In this PR basic MPI awareness is added to the slurm driver. Slurm allows very detailed control over how the tasks should be distributed over available nodes and cpus, this PR just does the absolute simplest - which is to state how many cpus are needed in total.

The main part of the PR is actually parsing the strings set in the environment variables `SLURM_JOB_NODELIST` and `SLURM_TASKS_PER_NODE` - this is an incredibly compact notation to get the names of the all the nodes in the allocation, and how many cpus are allocated on each of them, this is needed for mpirun.

