### PR TITLE
field_config_guess_file_type: Use extension when guessing grdecl

### DIFF
--- a/tests/res/enkf/test_field_config.py
+++ b/tests/res/enkf/test_field_config.py
@@ -31,8 +31,9 @@ class FieldConfigTest(ResTest):
                 f.write("-- my comment\n")
                 f.write("-- more comments\n")
                 f.write("SOWCR\n")
-                for i in range(256 // 8):  # technicalities demand file has >= 256B
+                for i in range(128 // 8):
                     f.write("0 0 0 0\n")
+                f.write("/\n")
 
             ft = FieldConfig.guessFiletype(fname)
             grdecl_type = EnkfFieldFileFormatEnum(5)


### PR DESCRIPTION
**Issue**
This is a drive-by change while working on #1069. The .grdecl file format is by far the most important to support for the field_config class. With these changes we remove the restriction that files must be above 256 bytes to check type. 

**Approach**
For grdecl formatted files we start by checking extension, and then content. The grdecl based check is first in the list of file formats tested.
