### PR TITLE
Remove processor argument when using eclrun

### DIFF
--- a/python/res/fm/ecl/ecl_run.py
+++ b/python/res/fm/ecl/ecl_run.py
@@ -257,8 +257,6 @@ class EclRun(object):
             "eclrun",
             "-v",
             eclrun_config.version,
-            "--np",
-            str(self.num_cpu),
             eclrun_config.simulator_name,
             "{}.DATA".format(self.base_name),
         ]


### PR DESCRIPTION
**Issue**
Resolves #1101


eclrun is capable of finding out the number of processors needed
on its own. Further, specifying the number of processors manually when
running setups with coupled reservoirs trips up eclrun, and causes it
to try to use to many processors.



