### PR TITLE
Make COPY_DIRECTORY always copy to target folder

### DIFF
--- a/python/res/fm/shell/shell.py
+++ b/python/res/fm/shell/shell.py
@@ -158,8 +158,6 @@ class Shell(object):
                     Shell.mkdir( target_root )
 
             print("Copying directory structure %s -> %s" % (src_path , target_path))
-            if os.path.isdir( target_path ):
-                target_path = os.path.join( target_path, src_basename )
             distutils.dir_util.copy_tree( src_path , target_path , preserve_times = 0)
         else:
             raise IOError("Input argument:'%s' does not correspond to an existing directory" % src_path)

--- a/python/tests/res/fm/test_shell.py
+++ b/python/tests/res/fm/test_shell.py
@@ -239,11 +239,36 @@ class ShellTest(ResTest):
             self.assertFalse( os.path.exists( "path" ))
             self.assertTrue( os.path.exists("link_target/link_file"))
 
+    def create_source_directory(self):
+        os.mkdir("source")
+        with open("source/file.txt" , "w") as f:
+            f.write("dummy content\n")
+
+
+    def test_copy_directory(self):
+        with TestAreaContext("copy/directory"):
+            self.create_source_directory()
+
+            copy_directory("source" , "target")
+
+            self.assertTrue(os.path.isfile("target/file.txt"))
+
+    def test_copy_directory_target_exists(self):
+        with TestAreaContext("copy/directory_exists"):
+            self.create_source_directory()
+
+            os.mkdir("target")
+
+            copy_directory("source" , "target")
+
+            self.assertFalse(os.path.isfile("target/source/file.txt"))
+            self.assertTrue(os.path.isfile("target/file.txt"))
+
     def test_copy_directory_error(self):
         with self.assertRaises(IOError):
             copy_directory("does/not/exist" , "target")
 
-        with TestAreaContext("copy/directory"):
+        with TestAreaContext("copy/directory_error"):
             with open("file" , "w") as f:
                 f.write("hei")
 


### PR DESCRIPTION
**Issue**
Resolves #608 

With this change, COPY_DIRECTORY will not create a folder with the
same name as the source directory inside the target folder if the target
folder already exists. This deviates from the standard shell commands.

