### PR TITLE
Revert local_config_clear()

### DIFF
--- a/lib/enkf/local_config.cpp
+++ b/lib/enkf/local_config.cpp
@@ -137,11 +137,31 @@ static local_updatestep_type * local_config_alloc_updatestep( local_config_type 
 
 
 
+/*
+  The local_config_clear() function will remove all current local configuration,
+  and then reallocate a new empty updatestep configuration.
+*/
 void local_config_clear( local_config_type * local_config ) {
-  hash_clear( local_config->updatestep_storage );
-  local_config->default_updatestep = local_config_alloc_updatestep(local_config, "DEFAULT");
+   local_config->default_updatestep  = NULL;
+   hash_clear( local_config->updatestep_storage );
+   hash_clear( local_config->ministep_storage );
+   hash_clear( local_config->dataset_storage );
+   hash_clear( local_config->obsdata_storage );
+   local_config->default_updatestep = local_config_alloc_updatestep(local_config, "DEFAULT");
 }
 
+
+/*
+  The local_config_clear_active() function will reset the current active
+  updatestep, but the named building blocks of type ministep, local_dataset and
+  obsdata will be retained and can be reused through name based lookup when we
+  create a new local configuration.
+*/
+
+void local_config_clear_active( local_config_type * local_config ) {
+    hash_clear( local_config->updatestep_storage );
+    local_config->default_updatestep = local_config_alloc_updatestep(local_config, "DEFAULT");
+}
 
 
 

--- a/lib/include/ert/enkf/local_config.hpp
+++ b/lib/include/ert/enkf/local_config.hpp
@@ -43,6 +43,7 @@ typedef struct local_config_struct local_config_type;
 
 local_config_type           * local_config_alloc( );
 void                          local_config_clear( local_config_type * local_config );
+void                          local_config_clear_active( local_config_type * local_config );
 void                          local_config_free( local_config_type * local_config );
 local_ministep_type         * local_config_alloc_ministep( local_config_type * local_config , const char * key,  analysis_module_type* analysis_module );
 local_updatestep_type       * local_config_get_updatestep( const local_config_type * local_config );

--- a/python/res/enkf/local_config.py
+++ b/python/res/enkf/local_config.py
@@ -37,6 +37,7 @@ class LocalConfig(BaseCClass):
 
     _free = ResPrototype("void   local_config_free(local_config)")
     _clear = ResPrototype("void   local_config_clear(local_config)")
+    _clear_active = ResPrototype("void   local_config_clear_active(local_config)")
     _create_ministep = ResPrototype(
         "local_ministep_ref local_config_alloc_ministep(local_config, char*, analysis_module)"
     )
@@ -98,6 +99,9 @@ class LocalConfig(BaseCClass):
 
     def clear(self):
         self._clear()
+
+    def clear_active(self):
+        self._clear_active()
 
     def createMinistep(self, mini_step_key, analysis_module=None):
         """@rtype: Ministep"""

--- a/tests/res/enkf/test_row_scaling_case.py
+++ b/tests/res/enkf/test_row_scaling_case.py
@@ -554,7 +554,7 @@ TIME_MAP timemap.txt
             es_update.smootherUpdate(run_context)
 
             local_config = main.getLocalConfig()
-            local_config.clear()
+            local_config.clear_active()
             with self.assertRaises(KeyError):
                 obs_data = local_config.copyObsdata("NO_SUCH_OBS", "my_obs")
 


### PR DESCRIPTION
This commit reverts the changes in behavior in the local_config_clear() function
from commit: 7d29fdf0d and also introduces a new function
local_config_clear_active() which lets retains the named ministep, local_data
and obsdata objects for later reuse.


