### PR TITLE
Extend the doc on RMS forward model

### DIFF
--- a/share/ert/forward-models/docs/description/RMS.rst
+++ b/share/ert/forward-models/docs/description/RMS.rst
@@ -1,1 +1,5 @@
-Forward model for running RMS batches
+Forward model for running a given workflow in an existing RMS-project.
+
+The forward model requires explicit knowledge of the version used to
+produce the RMS project loaded. The Python environment is adapted to
+work with Python inside RMS.

--- a/share/ert/forward-models/docs/examples/RMS.rst
+++ b/share/ert/forward-models/docs/examples/RMS.rst
@@ -1,9 +1,14 @@
 Running the forward model
 #########################
 
+RMS is usually incorporated in ERT configurations using statements like
+
 .. code-block:: bash
 
-    FORWARD_MODEL RMS(<IENS> <RMS_PROJECT> <RMS_WORKFLOW>)
+    DEFINE  <RMS_PROJECT>         reek.rms11.0.1
+    DEFINE  <RMS_VERSION>         11.0.1
+    DEFINE  <RMS_WORKFLOW_NAME>   MAIN_WORKFLOW
+    FORWARD_MODEL RMS(<IENS>=<IENS>, <RMS_VERSION>=<RMS_VERSION>, <RMS_PROJECT>=<CONFIG_PATH>/../../rms/model/<RMS_NAME>)
 
 RMS script documentation
 ########################


### PR DESCRIPTION
**Issue**
The documentation on the RMS forward model is very terse.

**Approach**
Add more text, and add a typical usage example.
