### PR TITLE
Remove Python 3.8 implicit conversion to int warnings

### DIFF
--- a/lib/enkf/queue_config.cpp
+++ b/lib/enkf/queue_config.cpp
@@ -112,7 +112,7 @@ queue_config_type * queue_config_alloc_full(char * job_script,
                                             bool user_mode,
                                             int max_submit,
                                             int num_cpu,
-                                            int driver_type) {
+                                            job_driver_type driver_type) {
 
   queue_config_type * queue_config = (queue_config_type *)util_malloc(sizeof * queue_config);
   queue_config->queue_drivers = hash_alloc();

--- a/lib/include/ert/enkf/queue_config.hpp
+++ b/lib/include/ert/enkf/queue_config.hpp
@@ -45,7 +45,7 @@ typedef struct queue_config_struct queue_config_type;
                                                 bool user_mode,
                                                 int max_submit,
                                                 int num_cpu,
-                                                int driver_type);
+                                                job_driver_type driver_type);
     queue_config_type * queue_config_alloc_local_copy( queue_config_type * queue_config);
     void queue_config_free(queue_config_type * queue_config);
 

--- a/python/res/analysis/analysis_module.py
+++ b/python/res/analysis/analysis_module.py
@@ -31,7 +31,7 @@ class AnalysisModule(BaseCClass):
     _set_var             = ResPrototype("bool analysis_module_set_var(analysis_module, char*, char*)")
     _get_table_name      = ResPrototype("char* analysis_module_get_table_name(analysis_module)")
     _get_name            = ResPrototype("char* analysis_module_get_name(analysis_module)")
-    _check_option        = ResPrototype("bool analysis_module_check_option(analysis_module, long)")
+    _check_option        = ResPrototype("bool analysis_module_check_option(analysis_module, analysis_module_options_enum)")
     _has_var             = ResPrototype("bool analysis_module_has_var(analysis_module, char*)")
     _get_double          = ResPrototype("double analysis_module_get_double(analysis_module, char*)")
     _get_int             = ResPrototype("int analysis_module_get_int(analysis_module, char*)")

--- a/python/res/enkf/config/enkf_config_node.py
+++ b/python/res/enkf/config/enkf_config_node.py
@@ -90,7 +90,7 @@ class EnkfConfigNode(BaseCClass):
                                                                                          char*, \
                                                                                          char*, \
                                                                                          char*, \
-                                                                                         int, \
+                                                                                         enkf_truncation_type_enum, \
                                                                                          double, \
                                                                                          double, \
                                                                                          char*, \
@@ -100,7 +100,7 @@ class EnkfConfigNode(BaseCClass):
                                                                                      char*, \
                                                                                      char*, \
                                                                                      char*, \
-                                                                                     int, \
+                                                                                     enkf_truncation_type_enum, \
                                                                                      double, \
                                                                                      double, \
                                                                                      char*, \

--- a/python/res/enkf/model_config.py
+++ b/python/res/enkf/model_config.py
@@ -19,7 +19,7 @@ from ecl.summary import EclSum
 from ecl.util.util import StringList
 from res import ResPrototype
 from res.job_queue import ForwardModel, ExtJob, ExtJoblist
-from res.sched import HistorySourceEnum
+from res.sched import HistorySourceEnum, SchedFile
 from res.util import PathFormat
 from res.enkf import ConfigKeys
 from res.enkf.util import TimeMap
@@ -44,7 +44,7 @@ class ModelConfig(BaseCClass):
                                                                                 time_map, \
                                                                                 char*, \
                                                                                 char*, \
-                                                                                int, \
+                                                                                history_source_enum, \
                                                                                 ext_joblist, \
                                                                                 ecl_sum)", bind=False)
     _free                        = ResPrototype("void  model_config_free( model_config )")

--- a/python/res/enkf/queue_config.py
+++ b/python/res/enkf/queue_config.py
@@ -29,7 +29,7 @@ class QueueConfig(BaseCClass):
     _free                  = ResPrototype("void queue_config_free( queue_config )")
     _alloc_job_queue       = ResPrototype("job_queue_obj queue_config_alloc_job_queue( queue_config )")
     _alloc                 = ResPrototype("void* queue_config_alloc_load(char*)", bind=False)
-    _alloc_full            = ResPrototype("void* queue_config_alloc_full(char*, bool, int, int, int)", bind=False)
+    _alloc_full            = ResPrototype("void* queue_config_alloc_full(char*, bool, int, int, queue_driver_enum)", bind=False)
     _alloc_content         = ResPrototype("void* queue_config_alloc(config_content)", bind=False)
     _alloc_local_copy      = ResPrototype("queue_config_obj queue_config_alloc_local_copy( queue_config )")
     _has_job_script        = ResPrototype("bool queue_config_has_job_script( queue_config )")

--- a/python/res/job_queue/driver.py
+++ b/python/res/job_queue/driver.py
@@ -51,7 +51,7 @@ class Driver(BaseCClass):
     _set_option = ResPrototype("void queue_driver_set_option( driver , char* , char*)")
     _get_option = ResPrototype("char* queue_driver_get_option(driver, char*)")
     _free_job = ResPrototype("void   queue_driver_free_job( driver , job )")
-    _get_status = ResPrototype("int queue_driver_get_status( driver , job)")
+    _get_status = ResPrototype("job_status_type_enum queue_driver_get_status(driver, job)")
     _kill_job = ResPrototype("void queue_driver_kill_job( driver , job )")
     _get_max_running = ResPrototype("int queue_driver_get_max_running( driver )")
     _set_max_running = ResPrototype("void queue_driver_set_max_running( driver , int)")
@@ -91,8 +91,7 @@ class Driver(BaseCClass):
         self._free_job(job)
 
     def get_status( self, job ):
-        status = self._get_status(job)
-        return status
+        return self._get_status(job)
 
     def kill_job( self, job ):
         self._kill_job(job)

--- a/python/res/job_queue/job_queue_node.py
+++ b/python/res/job_queue/job_queue_node.py
@@ -24,9 +24,9 @@ class JobQueueNode(BaseCClass):
     _submit = ResPrototype("int job_queue_node_submit_simple(job_queue_node, driver)")
     _kill = ResPrototype("bool job_queue_node_kill_simple(job_queue_node, driver)")
     
-    _get_status = ResPrototype("int job_queue_node_get_status(job_queue_node)")
+    _get_status = ResPrototype("job_status_type_enum job_queue_node_get_status(job_queue_node)")
     _update_status = ResPrototype("bool job_queue_node_update_status_simple(job_queue_node, driver)")
-    _set_status = ResPrototype("void job_queue_node_set_status(job_queue_node, int)")
+    _set_status = ResPrototype("void job_queue_node_set_status(job_queue_node, job_status_type_enum)")
     _get_submit_attempt = ResPrototype("int job_queue_node_get_submit_attempt(job_queue_node)")
 
     def __init__(self,job_script, job_name, run_path, num_cpu, 

--- a/python/res/job_queue/queue.py
+++ b/python/res/job_queue/queue.py
@@ -70,11 +70,7 @@ class JobQueue(BaseCClass):
     _set_pause_off        = ResPrototype("void job_queue_set_pause_off(job_queue)")
     _get_max_submit       = ResPrototype("int job_queue_get_max_submit(job_queue)")
 
-    # The return type of the job_queue_iget_job_status should really
-    # be the enum job_status_type_enum, but I just did not manage to
-    # get the prototyping right. Have therefor taken the return as an
-    # integer and convert it in the getJobStatus() method.
-    _get_job_status  = ResPrototype("int job_queue_iget_job_status(job_queue, int)")
+    _get_job_status  = ResPrototype("job_status_type_enum job_queue_iget_job_status(job_queue, int)")
 
     _get_ok_file = ResPrototype("char* job_queue_get_ok_file(job_queue)")
     _get_exit_file = ResPrototype("char* job_queue_get_exit_file(job_queue)")
@@ -254,11 +250,8 @@ class JobQueue(BaseCClass):
         return self._get_active_size( )
 
     def getJobStatus(self, job_number):
-        # See comment about return type in the prototype section at
-        # the top of class.
         """ @rtype: JobStatusType """
-        int_status = self._get_job_status(job_number)
-        return JobStatusType( int_status )
+        return self._get_job_status(job_number)
 
     def is_active(self):
         for job in self.job_list:

--- a/python/res/sched/history.py
+++ b/python/res/sched/history.py
@@ -52,7 +52,7 @@ class History(BaseCClass):
         @type history_source_type: HistorySourceEnum
         @rtype: str
         """
-        return self._get_source_string(history_source_type)
+        return History._get_source_string(history_source_type)
 
     def free(self):
         self._free( self )

--- a/python/tests/res/enkf/test_model_config.py
+++ b/python/tests/res/enkf/test_model_config.py
@@ -138,7 +138,7 @@ class ModelConfigTest(ResTest):
                 ConfigKeys.TIME_MAP:"configuration_tests/input/refcase/time_map.txt",
                 ConfigKeys.OBS_CONFIG: "configuration_tests/input/observations/observations.txt",
                 ConfigKeys.DATAROOT: "configuration_tests/",
-                ConfigKeys.HISTORY_SOURCE: 1,
+                ConfigKeys.HISTORY_SOURCE: HistorySourceEnum(1),
                 ConfigKeys.GEN_KW_EXPORT_NAME: "parameter_test.json",
                 ConfigKeys.FORWARD_MODEL: [
                     {

--- a/python/tests/res/enkf/test_queue_config.py
+++ b/python/tests/res/enkf/test_queue_config.py
@@ -16,6 +16,8 @@
 
 import os
 from ecl.util.test import TestAreaContext
+
+from res.job_queue import QueueDriverEnum
 from tests import ResTest
 from res.enkf import QueueConfig, ConfigKeys
 from res.config import ConfigContent
@@ -50,7 +52,7 @@ class QueueConfigTest(ResTest):
             config_file = "simple_config/minimum_config"
             config_dict = {
                 ConfigKeys.JOB_SCRIPT: os.getcwd() + "/simple_config/script.sh",
-                ConfigKeys.QUEUE_SYSTEM: 2,
+                ConfigKeys.QUEUE_SYSTEM: QueueDriverEnum(2),
                 ConfigKeys.USER_MODE: True,
                 ConfigKeys.MAX_SUBMIT: 2,
                 ConfigKeys.NUM_CPU: 0,


### PR DESCRIPTION
In Python 3.8 this warning started to appear in `libres`:

`DeprecationWarning: an integer is required (got type ...).  Implicit conversion to integers using _int_ is deprecated, and may be removed in a future version of Python.`

This PR fix these warnings by leveraging the already available enums so that the implicit conversion goes away.