### PR TITLE
remove fs dependency for summary observation collector

### DIFF
--- a/python/res/enkf/export/summary_observation_collector.py
+++ b/python/res/enkf/export/summary_observation_collector.py
@@ -30,40 +30,32 @@ class SummaryObservationCollector(object):
         @type keys: list of str
         @rtype: DataFrame
         """
-        fs = ert.getEnkfFsManager().getFileSystem(case_name)
-
-        time_map = fs.getTimeMap()
-        dates = [time_map[index].datetime() for index in range(1, len(time_map))]
-
+        observations = ert.getObservations()
+        history_length = ert.getHistoryLength()
+        dates = [
+            observations.getObservationTime(index).datetime()
+            for index in range(1, history_length)
+        ]
         summary_keys = SummaryObservationCollector.getAllObservationKeys(ert)
         if keys is not None:
             summary_keys = [
                 key for key in keys if key in summary_keys
             ]  # ignore keys that doesn't exist
-
         columns = summary_keys
         std_columns = ["STD_%s" % key for key in summary_keys]
-
         df = DataFrame(index=dates, columns=columns + std_columns)
-
         for key in summary_keys:
             observation_keys = ert.ensembleConfig().getNode(key).getObservationKeys()
-
             for obs_key in observation_keys:
-                observations = ert.getObservations()
                 observation_data = observations[obs_key]
-                history_length = ert.getHistoryLength()
-
                 for index in range(0, history_length):
                     if observation_data.isActive(index):
                         obs_time = observations.getObservationTime(index).datetime()
                         node = observation_data.getNode(index)
                         value = node.getValue()
                         std = node.getStandardDeviation()
-
                         df[key][obs_time] = value
                         df["STD_%s" % key][obs_time] = std
-
         return df
 
     @classmethod


### PR DESCRIPTION
Summary observation collector is using the fs to set the time map for  observation data. Now we use the observation.getObservation time instead, reducing the need for fs when collecting the observation data.
