### PR TITLE
Ee write cloudevent as str

### DIFF
--- a/python/job_runner/reporting/event.py
+++ b/python/job_runner/reporting/event.py
@@ -65,7 +65,7 @@ class Event:
 
     def _dump_event(self, event):
         with open(self._event_log, "a") as el:
-            el.write("{}\n".format(to_json(event)))
+            el.write("{}\n".format(to_json(event).decode()))
 
     def _step_path(self):
         return f"/ert/ee/{self._ee_id}/real/{self._real_id}/stage/{self._stage_id}/step/{0}"


### PR DESCRIPTION
Not decoding that `ByteString` will write the `bytes`' `__repr__` to the file, IIUIC.