### PR TITLE
bump ecl version 2.9.1

### DIFF
--- a/.libecl_version
+++ b/.libecl_version
@@ -1,1 +1,1 @@
-export LIBECL_VERSION=2.9.0
+export LIBECL_VERSION=2.9.1


### PR DESCRIPTION
Update libecl to latest release

https://github.com/equinor/libecl/compare/2.9.0...2.9.1
