### PR TITLE
Remove builtin and __future__ imports

### DIFF
--- a/python/job_runner/reporting/network.py
+++ b/python/job_runner/reporting/network.py
@@ -4,9 +4,6 @@ import pwd
 import socket
 import sys
 
-# shadow map builtin in py2, making our map usage py2 compatible
-# TODO: safely remove after py2 support in ERT ends
-from builtins import map
 from sys import version as sys_version
 
 import requests

--- a/python/res/enkf/export/arg_loader.py
+++ b/python/res/enkf/export/arg_loader.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import math
 from pandas import DataFrame, MultiIndex
 import numpy

--- a/python/res/enkf/obs_data.py
+++ b/python/res/enkf/obs_data.py
@@ -14,8 +14,6 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from cwrap import BaseCClass
 from res import ResPrototype
 from res.util import Matrix

--- a/python/res/fm/rms/rms_run.py
+++ b/python/res/fm/rms/rms_run.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import json
 import os
 import sys

--- a/python/res/job_queue/queue.py
+++ b/python/res/job_queue/queue.py
@@ -18,8 +18,6 @@ Module implementing a queue for managing external jobs.
 
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import asyncio
 import sys
 import time

--- a/python/res/util/ui_return.py
+++ b/python/res/util/ui_return.py
@@ -14,8 +14,6 @@
 #  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
 #  for more details.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from cwrap import BaseCClass
 from res import ResPrototype
 from .enums import UIReturnStatusEnum


### PR DESCRIPTION
Both builtin and __future__ were used to import Python 3 functionality into Python 2.7. As Python 2.7 is no longer supported, remove these unnecessary imports.

Resolves: #1094 