### PR TITLE
Print update_log even if points are missing or locally inactive

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -672,6 +672,7 @@ foreach (test   enkf_active_list
                 enkf_plot_gen_kw_vector
                 enkf_plot_genvector
                 enkf_plot_tvector
+                enkf_update_log_test
                 enkf_run_arg
                 enkf_state_map
                 obs_vector_tests

--- a/lib/enkf/enkf_analysis.cpp
+++ b/lib/enkf/enkf_analysis.cpp
@@ -43,6 +43,9 @@
 
 void enkf_analysis_fprintf_obs_summary(const obs_data_type * obs_data , const meas_data_type * meas_data , const int_vector_type * step_list , const char * ministep_name , FILE * stream ) {
   const char * float_fmt = "%15.3f";
+  bool local_inactive_obs;
+  local_inactive_obs = false;
+
   fprintf(stream , "===============================================================================================================================\n");
   fprintf(stream , "Report step...: %04d",int_vector_iget( step_list , 0));
   if (int_vector_size( step_list ) == 1)
@@ -70,37 +73,39 @@ void enkf_analysis_fprintf_obs_summary(const obs_data_type * obs_data , const me
 
         for (int iobs = 0; iobs < obs_block_get_size( obs_block ); iobs++) {
           active_type active_mode = obs_block_iget_active_mode( obs_block , iobs );
-          if ((active_mode == MISSING) || (active_mode == LOCAL_INACTIVE))
-            continue;
-          else {
-            const char * print_key;
-            if (iobs == 0)
-              print_key = obs_key;
-            else
-              print_key = "  ...";
+          const char * print_key;
+          if (iobs == 0)
+            print_key = obs_key;
+          else
+            print_key = "  ...";
 
-            fprintf(stream , obs_fmt , obs_count , print_key , obs_block_iget_value( obs_block , iobs ) , obs_block_iget_std( obs_block , iobs ));
+          fprintf(stream , obs_fmt , obs_count , print_key , obs_block_iget_value( obs_block , iobs ) , obs_block_iget_std( obs_block , iobs ));
 
-            if (active_mode == ACTIVE)
-              fprintf(stream , "  Active   |");
-            else if (active_mode == DEACTIVATED)
-              fprintf(stream , "  Inactive |");
-            else if (active_mode == LOCAL_INACTIVE)
-              fprintf(stream , "           |");
-            else if (active_mode == MISSING)
-              fprintf(stream , "           |");
-            else
-              util_abort("%s: enum_value:%d not handled - internal error\n" , __func__ , active_mode);
+          if (active_mode == ACTIVE)
+            fprintf(stream , " Active    |");
+          else if (active_mode == DEACTIVATED)
+            fprintf(stream , " Inactive  |");
+          else if (active_mode == LOCAL_INACTIVE) {
+            fprintf(stream , " Inactive* |");
+            local_inactive_obs = true;
+            }
+          else if (active_mode == MISSING)
+            fprintf(stream , " Missing   |");
+          else
+            util_abort("%s: enum_value:%d not handled - internal error\n" , __func__ , active_mode);
 
-            if (active_mode == MISSING)
-              fprintf(stream , "                  Missing\n");
-            else if (active_mode == LOCAL_INACTIVE)
-              fprintf(stream , "                  Deactivated - local updates\n");
-            else
-              fprintf(stream , sim_fmt, meas_block_iget_ens_mean( meas_block , iobs ) , meas_block_iget_ens_std( meas_block , iobs ));
-
-            obs_count++;
+          double simulated_value;
+          double simulated_std;
+          if ((active_mode == MISSING) || (active_mode == LOCAL_INACTIVE)) {
+            simulated_value = NAN;
+            simulated_std = NAN;
           }
+          else {
+            simulated_value = meas_block_iget_ens_mean( meas_block , iobs );
+            simulated_std = meas_block_iget_ens_std( meas_block , iobs );
+          }
+          fprintf(stream , sim_fmt, simulated_value, simulated_std);
+          obs_count++;
         }
       }
     }
@@ -109,6 +114,8 @@ void enkf_analysis_fprintf_obs_summary(const obs_data_type * obs_data , const me
     free( sim_fmt );
   }
   fprintf(stream , "===============================================================================================================================\n");
+  if (local_inactive_obs == true)
+    fprintf(stream , "* Local inactive\n");
   fprintf(stream , "\n\n\n");
 }
 

--- a/lib/enkf/tests/enkf_update_log_test.cpp
+++ b/lib/enkf/tests/enkf_update_log_test.cpp
@@ -1,0 +1,95 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <ert/util/test_util.h>
+#include <ert/util/int_vector.h>
+#include <ert/util/type_vector_functions.h>
+
+#include <ert/enkf/meas_data.hpp>
+#include <ert/enkf/obs_data.hpp>
+#include <ert/enkf/enkf_analysis.hpp>
+
+
+void test_obs_in_log() {
+  int_vector_type * ens_active_list = int_vector_alloc(0 , false);
+  bool_vector_type * ens_mask;
+  int_vector_append( ens_active_list , 10 );
+
+  ens_mask = int_vector_alloc_mask(ens_active_list);
+  meas_data_type * meas_data = meas_data_alloc( ens_mask );
+  meas_block_type * block = meas_data_add_block(meas_data , "OBS" , 10 , 10);
+
+  obs_data_type * obs_data = obs_data_alloc(1.0);
+  obs_block_type * obs_block = obs_data_add_block( obs_data , "OBS", 10 , NULL , false );
+  for (int iobs = 0; iobs < 10; iobs++)
+    obs_block_iset( obs_block , iobs , iobs , 0.1);
+  /* Set one obs block as missing*/
+  obs_block_iset_missing(obs_block, 0);
+
+  const char * ministep_name;
+  ministep_name = "A random name";
+
+  /* Check that the update_log contains the first observation name */
+  char *str_stream;
+  size_t size;
+  FILE *stream;
+  stream = open_memstream (&str_stream, &size);
+  enkf_analysis_fprintf_obs_summary(obs_data, meas_data, ens_active_list, ministep_name, stream);
+  fclose(stream);
+  test_assert_true((strstr(str_stream, "OBS") != NULL));
+  test_assert_false((strstr(str_stream, "* Local inactive") != NULL));
+
+  free(str_stream);
+  obs_data_free( obs_data );
+  meas_data_free( meas_data );
+  bool_vector_free( ens_mask );
+  int_vector_free( ens_active_list );
+}
+
+
+void test_local_inactive() {
+  int_vector_type * ens_active_list = int_vector_alloc(0 , false);
+  bool_vector_type * ens_mask;
+  int_vector_append( ens_active_list , 10 );
+
+  ens_mask = int_vector_alloc_mask(ens_active_list);
+  meas_data_type * meas_data = meas_data_alloc( ens_mask );
+  meas_block_type * block = meas_data_add_block(meas_data , "OBS" , 10 , 10);
+
+  obs_data_type * obs_data = obs_data_alloc(1.0);
+  obs_block_type * obs_block = obs_data_add_block( obs_data , "OBS", 10 , NULL , false );
+
+  /* By not setting all obs we set one obs block as local inactive*/
+  for (int iobs = 1; iobs < 10; iobs++)
+    obs_block_iset( obs_block , iobs , iobs , 0.1);
+
+
+  const char * ministep_name;
+  ministep_name = "A random name";
+
+  /* Check that the update_log contains the first observation name */
+  char *str_stream;
+  size_t size;
+  FILE *stream;
+  stream = open_memstream (&str_stream, &size);
+  enkf_analysis_fprintf_obs_summary(obs_data, meas_data, ens_active_list, ministep_name, stream);
+  fclose(stream);
+
+  test_assert_true((strstr(str_stream, "OBS") != NULL));
+  test_assert_true((strstr(str_stream, "* Local inactive") != NULL));
+
+
+  free(str_stream);
+  obs_data_free( obs_data );
+  meas_data_free( meas_data );
+  bool_vector_free( ens_mask );
+  int_vector_free( ens_active_list );
+}
+
+
+int main(int argc , char ** argv) {
+  test_obs_in_log();
+  test_local_inactive();
+  exit(0);
+}
+


### PR DESCRIPTION
Closes #988 

My main concern with this particular fix is if that `if ((active_mode == MISSING) || (active_mode == LOCAL_INACTIVE))` was present to stop some bug occuring, but can find no discussion to suggest that. There observation vector should also be fully initialized so should not be a problem to read from that.