### PR TITLE
Remove unused configsuite dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ jinja2
 requests
 functools32;python_version=='2.7'
 psutil
-configsuite<0.6
 futures
 future


### PR DESCRIPTION
**Issue**

Configsuite was added with https://github.com/equinor/libres/commit/a275cd1ea6c223848aec7f162e6d19a1d5f82586 but the python part of the job has been moved to https://github.com/equinor/semeio/tree/master/semeio/jobs/correlated_observations_scaling - along with the configsuite dependency
