### PR TITLE
Export row_scaling::clamp() method

### DIFF
--- a/lib/enkf/row_scaling.cpp
+++ b/lib/enkf/row_scaling.cpp
@@ -61,14 +61,21 @@ double row_scaling::operator[](int index) const {
   return this->data.at(index);
 }
 
-void row_scaling::assign(int index, double value) {
+
+double row_scaling::clamp(double value) const {
+    return floor(value * this->resolution) / this->resolution;
+}
+
+
+double row_scaling::assign(int index, double value) {
   if (value < 0 || value > 1)
     throw std::invalid_argument("Invalid value ");
 
   if (this->data.size() <= index)
     this->data.resize(index + 1, 1);
 
-  this->data.at(index) = floor(value * this->resolution) / this->resolution;
+  this->data.at(index) = this->clamp(value);
+  return this->data.at(index);
 }
 
 
@@ -202,8 +209,12 @@ double row_scaling_iget(const row_scaling_type * scaling, int index) {
   return scaling->operator[](index);
 }
 
-void row_scaling_iset(row_scaling_type * scaling, int index, double value) {
-  scaling->assign(index, value);
+double row_scaling_iset(row_scaling_type * scaling, int index, double value) {
+  return scaling->assign(index, value);
+}
+
+double row_scaling_clamp(const row_scaling_type * scaling, double value) {
+  return scaling->clamp(value);
 }
 
 void row_scaling_multiply(const row_scaling_type * scaling, matrix_type * A, const matrix_type * X0) {

--- a/lib/include/ert/enkf/row_scaling.hpp
+++ b/lib/include/ert/enkf/row_scaling.hpp
@@ -24,7 +24,8 @@
 class row_scaling {
 public:
   double operator[](int index) const;
-  void assign(int index, double value);
+  double assign(int index, double value);
+  double clamp(double value) const;
   void multiply(matrix_type * A, const matrix_type * X0) const;
   int size() const;
 private:
@@ -47,7 +48,8 @@ void               row_scaling_free(row_scaling_type * row_scaling);
 void               row_scaling_multiply(const row_scaling_type * row_scaling, matrix_type * A, const matrix_type * X0);
 int                row_scaling_get_size(const row_scaling_type * row_scaling);
 double             row_scaling_iget(const row_scaling_type * row_scaling, int index);
-void               row_scaling_iset(row_scaling_type * row_scaling, int index, double value);
+double             row_scaling_iset(row_scaling_type * row_scaling, int index, double value);
+double             row_scaling_clamp(const row_scaling_type * row_scaling, double value);
 
 UTIL_IS_INSTANCE_HEADER( row_scaling );
 

--- a/python/res/enkf/row_scaling.py
+++ b/python/res/enkf/row_scaling.py
@@ -24,8 +24,9 @@ class RowScaling(BaseCClass):
     _alloc = ResPrototype("void*  row_scaling_alloc()", bind=False)
     _free = ResPrototype("void   row_scaling_free(row_scaling)")
     _size = ResPrototype("int    row_scaling_get_size(row_scaling)")
-    _iset = ResPrototype("void   row_scaling_iset(row_scaling, int, double)")
+    _iset = ResPrototype("double row_scaling_iset(row_scaling, int, double)")
     _iget = ResPrototype("double row_scaling_iget(row_scaling, int)")
+    _clamp = ResPrototype("double row_scaling_clamp(row_scaling, double)")
 
     def __init__(self):
         c_ptr = self._alloc()
@@ -47,3 +48,6 @@ class RowScaling(BaseCClass):
         raise IndexError(
             "Index: {} outside valid range [0,{}>".format(index, len(self))
         )
+
+    def clamp(self, value):
+        return self._clamp(value)

--- a/tests/res/enkf/test_row_scaling.py
+++ b/tests/res/enkf/test_row_scaling.py
@@ -15,6 +15,7 @@
 #  for more details.
 
 import pytest
+import random
 from res.enkf import RowScaling
 
 
@@ -29,3 +30,8 @@ def test_access():
 
     with pytest.raises(IndexError):
         var = row_scaling[10]
+
+    for i in range(len(row_scaling)):
+        r = random.random()
+        row_scaling[i] = r
+        assert row_scaling[i] == row_scaling.clamp(r)


### PR DESCRIPTION
**Issue**
Part of localization updates.

**Approach**
The values in the row_scaling class have a finite resolution - currently 1 / 1000 - this is to enable lumping of the multiplications together in blocks. This PR exports the rounding function as `row_scaling::clamp()`. The sole reason for exporting this is to enable testing - not of the clamping itself but of row scaling operations of various kinds. 