### PR TITLE
Add PRE_FIRST_UPDATE hook

### DIFF
--- a/lib/enkf/hook_workflow.cpp
+++ b/lib/enkf/hook_workflow.cpp
@@ -27,6 +27,7 @@
 #include <ert/enkf/config_keys.hpp>
 #include <ert/enkf/hook_workflow.hpp>
 
+#define RUN_MODE_PRE_FIRST_UPDATE_NAME   "PRE_FIRST_UPDATE"
 #define RUN_MODE_PRE_SIMULATION_NAME     "PRE_SIMULATION"
 #define RUN_MODE_POST_SIMULATION_NAME    "POST_SIMULATION"
 #define RUN_MODE_PRE_UPDATE_NAME         "PRE_UPDATE"
@@ -88,6 +89,8 @@ hook_run_mode_enum hook_workflow_run_mode_from_name( const char * run_mode ) {
     mode = PRE_UPDATE;
   else if (strcmp( run_mode , RUN_MODE_POST_UPDATE_NAME) == 0)
     mode = POST_UPDATE;
+  else if (strcmp( run_mode , RUN_MODE_PRE_FIRST_UPDATE_NAME) == 0)
+    mode = PRE_FIRST_UPDATE;
   else {
     util_abort("%s: unrecognized run mode :%s \n",__func__ , run_mode);
     mode = POST_UPDATE; /* Dummy */

--- a/lib/enkf/site_config.cpp
+++ b/lib/enkf/site_config.cpp
@@ -425,6 +425,7 @@ void site_config_add_config_items(config_parser_type * config, bool site_mode) {
     stringlist_append_copy(argv, RUN_MODE_POST_SIMULATION_NAME);
     stringlist_append_copy(argv, RUN_MODE_PRE_UPDATE_NAME);
     stringlist_append_copy(argv, RUN_MODE_POST_UPDATE_NAME);
+    stringlist_append_copy(argv, RUN_MODE_PRE_FIRST_UPDATE_NAME);
     config_schema_item_set_indexed_selection_set(item, 1, argv);
     stringlist_free( argv );
   }

--- a/lib/include/ert/enkf/config_keys.hpp
+++ b/lib/include/ert/enkf/config_keys.hpp
@@ -117,6 +117,7 @@ extern "C" {
 #define  RUN_MODE_POST_SIMULATION_NAME     "POST_SIMULATION"
 #define  RUN_MODE_PRE_UPDATE_NAME          "PRE_UPDATE"
 #define  RUN_MODE_POST_UPDATE_NAME         "POST_UPDATE"
+#define  RUN_MODE_PRE_FIRST_UPDATE_NAME    "PRE_FIRST_UPDATE"
 #define  STOP_LONG_RUNNING_KEY             "STOP_LONG_RUNNING"
 #define  MAX_RUNTIME_KEY                   "MAX_RUNTIME"
 #define  TIME_MAP_KEY                      "TIME_MAP"

--- a/lib/include/ert/enkf/hook_workflow.hpp
+++ b/lib/include/ert/enkf/hook_workflow.hpp
@@ -29,10 +29,11 @@ extern "C" {
 #include <ert/enkf/ert_workflow_list.hpp>
 
 
-  typedef enum {PRE_SIMULATION  = 0,
-                POST_SIMULATION = 1,
-                PRE_UPDATE      = 2,
-                POST_UPDATE     = 3} hook_run_mode_enum;
+  typedef enum {PRE_SIMULATION   = 0,
+                POST_SIMULATION  = 1,
+                PRE_UPDATE       = 2,
+                POST_UPDATE      = 3,
+                PRE_FIRST_UPDATE = 4} hook_run_mode_enum;
 
   typedef struct hook_workflow_struct hook_workflow_type;
 

--- a/python/res/enkf/enums/hook_runtime_enum.py
+++ b/python/res/enkf/enums/hook_runtime_enum.py
@@ -21,9 +21,11 @@ class HookRuntime(BaseCEnum):
     POST_SIMULATION = None
     PRE_UPDATE      = None
     POST_UPDATE     = None
+    PRE_FIRST_UPDATE = None
 
 
 HookRuntime.addEnum("PRE_SIMULATION"  , 0)
 HookRuntime.addEnum("POST_SIMULATION" , 1)
 HookRuntime.addEnum("PRE_UPDATE"      , 2)
 HookRuntime.addEnum("POST_UPDATE"     , 3)
+HookRuntime.addEnum("PRE_FIRST_UPDATE", 4)


### PR DESCRIPTION
There is sometimes a need for a hook that will only run before the first update and not subsequent times for an iterative algorithm. This is for example relevant if scaling observations, as doing that for each iteration could lead to numeric  instabilities.