### PR TITLE
Update deprecated commands in GitHub actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,10 +34,10 @@ jobs:
         sudo apt-get install libopm-simulators liblapack-dev valgrind
     - name: Setup environment
       run: |
-        echo "::add-path::${{ env.INSTALL_DIR}}/bin"
-        echo "::set-env name=LD_LIBRARY_PATH::${{ env.INSTALL_DIR }}/lib:${{ env.INSTALL_DIR }}/lib64"
-        echo "::set-env name=DYLD_LIBRARY_PATH::${{ env.INSTALL_DIR }}/lib:${{ env.INSTALL_DIR }}/lib64"
-        echo "::set-env name=PYTHONPATH::${{ env.INSTALL_DIR }}/lib/python${{ matrix.python-version }}/site-packages:${{ env.INSTALL_DIR }}/lib/python${{ matrix.python-version }}/dist-packages"
+        echo "${{ env.INSTALL_DIR}}/bin" >> $GITHUB_PATH
+        echo "LD_LIBRARY_PATH=${{ env.INSTALL_DIR }}/lib:${{ env.INSTALL_DIR }}/lib64" >> $GITHUB_ENV
+        echo "DYLD_LIBRARY_PATH=${{ env.INSTALL_DIR }}/lib:${{ env.INSTALL_DIR }}/lib64" >> $GITHUB_ENV
+        echo "PYTHONPATH=${{ env.INSTALL_DIR }}/lib/python${{ matrix.python-version }}/site-packages:${{ env.INSTALL_DIR }}/lib/python${{ matrix.python-version }}/dist-packages" >> $GITHUB_ENV
     - name: Install dependencies
       run: |
           pip install -r requirements.txt


### PR DESCRIPTION
**Issue**
Resolves #1043 


**Approach**
Use GitHiub environment variables instead of soon-to-be-deprecated `set-env` and system path instead of soon-to-be-deprecated `add-path`
