### PR TITLE
Disable black in komodo tests

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -71,4 +71,5 @@ python -m pytest \
  --ignore="tests/res/enkf/test_site_config.py"\
  --ignore="tests/res/enkf/test_workflow_list.py"\
  --ignore="tests/res/enkf/test_hook_manager.py"\
- --ignore="tests/legacy"
+ --ignore="tests/legacy"\
+ --ignore="tests/test_formatting.py"

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,6 +2,6 @@ pytest
 mock
 decorator
 pylint
-black ; python_version >= '3.6'
+black==19.10b0 ; python_version >= '3.6'
 click ; python_version >= '3.6'
 faulthandler ;  python_version == '2.7'


### PR DESCRIPTION
We don't need black in komodo tests
