### PR TITLE
Drop futures as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ ninja
 # From setup.py install_requires
 cloudevents
 ecl
-futures
 jinja2
 numpy
 pandas

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ skbuild.setup(
         "cloudevents",
         "cwrap",
         "ecl",
-        "futures",
         "jinja2",
         "numpy",
         "pandas",


### PR DESCRIPTION
`concurrent.futures` has been part of the standard library starting python `3.2`.