### PR TITLE
Disable network reporting

### DIFF
--- a/python/ert_logger/__init__.py
+++ b/python/ert_logger/__init__.py
@@ -11,19 +11,25 @@ BASE_MESSAGE = {
 }
 
 
+# Disabled temporarily, according to issue #1095.
+#
+# The tests in tests/job_runner/test_network_reporter.py are disabled
+# accordingly.
+#
 def log_message(input_payload):
-    payload = deepcopy(BASE_MESSAGE)
-    payload.update(input_payload)
-    try:
-        data = json.dumps(payload)
-        # Disabling proxies
-        proxies = {"http": None, "https": None}
-        requests.post(
-            LOG_URL,
-            timeout=3,
-            headers={"Content-Type": "application/json"},
-            data=data,
-            proxies=proxies,
-        )
-    except:  # noqa
-        pass
+    # payload = deepcopy(BASE_MESSAGE)
+    # payload.update(input_payload)
+    # try:
+    #     data = json.dumps(payload)
+    #     # Disabling proxies
+    #     proxies = {"http": None, "https": None}
+    #     requests.post(
+    #         LOG_URL,
+    #         timeout=3,
+    #         headers={"Content-Type": "application/json"},
+    #         data=data,
+    #         proxies=proxies,
+    #     )
+    # except:  # noqa
+    #     pass
+    pass

--- a/tests/job_runner/test_network_reporter.py
+++ b/tests/job_runner/test_network_reporter.py
@@ -8,7 +8,11 @@ from job_runner.reporting.message import Exited, Init, Finish
 
 from unittest.mock import patch
 
+import pytest
 
+# Network reporting is disabled temporarily in python/ert_logger/__init__.py
+# according to issue #1095.
+@pytest.mark.skip(reason="Logging to the network is currently disabled")
 class NetworkReporterTests(TestCase):
     def setUp(self):
         self.reporter = Network()


### PR DESCRIPTION
**Issue**
Solution for  #1095: temporarily logging to a server at Equinor.


**Approach**
The function `log_message` in `python/ert_logger/__init__.py` has been disabled. Corresponding tests are skipped.