### PR TITLE
Re-use Client for dispatch lifecycle

### DIFF
--- a/tests/job_runner/test_event_reporter.py
+++ b/tests/job_runner/test_event_reporter.py
@@ -25,8 +25,8 @@ def test_report_with_successful_start_message_argument(unused_tcp_port):
     lines = []
     with _mock_ws_thread(host, unused_tcp_port, lines):
         reporter.report(Init([job1], 1, 19, ee_id="ee_id", real_id=0, step_id=0))
-        msg = Start(job1)
-        reporter.report(msg)
+        reporter.report(Start(job1))
+        reporter.report(Finish())
 
     assert len(lines) == 1
     event = json.loads(lines[0])
@@ -48,6 +48,7 @@ def test_report_with_failed_start_message_argument(unused_tcp_port):
         msg = Start(job1).with_error("massive_failure")
 
         reporter.report(msg)
+        reporter.report(Finish())
 
     assert len(lines) == 2
     event = json.loads(lines[1])
@@ -65,6 +66,7 @@ def test_report_with_successful_exit_message_argument(unused_tcp_port):
     with _mock_ws_thread(host, unused_tcp_port, lines):
         reporter.report(Init([job1], 1, 19, ee_id="ee_id", real_id=0, step_id=0))
         reporter.report(Exited(job1, 0))
+        reporter.report(Finish().with_error("failed"))
 
     assert len(lines) == 1
     event = json.loads(lines[0])
@@ -81,6 +83,7 @@ def test_report_with_failed_exit_message_argument(unused_tcp_port):
     with _mock_ws_thread(host, unused_tcp_port, lines):
         reporter.report(Init([job1], 1, 19, ee_id="ee_id", real_id=0, step_id=0))
         reporter.report(Exited(job1, 1).with_error("massive_failure"))
+        reporter.report(Finish())
 
     assert len(lines) == 1
     event = json.loads(lines[0])
@@ -98,6 +101,7 @@ def test_report_with_running_message_argument(unused_tcp_port):
     with _mock_ws_thread(host, unused_tcp_port, lines):
         reporter.report(Init([job1], 1, 19, ee_id="ee_id", real_id=0, step_id=0))
         reporter.report(Running(job1, 100, 10))
+        reporter.report(Finish())
 
     assert len(lines) == 1
     event = json.loads(lines[0])


### PR DESCRIPTION
**Issue**
We do a fairly expensive ssl handshake for _every_ event sent by a dispatcher. Even though this performs fine, it is wasteful.

**Approach**
Match the lifecycle of the client with that of the event reporter, using queues and threads and stuff.
