### PR TITLE
Fix komodo PR tests

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -20,6 +20,8 @@ copy_test_files () {
 install_package () {
     local PWD=$(pwd)
     export ERT_SITE_CONFIG=$PWD/share/ert/site-config
+    export PYTHONPATH=$CI_SOURCE_ROOT/cmake-build/lib/python3.6/site-packages:${PYTHONPATH:-}
+    export LD_LIBRARY_PATH=$CI_SOURCE_ROOT/cmake-build/lib:$CI_SOURCE_ROOT/cmake-build/lib64:${LD_LIBRARY_PATH:-}
 }
 
 start_tests () {


### PR DESCRIPTION
Python tests in the komodo PR tests have not been running against the python code in the PR. This PR fixes that by adding the python files in the build folder to PYTHONPATH and updating LD_LIBRARY_PATH so the correct .so files are used when running
the tests.

(I have verified this manually by making a test fail and then "fixing" the introduced error in the PR) 