### PR TITLE
Allow __setitem__() access to Summary data container

### DIFF
--- a/lib/enkf/summary.cpp
+++ b/lib/enkf/summary.cpp
@@ -44,19 +44,8 @@ struct summary_struct {
 
 
 
-static double SUMMARY_GET_VALUE( const summary_type * summary,
-                                 int report_step) {
-  return double_vector_iget( summary->data_vector, report_step );
-}
 
 
-static void SUMMARY_SET_VALUE( summary_type * summary,
-                               int report_step,
-                               double value) {
-  double_vector_iset( summary->data_vector, report_step, value);
-}
-
-/*****************************************************************/
 
 
 
@@ -146,7 +135,7 @@ void summary_serialize(const summary_type * summary,
                        matrix_type * A,
                        int row_offset,
                        int column) {
-  double value = SUMMARY_GET_VALUE( summary, node_id.report_step );
+  double value = summary_get( summary, node_id.report_step );
   enkf_matrix_serialize( &value, 1, ECL_DOUBLE, active_list, A, row_offset, column);
 }
 
@@ -159,7 +148,7 @@ void summary_deserialize(summary_type * summary,
                          int column) {
   double value;
   enkf_matrix_deserialize( &value, 1, ECL_DOUBLE, active_list, A, row_offset, column);
-  SUMMARY_SET_VALUE( summary, node_id.report_step, value );
+  summary_set( summary, node_id.report_step, value );
 }
 
 int summary_length(const summary_type * summary) {
@@ -167,9 +156,19 @@ int summary_length(const summary_type * summary) {
 }
 
 double summary_get(const summary_type * summary, int report_step) {
-  return SUMMARY_GET_VALUE( summary, report_step );
+  return double_vector_iget( summary->data_vector, report_step );
 }
 
+
+void summary_set( summary_type * summary,
+                  int report_step,
+                  double value) {
+  double_vector_iset( summary->data_vector, report_step, value);
+}
+
+double summary_undefined_value() {
+  return SUMMARY_UNDEF;
+}
 
 bool summary_user_get(const summary_type * summary,
                       const char * index_key,
@@ -273,7 +272,7 @@ bool summary_forward_load(summary_type * summary,
   }
 
   if (loadOK)
-    SUMMARY_SET_VALUE( summary, report_step, load_value );
+    summary_set( summary, report_step, load_value );
 
   return loadOK;
 }

--- a/lib/include/ert/enkf/summary.hpp
+++ b/lib/include/ert/enkf/summary.hpp
@@ -36,8 +36,11 @@ extern "C" {
 summary_type * summary_alloc(const summary_config_type * summary_config);
 void           summary_free(summary_type *summary);
 double         summary_get(const summary_type * summary, int report_step );
+void           summary_set( summary_type * summary, int report_step, double value);
 bool           summary_active_value( double value );
 int            summary_length(const summary_type * summary);
+double         summary_undefined_value();
+
 
 VOID_HAS_DATA_HEADER(summary);
 UTIL_SAFE_CAST_HEADER(summary);

--- a/python/res/enkf/data/summary.py
+++ b/python/res/enkf/data/summary.py
@@ -22,18 +22,42 @@ class Summary(BaseCClass):
     _alloc = ResPrototype("void*   summary_alloc(summary_config)", bind=False)
     _free = ResPrototype("void    summary_free(summary)")
     _iget_value = ResPrototype("double  summary_get(summary, int)")
+    _iset_value = ResPrototype("void    summary_set(summary, int, double)")
     _length = ResPrototype("int     summary_length(summary)")
+    _get_undef_value = ResPrototype("double summary_undefined_value()", bind=False)
 
     def __init__(self, config):
         c_ptr = self._alloc(config)
         self._config = config
         super(Summary, self).__init__(c_ptr)
+        self._undefined_value = self._get_undef_value()
 
     def __len__(self):
         return self._length()
 
     def __repr__(self):
         return "Summary(key=%s, length=%d) %s" % (self.key, len(self), self._ad_str())
+
+    #  The Summary class is intended to contain results loaded from an Eclipse
+    #  formatted summary file, the class has internal functionality for reading
+    #  and interpreting the summary files. In addition it has support for random
+    #  access to the elements with __getitem__() and __setitem__(). For observe
+    #  the following:
+    #
+    #   1. The index corresponds to the time axis - i.e. report step in eclipse
+    #      speak.
+    #
+    #   2. When using __setitem__() the container will automatically grow to
+    #      the required storage. When growing the underlying storage it will be
+    #      filled with undefined values, and if you later try to access those
+    #      values with __getitem__ you will get a ValueError exception:
+    #
+    #         summary = Summary( summary_config )
+    #         summary[10] = 25
+    #         v = summary[0] -> ValueError("Trying access undefined value")
+    #
+    #      The access of an undefined value is trapped in Python __getitem__()
+    #      - i.e. it can be bypassed from C.
 
     def __getitem__(self, index):
         if index < 0:
@@ -46,7 +70,16 @@ class Summary(BaseCClass):
                 "Invalid index:%d  Valid range: [0,%d>" % (index, len(self))
             )
 
-        return self._iget_value(index)
+        value = self._iget_value(index)
+        if value == self._undefined_value:
+            raise ValueError("Trying to access undefined value")
+        return value
+
+    def __setitem__(self, index, value):
+        if index < 0:
+            raise ValueError("Invalid report step")
+
+        self._iset_value(index, value)
 
     def value(self, report_step):
         return self[report_step]

--- a/tests/res/enkf/data/test_summary.py
+++ b/tests/res/enkf/data/test_summary.py
@@ -16,3 +16,12 @@ class SummaryTest(ResTest):
 
         with self.assertRaises(IndexError):
             v = summary[100]
+
+        summary[0] = 75
+        self.assertEqual(summary[0], 75)
+
+        summary[10] = 100
+        self.assertEqual(summary[10], 100)
+
+        with self.assertRaises(ValueError):
+            v5 = summary[5]


### PR DESCRIPTION
**Issue**
Part of #1069 


**Approach**
With this PR we allow programmatically setting values in the `summary` datatype. This allows simpler more direct testing, without having to load simulation results before being able to test.
