### PR TITLE
Change order of std-cutoff and alpha

### DIFF
--- a/lib/enkf/enkf_main.cpp
+++ b/lib/enkf/enkf_main.cpp
@@ -983,7 +983,7 @@ static void enkf_main_update__(enkf_main_type * enkf_main, const int_vector_type
 
         if (analysis_config_get_std_scale_correlated_obs(analysis_config)) {
           double scale_factor = enkf_obs_scale_correlated_std(enkf_main->obs, source_fs,
-                                                              ens_active_list, obsdata, std_cutoff, alpha, false);
+                                                              ens_active_list, obsdata, alpha, std_cutoff, false);
           res_log_finfo("Scaling standard deviation in obdsata set:%s with %g",
                         local_obsdata_get_name(obsdata), scale_factor);
         }


### PR DESCRIPTION
The order of _std-cutoff_ and _alpha_ are wrong and this PR fixes that.

For refeference this is the declaration of the function call.
```
double enkf_obs_scale_correlated_std(const enkf_obs_type * enkf_obs,
                                     enkf_fs_type * fs,
                                     const int_vector_type * ens_active_list,
                                     const local_obsdata_type * local_obsdata,
                                     double alpha,
                                     double std_cutoff,
                                     bool verbose) {
```