### PR TITLE
Remove bool flag force_vector from enkf_node_store()

### DIFF
--- a/lib/enkf/enkf_main.cpp
+++ b/lib/enkf/enkf_main.cpp
@@ -399,7 +399,7 @@ void enkf_main_inflate_node(enkf_main_type * enkf_main , enkf_fs_type * src_fs ,
   for (iens = 0; iens < ens_size; iens++) {
     node_id_type node_id = {.report_step = report_step , .iens = iens };
     enkf_node_iadd( (enkf_node_type * ) vector_iget( ensemble, iens) , mean );
-    enkf_node_store( (enkf_node_type * ) vector_iget( ensemble, iens) , target_fs , true , node_id);
+    enkf_node_store( (enkf_node_type * ) vector_iget( ensemble, iens) , target_fs , node_id);
   }
 
   enkf_node_free( mean );
@@ -900,7 +900,7 @@ static void enkf_main_update__(enkf_main_type * enkf_main, const int_vector_type
           node_id.report_step = 0;
 
           enkf_node_load(data_node, source_fs, node_id);
-          enkf_node_store(data_node, target_fs, false, node_id);
+          enkf_node_store(data_node, target_fs, node_id);
         }
         enkf_node_free(data_node);
       }

--- a/lib/enkf/enkf_node.cpp
+++ b/lib/enkf/enkf_node.cpp
@@ -451,21 +451,11 @@ bool enkf_node_store_vector(enkf_node_type *enkf_node , enkf_fs_type * fs , int 
 
 
 
-bool enkf_node_store(enkf_node_type * enkf_node , enkf_fs_type * fs , bool force_vectors , node_id_type node_id) {
-  if (enkf_node->vector_storage) {
-    if (force_vectors)
-      return enkf_node_store_vector( enkf_node , fs , node_id.iens );
-    else
-      return false;
-  } else {
-    if (node_id.report_step == 0) {
-      ert_impl_type impl_type = enkf_node_get_impl_type(enkf_node);
-      if (impl_type == SUMMARY)
-        return false;             /* For report step == 0 the summary data is just garbage. */
-    }
-
+bool enkf_node_store(enkf_node_type * enkf_node , enkf_fs_type * fs , node_id_type node_id) {
+  if (enkf_node->vector_storage)
+    return enkf_node_store_vector( enkf_node , fs , node_id.iens );
+  else
     return enkf_node_store_buffer( enkf_node , fs , node_id.report_step , node_id.iens );
-  }
 }
 
 
@@ -607,7 +597,7 @@ void enkf_node_copy(const enkf_config_node_type * config_node ,
     }
   }
 
-  enkf_node_store(enkf_node, target_case , true , target_id );
+  enkf_node_store(enkf_node, target_case , target_id );
   enkf_node_free(enkf_node);
 }
 
@@ -648,7 +638,7 @@ void enkf_node_deserialize(enkf_node_type *enkf_node , enkf_fs_type * fs , node_
 
   FUNC_ASSERT(enkf_node->deserialize);
   enkf_node->deserialize(enkf_node->data , node_id , active_list , A , row_offset , column);
-  enkf_node_store( enkf_node , fs , true , node_id );
+  enkf_node_store( enkf_node , fs , node_id );
 }
 
 

--- a/lib/enkf/enkf_state.cpp
+++ b/lib/enkf/enkf_state.cpp
@@ -133,7 +133,7 @@ void enkf_state_initialize(enkf_state_type * enkf_state , rng_type * rng, enkf_f
 
         if ((init_mode == INIT_FORCE) || (has_data == false) || (current_state == STATE_LOAD_FAILURE)) {
           if (enkf_node_initialize(param_node, iens, rng))
-            enkf_node_store(param_node, fs, true, node_id);
+            enkf_node_store(param_node, fs, node_id);
         }
 
         enkf_node_free( param_node );
@@ -367,7 +367,7 @@ static void enkf_state_load_gen_data_node(
       node_id_type node_id = {.report_step = report_step,
                               .iens = iens };
 
-      enkf_node_store(node, sim_fs, false, node_id);
+      enkf_node_store(node, sim_fs, node_id);
       enkf_state_log_GEN_DATA_load(node, report_step, load_context);
     } else {
       forward_load_context_update_result(load_context, LOAD_FAILURE);
@@ -764,7 +764,7 @@ static void enkf_state_internal_retry(const res_config_type * res_config,
       enkf_node_type * node = enkf_node_alloc( config_node );
       if (enkf_node_initialize( node , iens , rng )) {
         node_id_type node_id = { .report_step = 0, .iens = iens };
-        enkf_node_store(node, run_arg_get_sim_fs( run_arg ), true, node_id);
+        enkf_node_store(node, run_arg_get_sim_fs( run_arg ), node_id);
       }
       enkf_node_free( node );
     }

--- a/lib/enkf/ensemble_config.cpp
+++ b/lib/enkf/ensemble_config.cpp
@@ -902,7 +902,7 @@ int ensemble_config_forward_init(const ensemble_config_type * ens_config,
 
         if (!enkf_node_has_data( node , sim_fs , node_id)) {
           if (enkf_node_forward_init(node , run_arg_get_runpath( run_arg ) , iens ))
-            enkf_node_store( node , sim_fs , false , node_id );
+            enkf_node_store( node , sim_fs , node_id );
           else {
             char * init_file = enkf_config_node_alloc_initfile( enkf_node_get_config( node ) , run_arg_get_runpath(run_arg) , iens );
 

--- a/lib/enkf/tests/gen_kw_logarithmic_test.cpp
+++ b/lib/enkf/tests/gen_kw_logarithmic_test.cpp
@@ -69,8 +69,8 @@ void test_write_gen_kw_export_file(enkf_main_type * enkf_main) {
     node_id_type node_id = {.report_step = 0,
                             .iens        = 0 };
 
-    enkf_node_store(enkf_node, init_fs, true, node_id);
-    enkf_node_store(enkf_node2, init_fs, true, node_id);
+    enkf_node_store(enkf_node, init_fs, node_id);
+    enkf_node_store(enkf_node2, init_fs, node_id);
   }
 
   {

--- a/lib/include/ert/enkf/enkf_node.hpp
+++ b/lib/include/ert/enkf/enkf_node.hpp
@@ -147,7 +147,7 @@ void             enkf_node_clear(enkf_node_type *);
   bool              enkf_node_fload( enkf_node_type * enkf_node , const char * filename );
   void              enkf_node_load(enkf_node_type * enkf_node , enkf_fs_type * fs , node_id_type node_id );
   void              enkf_node_load_vector( enkf_node_type * enkf_node , enkf_fs_type * fs , int iens);
-  bool              enkf_node_store(enkf_node_type * enkf_node , enkf_fs_type * fs , bool force_vectors , node_id_type node_id);
+  bool              enkf_node_store(enkf_node_type * enkf_node , enkf_fs_type * fs , node_id_type node_id);
   bool              enkf_node_store_vector(enkf_node_type *enkf_node , enkf_fs_type * fs , int iens );
   bool              enkf_node_try_load(enkf_node_type *enkf_node , enkf_fs_type * fs , node_id_type node_id);
   bool              enkf_node_try_load_vector(enkf_node_type *enkf_node , enkf_fs_type * fs , int iens );

--- a/python/res/enkf/data/enkf_node.py
+++ b/python/res/enkf/data/enkf_node.py
@@ -31,7 +31,7 @@ class EnkfNode(BaseCClass):
     _get_name = ResPrototype("char* enkf_node_get_key(enkf_node)")
     _value_ptr = ResPrototype("void* enkf_node_value_ptr(enkf_node)")
     _try_load = ResPrototype("bool  enkf_node_try_load(enkf_node, enkf_fs, node_id)")
-    _store = ResPrototype("bool  enkf_node_store(enkf_node, enkf_fs, bool, node_id)")
+    _store = ResPrototype("bool  enkf_node_store(enkf_node, enkf_fs, node_id)")
     _get_impl_type = ResPrototype(
         "ert_impl_type_enum enkf_node_get_impl_type(enkf_node)"
     )
@@ -153,7 +153,7 @@ class EnkfNode(BaseCClass):
         assert isinstance(fs, EnkfFs)
         assert isinstance(node_id, NodeId)
 
-        return self._store(fs, False, node_id)
+        return self._store(fs, node_id)
 
     def free(self):
         self._free()


### PR DESCRIPTION
**Issue**
Drive by improvement/fix when working with: #1069


A long time ago - when ert was an implementation of the EnKF algorithm all data objects were stored with two coordinates, timestep and realization number. Since for the summary variables one such data object was just one single double value file system access was very inefficient. To improve on that *vector storage* was introduced to store/load an entire timeseries in one go. That was experimental - and optional ~10 years ago, and there were boolean switches to regulate. That boolean switch was just hardcoded to `False` in the `enkf_node.py` implementation, and that bit me while creating a test. With this PR the vector storage unconditionally on for summary variables (which it has been for ~10 years).


