### PR TITLE
Force sequential execution of first OK callback

### DIFF
--- a/lib/enkf/ensemble_config.cpp
+++ b/lib/enkf/ensemble_config.cpp
@@ -825,7 +825,9 @@ enkf_config_node_type * ensemble_config_add_summary(ensemble_config_type * ensem
 
   } else {
     config_node = enkf_config_node_alloc_summary( key , load_fail);
-    ensemble_config_add_node(ensemble_config , config_node );
+    sleep(3);
+    printf("waiting\n");
+    ensemble_config_add_node(ensemble_config, config_node);
   }
 
   return config_node;

--- a/python/res/job_queue/job_queue_node.py
+++ b/python/res/job_queue/job_queue_node.py
@@ -113,6 +113,7 @@ class JobQueueNode(BaseCClass):
         while not self.ok_cb_barrier.broken:
             try:
                 self.ok_cb_barrier.wait()
+                break
             except BrokenBarrierError:
                 pass
 


### PR DESCRIPTION
**Issue**
Resolves #1123 

**Approach**
Use a `Barrier` to only allow one OK callback to execute. If successful, the barrier is `abort()`, if unsuccessful, it is `reset`. In the broken state, the barrier will let any callback through.
