### PR TITLE
Add more precise deprecation warning for STD_SCALE_CORRELATED_OBS

### DIFF
--- a/lib/enkf/analysis_config.cpp
+++ b/lib/enkf/analysis_config.cpp
@@ -695,7 +695,7 @@ void analysis_config_add_config_items( config_parser_type * config ) {
           config,
           STD_SCALE_CORRELATED_OBS_KEY,
           "STD_SCALE_CORRELATED_OBS is deprecated. "
-          "Use the AUTO_SCALE workflow instead."
+          "Use the 'auto_scale' option in the MISFIT_PREPROCESSOR workflow instead."
   );
 
   item = config_add_key_value( config , STOP_LONG_RUNNING_KEY, false,  CONFIG_BOOL );

--- a/lib/enkf/enkf_main_jobs.cpp
+++ b/lib/enkf/enkf_main_jobs.cpp
@@ -416,6 +416,9 @@ C_USED void * enkf_main_export_runpath_file_JOB(void * self, const stringlist_ty
 
 // Internal workflow job
 C_USED void * enkf_main_std_scale_correlated_obs_JOB(void * self, const stringlist_type * args)  {
+  printf("The STD_SCALE_CORRELATED_OBS workflow is deprecated. "
+         "Use the 'auto_scale' option in the MISFIT_PREPROCESSOR workflow instead.\n"
+  );
 
   if (stringlist_get_size(args) > 0) {
     bool verbose = true;


### PR DESCRIPTION
The STD_SCALE_CORRELATED_OBS keyword and workflow is in the process of deprecation. This change creates a more precise message to the available alternative.

