### PR TITLE
Add cwrap as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ skbuild.setup(
     platforms="any",
     install_requires=[
         "cloudevents",
+        "cwrap",
         "ecl",
         "futures",
         "jinja2",


### PR DESCRIPTION
`cwrap` is a direct requirement of `libres`, but not listed as such. This has worked all along as `libecl` also depends on `cwrap`. But better to just keep it correct 🤷 