### PR TITLE
Row scaling assign field

### DIFF
--- a/lib/enkf/row_scaling.cpp
+++ b/lib/enkf/row_scaling.cpp
@@ -67,12 +67,17 @@ double row_scaling::clamp(double value) const {
 }
 
 
+void row_scaling::resize(int new_size) {
+  const double default_value = 1;
+  this->data.resize(new_size, default_value);
+}
+
 double row_scaling::assign(int index, double value) {
   if (value < 0 || value > 1)
     throw std::invalid_argument("Invalid value ");
 
   if (this->data.size() <= index)
-    this->data.resize(index + 1, 1);
+    this->resize(index + 1);
 
   this->data.at(index) = this->clamp(value);
   return this->data.at(index);
@@ -187,6 +192,14 @@ void row_scaling::multiply(matrix_type * A, const matrix_type * X0) const {
 }
 
 
+template <typename T>
+void row_scaling::assign(const T * data, int size) {
+  this->resize(size);
+  for (int index=0; index < size; index++)
+    this->assign(index, data[index]);
+}
+
+
 /*
   Below here is a C api for binding to Python.
 */
@@ -223,4 +236,12 @@ void row_scaling_multiply(const row_scaling_type * scaling, matrix_type * A, con
 
 int row_scaling_get_size(const row_scaling_type * row_scaling) {
   return row_scaling->size();
+}
+
+void row_scaling_assign_double(row_scaling_type * scaling, const double * data, int size) {
+  scaling->assign(data, size);
+}
+
+void row_scaling_assign_float(row_scaling_type * scaling, const float * data, int size) {
+  scaling->assign(data, size);
 }

--- a/lib/enkf/row_scaling.cpp
+++ b/lib/enkf/row_scaling.cpp
@@ -68,7 +68,7 @@ double row_scaling::clamp(double value) const {
 
 
 void row_scaling::resize(int new_size) {
-  const double default_value = 1;
+  const double default_value = 0;
   this->data.resize(new_size, default_value);
 }
 

--- a/lib/enkf/tests/row_scaling.cpp
+++ b/lib/enkf/tests/row_scaling.cpp
@@ -118,8 +118,11 @@ void test_multiply() {
   {
     row_scaling_type * row_scaling = row_scaling_alloc();
     matrix_type * A = matrix_alloc_copy(A0);
+    std::vector<float> row_data(data_size);
     for (int row = 0; row < data_size; row++)
-      row_scaling_iset(row_scaling, row, 0);
+      row_data[row] = 0;
+
+    row_scaling_assign_float(row_scaling, row_data.data(), row_data.size());
     row_scaling_multiply(row_scaling, A, X0);
 
     for (int row = 0; row < data_size; row++)
@@ -136,8 +139,16 @@ void test_multiply() {
   {
     row_scaling_type * row_scaling = row_scaling_alloc();
     matrix_type * A = matrix_alloc_copy(A0);
+    std::vector<double> row_data(data_size);
+
+    row_scaling_iset(row_scaling, 2*data_size, 1.0);
+    test_assert_int_equal( row_scaling_get_size(row_scaling), 2*data_size + 1);
+
     for (int row = 0; row < data_size; row++)
-      row_scaling_iset(row_scaling, row, rng_get_double(rng));
+      row_data[row] = rng_get_double(rng);
+
+    row_scaling_assign_double(row_scaling, row_data.data(), row_data.size());
+    test_assert_int_equal( row_scaling_get_size(row_scaling), data_size);
 
     row_scaling_multiply(row_scaling, A, X0);
     for (int row = 0; row < data_size; row++) {

--- a/lib/include/ert/enkf/row_scaling.hpp
+++ b/lib/include/ert/enkf/row_scaling.hpp
@@ -28,7 +28,11 @@ public:
   double clamp(double value) const;
   void multiply(matrix_type * A, const matrix_type * X0) const;
   int size() const;
+
+  template <typename T>
+  void assign(const T * data, int size);
 private:
+  void resize(int new_size);
   int resolution = 1000;
   std::vector<double> data;
 };
@@ -50,6 +54,8 @@ int                row_scaling_get_size(const row_scaling_type * row_scaling);
 double             row_scaling_iget(const row_scaling_type * row_scaling, int index);
 double             row_scaling_iset(row_scaling_type * row_scaling, int index, double value);
 double             row_scaling_clamp(const row_scaling_type * row_scaling, double value);
+void               row_scaling_assign_double(row_scaling_type * scaling, const double * data, int size);
+void               row_scaling_assign_float(row_scaling_type * scaling, const float * data, int size);
 
 UTIL_IS_INSTANCE_HEADER( row_scaling );
 

--- a/tests/res/enkf/test_row_scaling.py
+++ b/tests/res/enkf/test_row_scaling.py
@@ -59,7 +59,7 @@ def test_basic():
 
     row_scaling[9] = 0.25
     assert len(row_scaling) == 10
-    assert row_scaling[0] == 1
+    assert row_scaling[0] == 0
     assert row_scaling[9] == 0.25
 
     with pytest.raises(IndexError):

--- a/tests/res/enkf/test_row_scaling.py
+++ b/tests/res/enkf/test_row_scaling.py
@@ -89,6 +89,9 @@ def test_basic():
             g = j * nx + i
             assert row_scaling[g] == row_scaling.clamp(row_scaling_coloumb(nx, ny, g))
 
+    with pytest.raises(TypeError):
+        row_scaling.assign_vector(123.0)
+
 
 def test_field_config():
     nx = 10


### PR DESCRIPTION
**Issue**
Part of: #1069 

**Approach**
In this PR is a new function `row_scaling::assign_vector()` which will assign a row scaling value for all the elements in the vector. This is convenience/efficiency function for the case where the row_scaling has is loaded in it's entirety from file - typically because it has been prepared with an external application.

Observe the last commit which chganges a default.