### PR TITLE
Remove LSB_JOBID from env when using eclrun

### DIFF
--- a/python/res/fm/ecl/ecl100_config.yml
+++ b/python/res/fm/ecl/ecl100_config.yml
@@ -57,3 +57,4 @@ eclrun_env:
   SLBSLS_LICENSE_FILE: something@yourcompany.com
   ECLPATH: /path/to/ecl
   PATH: /path/to/ecl/macros
+  LSB_JOBID: null

--- a/python/res/fm/ecl/ecl300_config.yml
+++ b/python/res/fm/ecl/ecl300_config.yml
@@ -26,3 +26,8 @@ env:
   F_UFMTENDIAN: big
   ARCH: x86_64
 
+eclrun_env:
+  SLBSLS_LICENSE_FILE: something@yourcompany.com
+  ECLPATH: /path/to/ecl
+  PATH: /path/to/ecl/macros
+  LSB_JOBID: null

--- a/python/res/fm/ecl/ecl_config.py
+++ b/python/res/fm/ecl/ecl_config.py
@@ -222,6 +222,12 @@ class EclrunConfig:
             env["PATH"] = eclrun_env["PATH"] + os.pathsep + env["PATH"]
             eclrun_env.pop("PATH")
 
+        for k, v in eclrun_env.copy().items():
+            if v is None:
+                if k in env:
+                    env.pop(k)
+                eclrun_env.pop(k)
+
         env.update(eclrun_env)
         return env
 


### PR DESCRIPTION
**Issue**
Resolves #1099 


**Approach**
MPIrun from Intel MPI will try to connect to LSF if it detects LSB_JOBID in the environment. Unset the LSB_JOBID when using `eclrun`
