### PR TITLE
Remove unused quantile functions

### DIFF
--- a/python/res/util/__init__.py
+++ b/python/res/util/__init__.py
@@ -24,4 +24,4 @@ from .res_log import ResLog
 from .ui_return import UIReturn
 from .path_format import PathFormat
 from .matrix import Matrix
-from .stat import quantile, quantile_sorted, polyfit
+from .stat import polyfit

--- a/python/res/util/stat.py
+++ b/python/res/util/stat.py
@@ -23,15 +23,6 @@ from res import ResPrototype
 from res.util import LLSQResultEnum
 from res.util import Matrix
 
-
-quantile = ResPrototype("double statistics_empirical_quantile(double_vector, double)")
-"""@type: (ecl.util.DoubleVector, float)->float"""
-
-quantile_sorted = ResPrototype(
-    "double statistics_empirical_quantile(double_vector, double)"
-)
-"""@type: (ecl.util.DoubleVector, float)->float"""
-
 try:
     _polyfit = ResPrototype(
         "llsq_result_enum matrix_stat_polyfit(matrix, matrix, matrix, matrix)"
@@ -43,9 +34,9 @@ except PrototypeError:
 def polyfit(n, x, y, s=None):
     """
     @type n: int
-    @type x: Matrix or Sequence
-    @type y: Matrix or Sequence
-    @type s: Matrix or Sequence or None
+    @type x: Matrix or Sequence or DoubleVector
+    @type y: Matrix or Sequence or DoubleVector
+    @type s: Matrix or Sequence or DoubleVector or None
     @return: tuple
     """
     if _polyfit is None:

--- a/python/tests/res/util/test_stat.py
+++ b/python/tests/res/util/test_stat.py
@@ -1,23 +1,9 @@
 from tests import ResTest
 from ecl.util.util import DoubleVector
-from res.util import quantile, quantile_sorted, polyfit
-from ecl.util.util.rng import RandomNumberGenerator
+from res.util import polyfit
 
 
 class StatTest(ResTest):
-    def test_stat_quantiles(self):
-        rng = RandomNumberGenerator()
-        rng.setState("0123456789ABCDEF")
-        v = DoubleVector()
-        for i in range(100000):
-            v.append(rng.getDouble())
-
-        self.assertAlmostEqual(quantile(v, 0.1), 0.1, 2)
-        self.assertAlmostEqual(quantile_sorted(v, 0.2), 0.2, 2)
-        self.assertAlmostEqual(quantile_sorted(v, 0.3), 0.3, 2)
-        self.assertAlmostEqual(quantile_sorted(v, 0.4), 0.4, 2)
-        self.assertAlmostEqual(quantile_sorted(v, 0.5), 0.5, 2)
-
     def test_polyfit(self):
         x_list = DoubleVector()
         y_list = DoubleVector()


### PR DESCRIPTION
Two quantile functions pointing to the same C endpoint was only used in a test. This PR remove these from Python.