### PR TITLE
Use subprocess for rms

### DIFF
--- a/python/res/fm/rms/__init__.py
+++ b/python/res/fm/rms/__init__.py
@@ -1,5 +1,5 @@
 from .rms_config import RMSConfig
-from .rms_run import RMSRun
+from .rms_run import RMSRun, RMSRunException
 
 
 def run(

--- a/python/res/fm/rms/rms_config.py
+++ b/python/res/fm/rms/rms_config.py
@@ -1,6 +1,7 @@
 import os
 import os.path
 import yaml
+import shutil
 
 
 class RMSConfig(object):
@@ -22,6 +23,13 @@ class RMSConfig(object):
         if not os.access(exe, os.X_OK):
             raise OSError("The executable: {} can not run".format(exe))
 
+        return exe
+
+    @property
+    def wrapper(self):
+        exe = self._config.get("wrapper", None)
+        if exe is not None and shutil.which(exe) is None:
+            raise OSError("The executable: {} is not found".format(exe))
         return exe
 
     @property

--- a/python/res/fm/rms/rms_config.yml
+++ b/python/res/fm/rms/rms_config.yml
@@ -5,4 +5,5 @@ executable: /path/to/rms
 
 # The number of threads used by the RMS process for CPU intensive tasks. The
 # default number of threads is 1.
+
 threads: 1

--- a/python/res/fm/rms/rms_run.py
+++ b/python/res/fm/rms/rms_run.py
@@ -175,10 +175,7 @@ class RMSRun(object):
             args += ["-threads", str(self.config.threads)]
 
         if not exec_env:
-            exec_env = os.environ.copy()
-        exec_env["_PRE_RMS_BACKUP"] = "1"
-        if "PYTHONPATH" in os.environ:
-            exec_env["_PRE_RMS_PYTHONPATH"] = os.environ["PYTHONPATH"]
+            exec_env = os.environ
 
         comp_process = subprocess.run(args=args, env=exec_env)
         return comp_process.returncode

--- a/python/res/fm/rms/rms_run.py
+++ b/python/res/fm/rms/rms_run.py
@@ -21,6 +21,10 @@ def pushd(path):
     os.chdir(cwd0)
 
 
+class RMSRunException(Exception):
+    pass
+
+
 class RMSRun(object):
     _single_seed_file = "RMS_SEED"
     _multi_seed_file = "random.seeds"
@@ -120,7 +124,7 @@ class RMSRun(object):
             exit_status = self.exec_rms(exec_env)
 
         if exit_status != 0:
-            raise Exception(
+            raise RMSRunException(
                 "The RMS run failed with exit status: {}".format(exit_status)
             )
 
@@ -128,7 +132,7 @@ class RMSRun(object):
             return
 
         if not os.path.isfile(self.target_file):
-            raise Exception(
+            raise RMSRunException(
                 "The RMS run did not produce the expected  file: {}".format(
                     self.target_file
                 )
@@ -138,14 +142,15 @@ class RMSRun(object):
             return
 
         if os.path.getmtime(self.target_file) == self.target_file_mtime:
-            raise Exception(
+            raise RMSRunException(
                 "The target file:{} is unmodified - interpreted as failure".format(
                     self.target_file
                 )
             )
 
     def exec_rms(self, exec_env):
-        args = [
+        args = [self.config.wrapper] if self.config.wrapper is not None else []
+        args += [
             self.config.executable,
             "-project",
             self.project,

--- a/python/tests/res/fm/test_rms_config.py
+++ b/python/tests/res/fm/test_rms_config.py
@@ -73,6 +73,22 @@ class RMSConfigTest(ResTest):
             conf = RMSConfig()
             self.assertEqual(conf.threads, 17)
 
+            with open("file.yml", "w") as f:
+                f.write("executable: bin/rms\n")
+                f.write("wrapper: not-exisiting-exec")
+
+            conf = RMSConfig()
+
+            with self.assertRaises(OSError):
+                conf.wrapper
+
+            with open("file.yml", "w") as f:
+                f.write("executable: bin/rms\n")
+                f.write("wrapper: bash")
+
+            conf = RMSConfig()
+            self.assertEqual(conf.wrapper, "bash")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/res/fm/test_rms_run.py
+++ b/python/tests/res/fm/test_rms_run.py
@@ -34,46 +34,6 @@ from tests.conftest import source_root
 
 @tmpdir()
 @pytest.mark.parametrize(
-    "python_path",
-    [
-        (""),
-        ("/test/python/path/"),
-        (None),
-    ],
-)
-def test_run_backup_python_path(tmpdir, monkeypatch, python_path):
-    with open("rms_config.yml", "w") as f:
-        f.write("executable:  {}/bin/rms".format(os.getcwd()))
-
-    os.mkdir("run_path")
-    os.mkdir("bin")
-    os.mkdir("project")
-    shutil.copy(os.path.join(source_root(), "python/tests/res/fm/rms"), "bin")
-    monkeypatch.setenv("RMS_SITE_CONFIG", "rms_config.yml")
-    if python_path is None:
-        monkeypatch.delenv("PYTHONPATH", raising=False)
-    else:
-        monkeypatch.setenv("PYTHONPATH", python_path)
-
-    action = {"exit_status": 0}
-    with open("run_path/action.json", "w") as f:
-        f.write(json.dumps(action))
-
-    r = RMSRun(0, "project", "workflow", run_path="run_path")
-    r.run()
-
-    with open("run_path/env.json") as f:
-        env = json.load(f)
-
-    assert env["_PRE_RMS_BACKUP"] == "1"
-    if python_path is None:
-        assert "_PRE_RMS_PYTHONPATH" not in env
-    else:
-        assert env["_PRE_RMS_PYTHONPATH"] == python_path
-
-
-@tmpdir()
-@pytest.mark.parametrize(
     "test_input,expected_result",
     [
         (0, 422851785),


### PR DESCRIPTION
Closes https://github.com/equinor/libres/pull/1030

use wrapper script for rms if available

Should fix the RMS issues by executing rms through a komodo-disable-script defined in the rms_config.yml file 
