### PR TITLE
Add default argument to add_ee_stage

### DIFF
--- a/python/res/job_queue/queue.py
+++ b/python/res/job_queue/queue.py
@@ -506,7 +506,7 @@ class JobQueue(BaseCClass):
             return
         run_arg._set_queue_index(self.add_job(job, run_arg.iens))
 
-    def add_ee_stage(self, stage, callback_timeout):
+    def add_ee_stage(self, stage, callback_timeout=None):
         job = JobQueueNode(
             job_script=stage.get_job_script(),
             job_name=stage.get_job_name(),


### PR DESCRIPTION
Because we have some trouble merging the MAX_RUNTIME branch, we need to make this code not break ERT in bleeding until we can fix that. This should make it work both currently and after a merge of the ERT branch.