### PR TITLE
Update main update code with mock row scaling api.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -173,6 +173,7 @@ add_library(res SHARED
                 enkf/site_config.cpp
                 enkf/rng_manager.cpp
                 enkf/res_config.cpp
+                enkf/row_scaling.cpp
                 enkf/state_map.cpp
                 enkf/state_map.cpp
                 enkf/summary.cpp
@@ -578,6 +579,7 @@ foreach (test   enkf_active_list
                 enkf_model_config
                 enkf_obs_invalid_path
                 enkf_obs_tests
+                enkf_local_dataset
                 enkf_obs_vector
                 enkf_plot_data
                 enkf_plot_gendata
@@ -590,6 +592,7 @@ foreach (test   enkf_active_list
                 enkf_state_map
                 obs_vector_tests
                 log_config_level_parse
+                row_scaling
                 rng_manager
                 rng_config
                 trans_func

--- a/lib/enkf/local_dataset.cpp
+++ b/lib/enkf/local_dataset.cpp
@@ -135,3 +135,36 @@ int local_dataset_get_size( const local_dataset_type * dataset ) {
 hash_iter_type * local_dataset_alloc_iter(const local_dataset_type * dataset) {
   return hash_iter_alloc(dataset->nodes);
 }
+
+bool local_dataset_has_row_scaling(const local_dataset_type * dataset, const char * key) {
+  return false;
+}
+
+stringlist_type * local_dataset_alloc_scaled_keys(const local_dataset_type * dataset) {
+  stringlist_type * keys = stringlist_alloc_new();
+  hash_iter_type *node_iter = hash_iter_alloc( dataset->nodes );
+
+  while (!hash_iter_is_complete( node_iter )) {
+    const char * key = hash_iter_get_next_key( node_iter );
+    if (local_dataset_has_row_scaling(dataset, key))
+      stringlist_append_copy( keys, key);
+  }
+
+  hash_iter_free( node_iter );
+  return keys;
+}
+
+
+stringlist_type * local_dataset_alloc_unscaled_keys(const local_dataset_type * dataset) {
+  stringlist_type * keys = stringlist_alloc_new();
+  hash_iter_type *node_iter = hash_iter_alloc( dataset->nodes );
+
+  while (!hash_iter_is_complete( node_iter )) {
+    const char * key = hash_iter_get_next_key( node_iter );
+    if (!local_dataset_has_row_scaling(dataset, key))
+      stringlist_append_copy( keys, key);
+  }
+
+  hash_iter_free( node_iter );
+  return keys;
+}

--- a/lib/enkf/local_dataset.cpp
+++ b/lib/enkf/local_dataset.cpp
@@ -140,14 +140,14 @@ bool local_dataset_has_row_scaling(const local_dataset_type * dataset, const cha
   return false;
 }
 
-stringlist_type * local_dataset_alloc_scaled_keys(const local_dataset_type * dataset) {
-  stringlist_type * keys = stringlist_alloc_new();
+std::vector<std::string> local_dataset_scaled_keys(const local_dataset_type * dataset) {
+  std::vector<std::string> keys;
   hash_iter_type *node_iter = hash_iter_alloc( dataset->nodes );
 
   while (!hash_iter_is_complete( node_iter )) {
     const char * key = hash_iter_get_next_key( node_iter );
     if (local_dataset_has_row_scaling(dataset, key))
-      stringlist_append_copy( keys, key);
+      keys.emplace_back( key );
   }
 
   hash_iter_free( node_iter );
@@ -155,14 +155,14 @@ stringlist_type * local_dataset_alloc_scaled_keys(const local_dataset_type * dat
 }
 
 
-stringlist_type * local_dataset_alloc_unscaled_keys(const local_dataset_type * dataset) {
-  stringlist_type * keys = stringlist_alloc_new();
+std::vector<std::string> local_dataset_unscaled_keys(const local_dataset_type * dataset) {
+  std::vector<std::string> keys;
   hash_iter_type *node_iter = hash_iter_alloc( dataset->nodes );
 
   while (!hash_iter_is_complete( node_iter )) {
     const char * key = hash_iter_get_next_key( node_iter );
     if (!local_dataset_has_row_scaling(dataset, key))
-      stringlist_append_copy( keys, key);
+      keys.emplace_back( key );
   }
 
   hash_iter_free( node_iter );

--- a/lib/enkf/row_scaling.cpp
+++ b/lib/enkf/row_scaling.cpp
@@ -1,0 +1,32 @@
+/*
+   Copyright (C) 2020  Equinor ASA, Norway.
+
+   The file 'row_scaling.cpp' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <stdexcept>
+#include <vector>
+
+
+#include <ert/enkf/row_scaling.hpp>
+
+
+
+struct row_scaling_struct {
+};
+
+

--- a/lib/enkf/tests/enkf_local_dataset.cpp
+++ b/lib/enkf/tests/enkf_local_dataset.cpp
@@ -1,0 +1,54 @@
+/*
+   Copyright (C) 2020  Equinor ASA, Norway.
+
+   The file 'enkf_local_dataset.cpp' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+
+#include <stdlib.h>
+#include <stdexcept>
+#include <ert/util/test_util.hpp>
+#include <ert/enkf/local_dataset.hpp>
+
+
+void test_create() {
+  local_dataset_type * ld = local_dataset_alloc("DATA");
+  local_dataset_add_node(ld, "PERMX");
+  local_dataset_add_node(ld, "PERMY");
+  local_dataset_add_node(ld, "PERMZ");
+  test_assert_false( local_dataset_has_row_scaling(ld, "PERMX"));
+  test_assert_false( local_dataset_has_row_scaling(ld, "PERMY"));
+  test_assert_false( local_dataset_has_row_scaling(ld, "PERMZ"));
+
+  {
+    stringlist_type * unscaled_keys = local_dataset_alloc_unscaled_keys(ld);
+    test_assert_int_equal( stringlist_get_size(unscaled_keys), 3 );
+    test_assert_true( stringlist_contains(unscaled_keys, "PERMX"));
+    test_assert_true( stringlist_contains(unscaled_keys, "PERMY"));
+    test_assert_true( stringlist_contains(unscaled_keys, "PERMZ"));
+    stringlist_free(unscaled_keys);
+  }
+  {
+    stringlist_type * scaled_keys = local_dataset_alloc_scaled_keys(ld);
+    test_assert_int_equal( stringlist_get_size(scaled_keys), 0 );
+    stringlist_free(scaled_keys);
+  }
+
+  local_dataset_free(ld);
+}
+
+int main(int argc , char ** argv) {
+  test_create();
+}
+

--- a/lib/enkf/tests/enkf_local_dataset.cpp
+++ b/lib/enkf/tests/enkf_local_dataset.cpp
@@ -16,36 +16,40 @@
    for more details.
 */
 
-#include <stdlib.h>
+#include <algorithm>
 #include <stdexcept>
+#include <stdlib.h>
+#include <string>
+#include <vector>
 #include <ert/util/test_util.hpp>
 #include <ert/enkf/local_dataset.hpp>
 
 
+bool vector_contains(const std::vector<std::string>& keys, const std::string& key) {
+  auto iter = std::find(keys.begin(), keys.end(), key);
+  return (iter != keys.end());
+}
+
+
 void test_create() {
-  local_dataset_type * ld = local_dataset_alloc("DATA");
-  local_dataset_add_node(ld, "PERMX");
-  local_dataset_add_node(ld, "PERMY");
-  local_dataset_add_node(ld, "PERMZ");
-  test_assert_false( local_dataset_has_row_scaling(ld, "PERMX"));
-  test_assert_false( local_dataset_has_row_scaling(ld, "PERMY"));
-  test_assert_false( local_dataset_has_row_scaling(ld, "PERMZ"));
+    local_dataset_type * ld = local_dataset_alloc("DATA");
+    local_dataset_add_node(ld, "PERMX");
+    local_dataset_add_node(ld, "PERMY");
+    local_dataset_add_node(ld, "PERMZ");
+    test_assert_false( local_dataset_has_row_scaling(ld, "PERMX"));
+    test_assert_false( local_dataset_has_row_scaling(ld, "PERMY"));
+    test_assert_false( local_dataset_has_row_scaling(ld, "PERMZ"));
 
-  {
-    stringlist_type * unscaled_keys = local_dataset_alloc_unscaled_keys(ld);
-    test_assert_int_equal( stringlist_get_size(unscaled_keys), 3 );
-    test_assert_true( stringlist_contains(unscaled_keys, "PERMX"));
-    test_assert_true( stringlist_contains(unscaled_keys, "PERMY"));
-    test_assert_true( stringlist_contains(unscaled_keys, "PERMZ"));
-    stringlist_free(unscaled_keys);
-  }
-  {
-    stringlist_type * scaled_keys = local_dataset_alloc_scaled_keys(ld);
-    test_assert_int_equal( stringlist_get_size(scaled_keys), 0 );
-    stringlist_free(scaled_keys);
-  }
+    const auto& unscaled_keys = local_dataset_unscaled_keys(ld);
+    test_assert_int_equal( unscaled_keys.size(), 3 );
+    test_assert_true( vector_contains(unscaled_keys, "PERMX"));
+    test_assert_true( vector_contains(unscaled_keys, "PERMY"));
+    test_assert_true( vector_contains(unscaled_keys, "PERMZ"));
 
-  local_dataset_free(ld);
+    const auto& scaled_keys = local_dataset_scaled_keys(ld);
+    test_assert_int_equal( scaled_keys.size(), 0 );
+
+    local_dataset_free(ld);
 }
 
 int main(int argc , char ** argv) {

--- a/lib/enkf/tests/row_scaling.cpp
+++ b/lib/enkf/tests/row_scaling.cpp
@@ -1,0 +1,24 @@
+/*
+   Copyright (C) 2020  Equinor ASA, Norway.
+
+   The file 'row_scaling.cpp' is part of ERT - Ensemble based Reservoir Tool.
+
+   ERT is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.
+
+   See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+   for more details.
+*/
+#include <ert/util/test_util.hpp>
+
+#include <ert/enkf/row_scaling.hpp>
+
+int main(int argc , char ** argv) {
+}
+

--- a/lib/include/ert/enkf/local_dataset.hpp
+++ b/lib/include/ert/enkf/local_dataset.hpp
@@ -20,6 +20,10 @@
 #ifndef ERT_LOCAL_DATASET_H
 #define ERT_LOCAL_DATASET_H
 #include <ert/tooling.hpp>
+#include <ert/util/stringlist.hpp>
+#include <ert/util/hash.hpp>
+
+#include <ert/enkf/active_list.hpp>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -41,7 +45,9 @@ int                  local_dataset_get_size( const local_dataset_type * dataset 
 void                 local_dataset_del_node( local_dataset_type * dataset , const char * node_key);
 PY_USED bool         local_dataset_has_key(const local_dataset_type * dataset, const char * key);
 hash_iter_type     * local_dataset_alloc_iter(const local_dataset_type * dataset);
-
+bool                 local_dataset_has_row_scaling(const local_dataset_type * dataset, const char * key);
+stringlist_type    * local_dataset_alloc_scaled_keys(const local_dataset_type * dataset);
+stringlist_type    * local_dataset_alloc_unscaled_keys(const local_dataset_type * dataset);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/include/ert/enkf/local_dataset.hpp
+++ b/lib/include/ert/enkf/local_dataset.hpp
@@ -19,16 +19,20 @@
 
 #ifndef ERT_LOCAL_DATASET_H
 #define ERT_LOCAL_DATASET_H
+#include <vector>
+#include <string>
+
 #include <ert/tooling.hpp>
 #include <ert/util/stringlist.hpp>
 #include <ert/util/hash.hpp>
 
 #include <ert/enkf/active_list.hpp>
+
+typedef struct local_dataset_struct local_dataset_type;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct local_dataset_struct local_dataset_type;
 
 local_dataset_type * local_dataset_alloc_copy( local_dataset_type * src_dataset , const char * copy_name );
 local_dataset_type * local_dataset_alloc( const char * name );
@@ -46,10 +50,12 @@ void                 local_dataset_del_node( local_dataset_type * dataset , cons
 PY_USED bool         local_dataset_has_key(const local_dataset_type * dataset, const char * key);
 hash_iter_type     * local_dataset_alloc_iter(const local_dataset_type * dataset);
 bool                 local_dataset_has_row_scaling(const local_dataset_type * dataset, const char * key);
-stringlist_type    * local_dataset_alloc_scaled_keys(const local_dataset_type * dataset);
-stringlist_type    * local_dataset_alloc_unscaled_keys(const local_dataset_type * dataset);
+
 #ifdef __cplusplus
 }
 #endif
+
+std::vector<std::string> local_dataset_scaled_keys(const local_dataset_type * dataset);
+std::vector<std::string> local_dataset_unscaled_keys(const local_dataset_type * dataset);
 
 #endif

--- a/lib/include/ert/enkf/local_ministep.hpp
+++ b/lib/include/ert/enkf/local_ministep.hpp
@@ -19,6 +19,8 @@
 #ifndef ERT_LOCAL_MINISTEP_H
 #define ERT_LOCAL_MINISTEP_H
 
+#include <ert/enkf/local_dataset.hpp>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,7 +31,6 @@ extern "C" {
 #include <ert/analysis/analysis_module.hpp>
 
 #include <ert/enkf/active_list.hpp>
-#include <ert/enkf/local_dataset.hpp>
 #include <ert/enkf/local_obsdata.hpp>
 #include <ert/enkf/local_obsdata_node.hpp>
 #include <ert/enkf/obs_data.hpp>

--- a/lib/include/ert/enkf/local_updatestep.hpp
+++ b/lib/include/ert/enkf/local_updatestep.hpp
@@ -19,11 +19,12 @@
 #ifndef ERT_LOCAL_UPDATESTEP_H
 #define ERT_LOCAL_UPDATESTEP_H
 
+#include <ert/enkf/local_ministep.hpp>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <ert/enkf/local_ministep.hpp>
 #include <ert/enkf/local_obsdata.hpp>
 
 typedef struct local_updatestep_struct local_updatestep_type;

--- a/lib/include/ert/enkf/row_scaling.hpp
+++ b/lib/include/ert/enkf/row_scaling.hpp
@@ -1,0 +1,33 @@
+/*
+  Copyright (C) 2020  Equinor ASA, Norway.
+
+  The file 'row_scaling.hpp' is part of ERT - Ensemble based Reservoir Tool.
+
+  ERT is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ERT is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE.
+
+  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+  for more details.
+*/
+
+#ifndef ROW_SCALING_H
+#define ROW_SCALING_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct row_scaling_struct row_scaling_type;
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+

--- a/lib/include/ert/enkf/row_scaling.hpp
+++ b/lib/include/ert/enkf/row_scaling.hpp
@@ -19,15 +19,8 @@
 #ifndef ROW_SCALING_H
 #define ROW_SCALING_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef struct row_scaling_struct row_scaling_type;
 
-#ifdef __cplusplus
-}
-#endif
 #endif
 
 


### PR DESCRIPTION
**Issue**
Part of #1070


**Approach**
This PR creates an empty `row_scaling` datastructure in order to create a non-functional api and update the inner loop updating. This should be merged before #1069 - which has an actual implementation of the row_scaling class.

The distance based localization looks like it will be based loosely on three levels of abstraction/code:

1. At the very innermost level are changes to the core updating routine `enkf_main_update()`.
2. At the the intermediate level is a datastructure which represents the resulting row scaling for one parameter; the row scaling will enter into the inner loop code in point 1. A sketch of a possible `row_scaling`implementation can be found here: #1069.
3. Expert users can use the `row_scaling`functionality from Python - but probably it will make sense to create an additional utility layer which creates/initializes `row_scaling` instances based on relevant domain models like grids and 3D fields.

This PR addresses the changes needed in step 1 above; the current PR can certainly be improved - but it should contain the required changes in functionality to address point 1 above. The current PR can be merged without causing any harm to existing functionality, no new functionality will be enabled with this PR.


