### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python: ['3.6', '3.7', '3.8']
+        python: ['3.6', '3.7', '3.8', '3.9']
 
     runs-on: ${{ matrix.os }}
 

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ skbuild.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
**Issue**
Resolves #1157 


**Approach**
Add Python 3.9 to test pipeline
